### PR TITLE
Add save-prefix setting via .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-prefix=''


### PR DESCRIPTION
This will default all npm deps to be added without `^`.