### PR TITLE
Protect handlers from using incorrect options

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -5,9 +5,10 @@ import streamToPromise from 'stream-to-promise';
 
 import * as fs from './util/promised-fs';
 import {zipDir} from './util/zip-dir';
+import {ProgramOptions} from './program';
 
 
-export default function build({sourceDir, buildDir}: Object) {
+export default function build({sourceDir, buildDir}: ProgramOptions) {
   console.log(`Building web extension from ${sourceDir}`);
   return prepareBuildDir(buildDir)
     .then(() => zipDir(sourceDir))

--- a/src/cli.js
+++ b/src/cli.js
@@ -8,6 +8,9 @@ import {Program} from './program';
 
 export function main() {
   let program = new Program();
+  // yargs uses magic camel case expansion to expose options on the
+  // final argv object. For example, the 'build-dir' option is available
+  // as argv.buildDir.
   program.yargs
     .usage('Usage: $0 [options]')
     .help('help')

--- a/src/program.js
+++ b/src/program.js
@@ -2,6 +2,22 @@
 import yargs from 'yargs';
 
 
+/*
+ * Pseudo-class for all global program options.
+ *
+ * This is used to validate the definition of command handlers.
+ * Each class instance variable is a camel case expanded program
+ * option. Each option is defined in program.yargs.option(...).
+ */
+export class ProgramOptions {
+  sourceDir: string;
+  buildDir: string;
+}
+
+
+/*
+ * The command line program.
+ */
 export class Program {
   yargs: any;
   commands: { [key: string]: Function };

--- a/tests/build/adapter.js
+++ b/tests/build/adapter.js
@@ -1,0 +1,11 @@
+/* @flow */
+import build from '../../src/build';
+import {fixturePath, TempDir} from '../util';
+
+
+export function buildMinimalExt(tmpDir: TempDir): Promise {
+  return build({
+    sourceDir: fixturePath('minimal-web-ext'),
+    buildDir: tmpDir.path(),
+  });
+}

--- a/tests/build/test.build.js
+++ b/tests/build/test.build.js
@@ -1,10 +1,11 @@
 import path from 'path';
 import {assert} from 'chai';
 
-import {fixturePath, withTempDir, ZipFile} from '../util';
+import {withTempDir, ZipFile} from '../util';
 import * as fs from '../../src/util/promised-fs';
-import build from '../../src/build';
 import {prepareBuildDir} from '../../src/build';
+
+import * as adapter from './adapter';
 
 
 describe('build', () => {
@@ -14,10 +15,7 @@ describe('build', () => {
 
     return withTempDir(
       (tmpDir) =>
-        build({
-          sourceDir: fixturePath('minimal-web-ext'),
-          buildDir: tmpDir.path(),
-        })
+        adapter.buildMinimalExt(tmpDir)
         .then((buildResult) => zipFile.open(buildResult.xpiPath))
         .then(() => {
           var fileNames = [];


### PR DESCRIPTION
Fixes https://github.com/mozilla/web-ext/issues/39

Example of an error you get when you use an unknown option:
````
src/build.js:11
 11: export default function build({sourceDir, buildDir}: ProgramOptions) {
                                               ^^^^^^^^ property `buildDir`. Property not found in
 11: export default function build({sourceDir, buildDir}: ProgramOptions) {
                                                          ^^^^^^^^^^^^^^ ProgramOptions
````

This protects all command handlers so that they don't use an unknown option and thus they can be unit tested directly without relying on the construction of a complete program object.

It does not protect against defining a new option on a yargs object and *forgetting* to annotate it in ProgramOptions. I can't figure out how to solve that. Even without that protection, the benefit of using one annotation object, ProgramOptions, for all command handlers is that it's shared. If you add a new handler that relies on a new option then all other handlers will be verified against the new spec.