### PR TITLE
fix(): Increased test timeout for Travis

### DIFF
--- a/tasks/mochaTest.js
+++ b/tasks/mochaTest.js
@@ -1,6 +1,6 @@
 module.exports = {
   options: {
-    timeout: 1000,
+    timeout: 2000,
     reporter: 'mocha-multi',
     reporterOptions: {
       spec: '-',


### PR DESCRIPTION
There are several tests that require I/O and sometimes
these time out when TravisCI is overloaded.