### PR TITLE
Make an isolated entry point

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,3 @@
+/* @flow */
+import * as cli from './cli';
+export const main = cli.main;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,7 +18,7 @@ fs.readdirSync('node_modules')
 
 
 module.exports = {
-  entry: './src/cli.js',
+  entry: './src/main.js',
   target: 'node',
   node: {
     __dirname: true,


### PR DESCRIPTION
I guess webpack doesn't let you import modules from an entry point so we need something minimal like this.