### PR TITLE
Adds a logger and implements --verbose

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -36,6 +36,7 @@
     "no-bitwise": 2,
     "no-caller": 2,
     "no-cond-assign": [2, "except-parens"],
+    "no-console": 2,
     "no-debugger": 2,
     "no-empty": 2,
     "no-eval": 2,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,14 +43,14 @@ classes are used correctly. Run all flow checks with `npm run flow-check`.
 ### Code Coverage
 
 You can generate Code Coverage reports every time you run the test suite
-by setting `$CODE_COVERAGE` in the environment. Here is an example of running
+by setting `$COVERAGE` in the environment. Here is an example of running
 the test suite on the instrumented source code:
 
-    CODE_COVERAGE=y npm test
+    COVERAGE=y npm test
 
 or even when the test suite re-runs automatically as you edit files:
 
-    CODE_COVERAGE=y npm start
+    COVERAGE=y npm start
 
 Once the report has been generated, it can be found in the `./coverage` directory.
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   ],
   "dependencies": {
     "babel-polyfill": "6.7.4",
+    "bunyan": "1.8.0",
     "es6-error": "2.1.0",
     "es6-promisify": "3.0.0",
     "firefox-profile": "0.3.12",

--- a/src/cmd/build.js
+++ b/src/cmd/build.js
@@ -7,17 +7,20 @@ import streamToPromise from 'stream-to-promise';
 import {zipDir} from '../util/zip-dir';
 import getValidatedManifest from '../util/manifest';
 import {prepareArtifactsDir} from '../util/artifacts';
+import {createLogger} from '../util/logger';
+
+const log = createLogger(__filename);
 
 
 export default function build(
     {sourceDir, artifactsDir}: Object,
     {manifestData, fileFilter}: Object = {}): Promise {
 
-  console.log(`Building web extension from ${sourceDir}`);
+  log.info(`Building web extension from ${sourceDir}`);
 
   let resolveManifest;
   if (manifestData) {
-    console.log(`Using manifest id=${manifestData.applications.gecko.id}`);
+    log.debug(`Using manifest id=${manifestData.applications.gecko.id}`);
     resolveManifest = Promise.resolve(manifestData);
   } else {
     resolveManifest = getValidatedManifest(sourceDir);
@@ -47,7 +50,7 @@ export default function build(
 
         return promisedStream
           .then(() => {
-            console.log(`Your web extension is ready: ${extensionPath}`);
+            log.info(`Your web extension is ready: ${extensionPath}`);
             return {extensionPath};
           });
       })
@@ -83,7 +86,7 @@ export class FileFilter {
   wantFile(path: string): boolean {
     for (const test of this.filesToIgnore) {
       if (minimatch(path, test)) {
-        console.log(`Not including file ${path} in ZIP archive`);
+        log.debug(`Not including file ${path} in ZIP archive`);
         return false;
       }
     }

--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -2,14 +2,17 @@
 import buildExtension from './build';
 import * as defaultFirefox from '../firefox';
 import {withTempDir} from '../util/temp-dir';
+import {createLogger} from '../util/logger';
 import getValidatedManifest from '../util/manifest';
+
+const log = createLogger(__filename);
 
 
 export default function run(
     {sourceDir, firefoxBinary, firefoxProfile}: Object,
     {firefox=defaultFirefox}: Object = {}): Promise {
 
-  console.log(`Running web extension from ${sourceDir}`);
+  log.info(`Running web extension from ${sourceDir}`);
 
   return getValidatedManifest(sourceDir)
     .then((manifestData) => withTempDir(
@@ -19,10 +22,10 @@ export default function run(
                          {manifestData}),
           new Promise((resolve) => {
             if (firefoxProfile) {
-              console.log(`Copying Firefox profile from ${firefoxProfile}`);
+              log.debug(`Copying Firefox profile from ${firefoxProfile}`);
               resolve(firefox.copyProfile(firefoxProfile));
             } else {
-              console.log('Creating new Firefox profile');
+              log.debug('Creating new Firefox profile');
               resolve(firefox.createProfile());
             }
           }),

--- a/src/cmd/sign.js
+++ b/src/cmd/sign.js
@@ -5,10 +5,14 @@ import defaultBuilder from './build';
 import {withTempDir} from '../util/temp-dir';
 import getValidatedManifest from '../util/manifest';
 import {prepareArtifactsDir} from '../util/artifacts';
+import {createLogger} from '../util/logger';
+
+const log = createLogger(__filename);
 
 
 export default function sign(
-    {sourceDir, artifactsDir, apiKey, apiSecret, apiUrlPrefix}: Object,
+    {verbose, sourceDir, artifactsDir, apiKey, apiSecret,
+     apiUrlPrefix}: Object,
     {build=defaultBuilder, signAddon=defaultAddonSigner,
      preValidatedManifest=null}: Object = {}): Promise {
 
@@ -34,6 +38,7 @@ export default function sign(
           apiKey,
           apiSecret,
           apiUrlPrefix,
+          verbose,
           xpiPath: buildResult.extensionPath,
           id: manifestData.applications.gecko.id,
           version: manifestData.version,
@@ -42,7 +47,7 @@ export default function sign(
         .then((signingResult) => {
           // All information about the downloaded files would have
           // already been logged by signAddon().
-          console.log(signingResult.success ? 'SUCCESS' : 'FAIL');
+          log.info(signingResult.success ? 'SUCCESS' : 'FAIL');
           return signingResult;
         });
     }

--- a/src/util/artifacts.js
+++ b/src/util/artifacts.js
@@ -1,6 +1,9 @@
 /* @flow */
 import fs from 'mz/fs';
 import {WebExtError, onlyErrorsWithCode} from '../errors';
+import {createLogger} from './logger';
+
+const log = createLogger(__filename);
 
 
 export function prepareArtifactsDir(artifactsDir: string): Promise {
@@ -11,7 +14,7 @@ export function prepareArtifactsDir(artifactsDir: string): Promise {
       }
     })
     .catch(onlyErrorsWithCode('ENOENT', () => {
-      console.log(`Creating artifacts directory: ${artifactsDir}`);
+      log.debug(`Creating artifacts directory: ${artifactsDir}`);
       return fs.mkdir(artifactsDir);
     }))
     .then(() => artifactsDir);

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -1,0 +1,73 @@
+/* @flow */
+import bunyan, {nameFromLevel, createLogger as defaultLogCreator}
+  from 'bunyan';
+
+
+export class ConsoleStream {
+  verbose: boolean;
+  isCapturing: boolean;
+  capturedMessages: Array<string>;
+
+  constructor({verbose=false}: Object = {}) {
+    this.verbose = verbose;
+    this.isCapturing = false;
+    this.capturedMessages = [];
+  }
+
+  format({name, msg, level}: Object): string {
+    const prefix = this.verbose ? `[${name}][${nameFromLevel[level]}] ` : '';
+    return `${prefix}${msg}\n`;
+  }
+
+  makeVerbose() {
+    this.verbose = true;
+  }
+
+  write(packet: Object, {localProcess=process}: Object = {}) {
+    const thisLevel = this.verbose ? bunyan.TRACE : bunyan.INFO;
+    if (packet.level >= thisLevel) {
+      const msg = this.format(packet);
+      if (this.isCapturing) {
+        this.capturedMessages.push(msg);
+      } else {
+        localProcess.stdout.write(msg);
+      }
+    }
+  }
+
+  startCapturing() {
+    this.isCapturing = true;
+  }
+
+  stopCapturing() {
+    this.isCapturing = false;
+    this.capturedMessages = [];
+  }
+
+  flushCapturedLogs({localProcess=process}: Object = {}) {
+    for (let msg of this.capturedMessages) {
+      localProcess.stdout.write(msg);
+    }
+    this.capturedMessages = [];
+  }
+}
+
+export const consoleStream = new ConsoleStream();
+
+
+export function createLogger(
+    filename: string,
+    {createBunyanLog=defaultLogCreator}: Object = {}): Object {
+
+  return createBunyanLog({
+    // Strip the leading src/ from file names (which is in all file names) to
+    // make the name less redundant.
+    name: filename.replace(/^src\//, ''),
+    // Capture all log levels and let the stream filter them.
+    level: bunyan.TRACE,
+    streams: [{
+      type: 'raw',
+      stream: consoleStream,
+    }],
+  });
+}

--- a/src/util/manifest.js
+++ b/src/util/manifest.js
@@ -3,11 +3,14 @@ import path from 'path';
 
 import fs from 'mz/fs';
 import {InvalidManifest} from '../errors';
+import {createLogger} from './logger';
+
+const log = createLogger(__filename);
 
 
 export default function getValidatedManifest(sourceDir: string): Promise {
   let manifestFile = path.join(sourceDir, 'manifest.json');
-  console.log(`Validating manifest at ${manifestFile}`);
+  log.debug(`Validating manifest at ${manifestFile}`);
   return fs.readFile(manifestFile)
     .catch((error) => {
       throw new InvalidManifest(

--- a/src/util/temp-dir.js
+++ b/src/util/temp-dir.js
@@ -2,6 +2,9 @@
 import tmp from 'tmp';
 
 import {promisify} from './es6-modules';
+import {createLogger} from './logger';
+
+const log = createLogger(__filename);
 
 
 /*
@@ -70,7 +73,7 @@ export class TempDir {
         let [tmpPath, removeTempDir] = args;
         this._path = tmpPath;
         this._removeTempDir = removeTempDir;
-        console.log(`Created temporary directory: ${this.path()}`);
+        log.debug(`Created temporary directory: ${this.path()}`);
         return this;
       });
   }
@@ -119,7 +122,7 @@ export class TempDir {
     if (!this._removeTempDir) {
       return;
     }
-    console.log(`Removing temporary directory: ${this.path()}`);
+    log.debug(`Removing temporary directory: ${this.path()}`);
     this._removeTempDir && this._removeTempDir();
   }
 

--- a/tests/coverage-reporter.js
+++ b/tests/coverage-reporter.js
@@ -10,6 +10,7 @@ module.exports = function CoverageReporter(runner) {
 
     reporter.addAll([ 'text', 'text-summary', 'lcov' ]);
     reporter.write(collector, sync, function() {
+      // eslint-disable-next-line no-console
       console.log('All coverage reports generated');
     });
   });

--- a/tests/fixtures/minimal-web-ext/background-script.js
+++ b/tests/fixtures/minimal-web-ext/background-script.js
@@ -1,1 +1,3 @@
+/* eslint no-console:0 */
+
 console.log('background script loaded');

--- a/tests/test-cmd/test.sign.js
+++ b/tests/test-cmd/test.sign.js
@@ -43,11 +43,13 @@ describe('sign', () => {
   /*
    * Run the sign command with stubs for all dependencies.
    */
-  function sign(artifactsDir, stubs) {
+  function sign(artifactsDir, stubs, extraArgs={}) {
     return completeSignCommand({
       sourceDir: '/fake/path/to/local/extension',
+      verbose: false,
       artifactsDir,
       ...stubs.signingConfig,
+      ...extraArgs,
     }, {
       ...stubs,
     });
@@ -108,6 +110,17 @@ describe('sign', () => {
                        stubs.preValidatedManifest.version);
           assert.equal(signedAddonCall.downloadDir,
                        tmpDir.path());
+        });
+    }
+  ));
+
+  it('passes the verbose flag to the signer', () => withTempDir(
+    (tmpDir) => {
+      let stubs = getStubs();
+      return sign(tmpDir.path(), stubs, {verbose: true})
+        .then(() => {
+          assert.equal(stubs.signAddon.called, true);
+          assert.equal(stubs.signAddon.firstCall.args[0].verbose, true);
         });
     }
   ));

--- a/tests/test-firefox/test.firefox.js
+++ b/tests/test-firefox/test.firefox.js
@@ -98,6 +98,31 @@ describe('firefox', () => {
         });
     });
 
+    it('logs stdout and stderr without errors', () => {
+      // Store a registry of handlers that we can execute directly.
+      const firefoxApp = {};
+      const runner = createFakeFxRunner({
+        stdout: {
+          on: (event, handler) => {
+            firefoxApp.writeStdout = handler;
+          },
+        },
+        stderr: {
+          on: (event, handler) => {
+            firefoxApp.writeStderr = handler;
+          },
+        },
+      });
+
+      return firefox.run(fakeProfile, {fxRunner: runner})
+        .then(() => {
+          // This makes sure that when each handler writes to the
+          // logger they don't raise any exceptions.
+          firefoxApp.writeStdout('example of stdout');
+          firefoxApp.writeStderr('example of stderr');
+        });
+    });
+
   });
 
   describe('copyProfile', () => {

--- a/tests/test-util/test.logger.js
+++ b/tests/test-util/test.logger.js
@@ -1,0 +1,153 @@
+/* @flow */
+import {it, describe} from 'mocha';
+import {assert} from 'chai';
+import bunyan from 'bunyan';
+import sinon from 'sinon';
+
+import {createLogger, ConsoleStream} from '../../src/util/logger';
+
+
+describe('logger', () => {
+
+  describe('createLogger', () => {
+
+    it('makes file names less redundant', () => {
+      const createBunyanLog = sinon.spy(() => {});
+      createLogger('src/some-file.js', {createBunyanLog});
+      assert.equal(createBunyanLog.firstCall.args[0].name, 'some-file.js');
+    });
+
+  });
+
+  describe('ConsoleStream', () => {
+
+    function packet(overrides) {
+      return {
+        name: 'some name',
+        msg: 'some messge',
+        level: bunyan.INFO,
+        ...overrides,
+      };
+    }
+
+    function fakeProcess() {
+      return {
+        stdout: {
+          write: sinon.spy(() => {}),
+        },
+      };
+    }
+
+    it('lets you turn on verbose logging', () => {
+      const log = new ConsoleStream({verbose: false});
+      log.makeVerbose();
+      assert.equal(log.verbose, true);
+    });
+
+    it('logs names in verbose mode', () => {
+      const log = new ConsoleStream({verbose: true});
+      assert.equal(
+        log.format(packet({
+          name: 'foo',
+          msg: 'some message',
+          level: bunyan.DEBUG,
+        })),
+        '[foo][debug] some message\n');
+    });
+
+    it('does not log names in non-verbose mode', () => {
+      const log = new ConsoleStream({verbose: false});
+      assert.equal(
+        log.format(packet({name: 'foo', msg: 'some message'})),
+        'some message\n');
+    });
+
+    it('does not log debug packets unless verbose', () => {
+      const log = new ConsoleStream({verbose: false});
+      const localProcess = fakeProcess();
+      log.write(packet({level: bunyan.DEBUG}), {localProcess});
+      assert.equal(localProcess.stdout.write.called, false);
+    });
+
+    it('does not log trace packets unless verbose', () => {
+      const log = new ConsoleStream({verbose: false});
+      const localProcess = fakeProcess();
+      log.write(packet({level: bunyan.TRACE}), {localProcess});
+      assert.equal(localProcess.stdout.write.called, false);
+    });
+
+    it('logs debug packets when verbose', () => {
+      const log = new ConsoleStream({verbose: true});
+      const localProcess = fakeProcess();
+      log.write(packet({level: bunyan.DEBUG}), {localProcess});
+      assert.equal(localProcess.stdout.write.called, true);
+    });
+
+    it('logs trace packets when verbose', () => {
+      const log = new ConsoleStream({verbose: true});
+      const localProcess = fakeProcess();
+      log.write(packet({level: bunyan.TRACE}), {localProcess});
+      assert.equal(localProcess.stdout.write.called, true);
+    });
+
+    it('logs info packets when verbose or not', () => {
+      const log = new ConsoleStream({verbose: false});
+      const localProcess = fakeProcess();
+      log.write(packet({level: bunyan.INFO}), {localProcess});
+      log.makeVerbose();
+      log.write(packet({level: bunyan.INFO}), {localProcess});
+      assert.equal(localProcess.stdout.write.callCount, 2);
+    });
+
+    it('lets you capture logging', () => {
+      const log = new ConsoleStream();
+      const localProcess = fakeProcess();
+
+      log.startCapturing();
+      log.write(packet({msg: 'message'}), {localProcess});
+      assert.equal(localProcess.stdout.write.called, false);
+
+      log.flushCapturedLogs({localProcess});
+      assert.equal(localProcess.stdout.write.called, true);
+      assert.equal(localProcess.stdout.write.firstCall.args[0],
+                   'message\n');
+    });
+
+    it('only flushes captured messages once', () => {
+      const log = new ConsoleStream();
+      let localProcess = fakeProcess();
+
+      log.startCapturing();
+      log.write(packet(), {localProcess});
+      log.flushCapturedLogs({localProcess});
+
+      // Make sure there is nothing more to flush.
+      localProcess = fakeProcess();
+      log.flushCapturedLogs({localProcess});
+      assert.equal(localProcess.stdout.write.callCount, 0);
+    });
+
+    it('lets you start and stop capturing', () => {
+      const log = new ConsoleStream();
+      let localProcess = fakeProcess();
+
+      log.startCapturing();
+      log.write(packet(), {localProcess});
+      assert.equal(localProcess.stdout.write.callCount, 0);
+
+      log.stopCapturing();
+      log.write(packet(), {localProcess});
+      assert.equal(localProcess.stdout.write.callCount, 1);
+
+      // Make sure that when we start capturing again,
+      // the queue gets reset.
+      log.startCapturing();
+      log.write(packet());
+      localProcess = fakeProcess();
+      log.flushCapturedLogs({localProcess});
+      assert.equal(localProcess.stdout.write.callCount, 1);
+    });
+
+  });
+
+});

--- a/tests/test.program.js
+++ b/tests/test.program.js
@@ -9,6 +9,7 @@ import {version, main, Program} from '../src/program';
 import commands from '../src/cmd';
 import {onlyInstancesOf, WebExtError} from '../src/errors';
 import {fake, makeSureItFails} from './helpers';
+import {ConsoleStream} from '../src/util/logger';
 
 
 describe('program.Program', () => {
@@ -125,6 +126,25 @@ describe('program.Program', () => {
         // will be applied to sub commands.
         assert.equal(handler.firstCall.args[0].globalOption, 'the default');
         assert.equal(handler.firstCall.args[0].someOption, 'default value');
+      });
+  });
+
+  it('configures the logger when verbose', () => {
+    const logStream = fake(new ConsoleStream());
+    let program = new Program(['thing', '--verbose'])
+      .command('thing', 'does a thing', () => {});
+    return run(program, {logStream})
+      .then(() => {
+        assert.equal(logStream.makeVerbose.called, true);
+      });
+  });
+
+  it('does not configure the logger unless verbose', () => {
+    const logStream = fake(new ConsoleStream());
+    let program = new Program(['thing']).command('thing', '', () => {});
+    return run(program, {logStream})
+      .then(() => {
+        assert.equal(logStream.makeVerbose.called, false);
       });
   });
 

--- a/tests/test.setup.js
+++ b/tests/test.setup.js
@@ -1,0 +1,15 @@
+/* @flow */
+import {beforeEach, afterEach} from 'mocha';
+import {consoleStream} from '../src/util/logger';
+
+beforeEach(function() {
+  consoleStream.makeVerbose();
+  consoleStream.startCapturing();
+});
+
+afterEach(function() {
+  if (this.currentTest.state !== 'passed') {
+    consoleStream.flushCapturedLogs();
+  }
+  consoleStream.stopCapturing();
+});


### PR DESCRIPTION
* Adds a logger, implements `--verbose`, and converts all old console calls (fixes https://github.com/mozilla/web-ext/issues/33)
* Adds log capturing for tests so that only failing tests spew logs (fixes https://github.com/mozilla/web-ext/issues/120)

Example:

````
$ web-ext build
Building web extension from /Users/kumar/dev/bookmarker-ext/moz-webext
Your web extension is ready: /Users/kumar/dev/bookmarker-ext/moz-webext/web-ext-artifacts/getting_started_example-1.2.25.xpi
````

````
$ web-ext --verbose build
[cmd/build.js][info] Building web extension from /Users/kumar/dev/bookmarker-ext/moz-webext
[util/manifest.js][debug] Validating manifest at /Users/kumar/dev/bookmarker-ext/moz-webext/manifest.json
[cmd/build.js][debug] Not including file /Users/kumar/dev/bookmarker-ext/moz-webext/.DS_Store in ZIP archive
[cmd/build.js][debug] Not including file /Users/kumar/dev/bookmarker-ext/moz-webext/web-ext-artifacts/getting_started_example-1.2.22.xpi in ZIP archive
[cmd/build.js][debug] Not including file /Users/kumar/dev/bookmarker-ext/moz-webext/web-ext-artifacts/getting_started_example-1.2.23-fx.xpi in ZIP archive
[cmd/build.js][debug] Not including file /Users/kumar/dev/bookmarker-ext/moz-webext/web-ext-artifacts/getting_started_example-1.2.25-fx.xpi in ZIP archive
[cmd/build.js][debug] Not including file /Users/kumar/dev/bookmarker-ext/moz-webext/web-ext-artifacts/getting_started_example-1.2.25.xpi in ZIP archive
[cmd/build.js][info] Your web extension is ready: /Users/kumar/dev/bookmarker-ext/moz-webext/web-ext-artifacts/getting_started_example-1.2.25.xpi
````