### PR TITLE
fix(): Fixed source-map-support import error

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "minimatch": "3.0.0",
     "mz": "2.4.0",
     "sign-addon": "0.0.1",
+    "source-map-support": "0.4.0",
     "stream-to-promise": "1.1.0",
     "tmp": "0.0.28",
     "yargs": "4.4.0",


### PR DESCRIPTION
The webpack banner adds a source-map-support import at the top of the distributed file so it needs to be an explicit dependency.