### PR TITLE
Added build --as-needed to watch and rebuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "babel-polyfill": "6.7.4",
     "bunyan": "1.8.0",
+    "debounce": "1.0.0",
     "es6-error": "2.1.0",
     "es6-promisify": "4.0.0",
     "firefox-profile": "0.3.12",
@@ -47,6 +48,7 @@
     "source-map-support": "0.4.0",
     "stream-to-promise": "1.1.0",
     "tmp": "0.0.28",
+    "watchpack": "1.0.1",
     "yargs": "4.6.0",
     "zip-dir": "1.0.2"
   },

--- a/src/program.js
+++ b/src/program.js
@@ -142,7 +142,12 @@ Example: $0 --help run.
   program
     .command('build',
              'Create a web extension package from source',
-             commands.build, {})
+             commands.build, {
+      'as-needed': {
+        describe: 'Watch for file changes and re-build as needed',
+        type: 'boolean',
+      },
+    })
     .command('sign',
              'Sign the web extension so it can be installed in Firefox',
              commands.sign, {

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -1,0 +1,41 @@
+/* @flow */
+import Watchpack from 'watchpack';
+import debounce from 'debounce';
+
+import {createLogger} from './util/logger';
+
+const log = createLogger(__filename);
+
+
+export default function onSourceChange(
+    {sourceDir, artifactsDir, onChange, shouldWatchFile}: Object): Watchpack {
+  // TODO: For network disks, we would need to add {poll: true}.
+  const watcher = new Watchpack();
+
+  const onFileChange = (filePath) => {
+    proxyFileChanges({artifactsDir, onChange, filePath, shouldWatchFile});
+  };
+  const executeImmediately = true;
+  watcher.on('change', debounce(onFileChange, 1000, executeImmediately));
+
+  log.debug(`Watching for file changes in ${sourceDir}`);
+  watcher.watch([], [sourceDir], Date.now());
+
+  // TODO: support windows See:
+  // http://stackoverflow.com/questions/10021373/what-is-the-windows-equivalent-of-process-onsigint-in-node-js
+  process.on('SIGINT', () => watcher.close());
+  return watcher;
+}
+
+
+export function proxyFileChanges(
+    {artifactsDir, onChange, filePath, shouldWatchFile=() => true}
+    : Object) {
+  if (filePath.indexOf(artifactsDir) === 0 || !shouldWatchFile(filePath)) {
+    log.debug(`Ignoring change to: ${filePath}`);
+  } else {
+    log.info(`Changed: ${filePath}`);
+    log.debug(`Last change detection: ${(new Date()).toTimeString()}`);
+    onChange();
+  }
+}

--- a/tests/test-cmd/test.build.js
+++ b/tests/test-cmd/test.build.js
@@ -3,92 +3,164 @@ import fs from 'mz/fs';
 import path from 'path';
 import {it, describe} from 'mocha';
 import {assert} from 'chai';
+import sinon from 'sinon';
 
 import build, {safeFileName, FileFilter} from '../../src/cmd/build';
 import {withTempDir} from '../../src/util/temp-dir';
-import {fixturePath, ZipFile} from '../helpers';
+import {fixturePath, makeSureItFails, ZipFile} from '../helpers';
 import {basicManifest} from '../test-util/test.manifest';
 
 
 describe('build', () => {
 
-  describe('build', () => {
+  it('zips a package', () => {
+    let zipFile = new ZipFile();
 
-    it('zips a package', () => {
-      let zipFile = new ZipFile();
-
-      return withTempDir(
-        (tmpDir) =>
-          build({
-            sourceDir: fixturePath('minimal-web-ext'),
-            artifactsDir: tmpDir.path(),
-          })
-          .then((buildResult) => {
-            assert.match(buildResult.extensionPath,
-                         /minimal_extension-1\.0\.xpi$/);
-            return buildResult.extensionPath;
-          })
-          .then((extensionPath) => zipFile.open(extensionPath))
-          .then(() => zipFile.extractFilenames())
-          .then((fileNames) => {
-            fileNames.sort();
-            assert.deepEqual(fileNames,
-                             ['background-script.js', 'manifest.json']);
-          })
-      );
-    });
-
-    it('prepares the artifacts dir', () => withTempDir(
-      (tmpDir) => {
-        const artifactsDir = path.join(tmpDir.path(), 'artifacts');
-        return build(
-          {
-            sourceDir: fixturePath('minimal-web-ext'),
-            artifactsDir,
-          })
-          .then(() => fs.stat(artifactsDir))
-          .then((stats) => {
-            assert.equal(stats.isDirectory(), true);
-          });
-      }
-    ));
-
-    it('lets you specify a manifest', () => withTempDir(
+    return withTempDir(
       (tmpDir) =>
         build({
           sourceDir: fixturePath('minimal-web-ext'),
           artifactsDir: tmpDir.path(),
-        }, {
-          manifestData: basicManifest,
         })
         .then((buildResult) => {
           assert.match(buildResult.extensionPath,
-                       /the_extension-0\.0\.1\.xpi$/);
+                       /minimal_extension-1\.0\.xpi$/);
           return buildResult.extensionPath;
         })
-    ));
+        .then((extensionPath) => zipFile.open(extensionPath))
+        .then(() => zipFile.extractFilenames())
+        .then((fileNames) => {
+          fileNames.sort();
+          assert.deepEqual(fileNames,
+                           ['background-script.js', 'manifest.json']);
+        })
+    );
+  });
 
-    it('asks FileFilter what files to include in the XPI', () => {
-      let zipFile = new ZipFile();
-      let fileFilter = new FileFilter({
-        filesToIgnore: ['**/background-script.js'],
-      });
+  it('prepares the artifacts dir', () => withTempDir(
+    (tmpDir) => {
+      const artifactsDir = path.join(tmpDir.path(), 'artifacts');
+      return build(
+        {
+          sourceDir: fixturePath('minimal-web-ext'),
+          artifactsDir,
+        })
+        .then(() => fs.stat(artifactsDir))
+        .then((stats) => {
+          assert.equal(stats.isDirectory(), true);
+        });
+    }
+  ));
 
-      return withTempDir(
-        (tmpDir) =>
-          build({
-            sourceDir: fixturePath('minimal-web-ext'),
-            artifactsDir: tmpDir.path(),
-          }, {fileFilter})
-          .then((buildResult) => zipFile.open(buildResult.extensionPath))
-          .then(() => zipFile.extractFilenames())
-          .then((fileNames) => {
-            assert.notInclude(fileNames, 'background-script.js');
-          })
-      );
+  it('lets you specify a manifest', () => withTempDir(
+    (tmpDir) =>
+      build({
+        sourceDir: fixturePath('minimal-web-ext'),
+        artifactsDir: tmpDir.path(),
+      }, {
+        manifestData: basicManifest,
+      })
+      .then((buildResult) => {
+        assert.match(buildResult.extensionPath,
+                     /the_extension-0\.0\.1\.xpi$/);
+        return buildResult.extensionPath;
+      })
+  ));
+
+  it('asks FileFilter what files to include in the XPI', () => {
+    let zipFile = new ZipFile();
+    let fileFilter = new FileFilter({
+      filesToIgnore: ['**/background-script.js'],
     });
 
+    return withTempDir(
+      (tmpDir) =>
+        build({
+          sourceDir: fixturePath('minimal-web-ext'),
+          artifactsDir: tmpDir.path(),
+        }, {fileFilter})
+        .then((buildResult) => zipFile.open(buildResult.extensionPath))
+        .then(() => zipFile.extractFilenames())
+        .then((fileNames) => {
+          assert.notInclude(fileNames, 'background-script.js');
+        })
+    );
   });
+
+  it('lets you rebuild when files change', () => withTempDir(
+    (tmpDir) => {
+      const fileFilter = new FileFilter();
+      sinon.spy(fileFilter, 'wantFile');
+      const onSourceChange = sinon.spy(() => {});
+      const sourceDir = fixturePath('minimal-web-ext');
+      const artifactsDir = tmpDir.path();
+      return build(
+        {sourceDir, artifactsDir, asNeeded: true},
+        {manifestData: basicManifest, onSourceChange, fileFilter})
+        .then((buildResult) => {
+          // Make sure we still have a build result.
+          assert.match(buildResult.extensionPath, /\.xpi$/);
+          return buildResult;
+        })
+        .then((buildResult) => {
+          assert.equal(onSourceChange.called, true);
+          const args = onSourceChange.firstCall.args[0];
+          assert.equal(args.sourceDir, sourceDir);
+          assert.equal(args.artifactsDir, artifactsDir);
+          assert.typeOf(args.onChange, 'function');
+
+          // Make sure it uses the file filter.
+          assert.typeOf(args.shouldWatchFile, 'function');
+          args.shouldWatchFile('/some/path');
+          assert.equal(fileFilter.wantFile.called, true);
+
+          // Remove the built extension.
+          return fs.unlink(buildResult.extensionPath)
+            // Execute the onChange handler to make sure it gets built
+            // again. This simulates what happens when the file watcher
+            // executes the callback.
+            .then(() => args.onChange());
+        })
+        .then((buildResult) => {
+          assert.match(buildResult.extensionPath, /\.xpi$/);
+          return fs.stat(buildResult.extensionPath);
+        })
+        .then((stat) => {
+          assert.equal(stat.isFile(), true);
+        });
+    }
+  ));
+
+  it('throws errors when rebuilding in source watcher', () => withTempDir(
+    (tmpDir) => {
+      var packageResult = Promise.resolve({});
+      const packageCreator = sinon.spy(() => packageResult);
+      const onSourceChange = sinon.spy(() => {});
+      return build(
+        {
+          sourceDir: fixturePath('minimal-web-ext'),
+          artifactsDir: tmpDir.path(),
+          asNeeded: true,
+        },
+        {manifestData: basicManifest, onSourceChange, packageCreator})
+        .then(() => {
+          assert.equal(onSourceChange.called, true);
+          assert.equal(packageCreator.callCount, 1);
+
+          const {onChange} = onSourceChange.firstCall.args[0];
+          packageResult = Promise.reject(new Error(
+            'Simulate an error on the second call to packageCreator()'));
+          // Invoke the stub packageCreator() again which should throw an error
+          return onChange();
+        })
+        .then(makeSureItFails())
+        .catch((error) => {
+          assert.include(
+            error.message,
+            'Simulate an error on the second call to packageCreator()');
+        });
+    }
+  ));
 
   describe('safeFileName', () => {
 

--- a/tests/test.watcher.js
+++ b/tests/test.watcher.js
@@ -1,0 +1,106 @@
+/* @flow */
+import path from 'path';
+import {it, describe} from 'mocha';
+import fs from 'mz/fs';
+import sinon from 'sinon';
+import {assert} from 'chai';
+
+import {default as onSourceChange, proxyFileChanges} from '../src/watcher';
+import {withTempDir} from '../src/util/temp-dir';
+
+
+describe('watcher', () => {
+
+  it('watches for file changes', () => withTempDir(
+    (tmpDir) => {
+      const artifactsDir = path.join(tmpDir.path(), 'web-ext-artifacts');
+      const someFile = path.join(tmpDir.path(), 'foo.txt');
+
+      var resolveChange;
+      const whenFilesChanged = new Promise((resolve) => {
+        resolveChange = resolve;
+      });
+      const onChange = sinon.spy(() => {
+        resolveChange();
+      });
+
+      return fs.writeFile(someFile, '<contents>')
+        .then(() => {
+          return onSourceChange({
+            sourceDir: tmpDir.path(),
+            artifactsDir,
+            onChange,
+          });
+        })
+        .then((watcher) => {
+          return fs.utimes(someFile, Date.now(), Date.now())
+            .then(() => watcher);
+        })
+        .then((watcher) => {
+          return whenFilesChanged
+            .then(() => {
+              watcher.close();
+              assert.equal(onChange.callCount, 1);
+              // This delay seems to avoid stat errors from the watcher
+              // which can happen when the temp dir is deleted (presumably
+              // before watcher.close() has removed all listeners).
+              return new Promise((resolve) => setTimeout(resolve, 2));
+            });
+        });
+    }
+  ));
+
+  describe('proxyFileChanges', () => {
+
+    const defaults = {
+      artifactsDir: '/some/artifacts/dir/',
+      onChange: () => {},
+    };
+
+    it('proxies file changes', () => {
+      const onChange = sinon.spy(() => {});
+      proxyFileChanges({
+        ...defaults,
+        filePath: '/some/file.js',
+        onChange,
+      });
+      assert.equal(onChange.called, true);
+    });
+
+    it('ignores changes to artifacts', () => {
+      const onChange = sinon.spy(() => {});
+      proxyFileChanges({
+        ...defaults,
+        filePath: '/some/artifacts/dir/build.xpi',
+        artifactsDir: '/some/artifacts/dir/',
+        onChange,
+      });
+      assert.equal(onChange.called, false);
+    });
+
+    it('provides a callback for ignoring files', () => {
+
+      function shouldWatchFile(filePath) {
+        if (filePath === '/somewhere/.git') {
+          return false;
+        } else {
+          return true;
+        }
+      }
+
+      const conf = {
+        ...defaults, shouldWatchFile,
+        onChange: sinon.spy(() => {}),
+      };
+
+      proxyFileChanges({...conf, filePath: '/somewhere/.git'});
+      assert.equal(conf.onChange.called, false);
+
+      proxyFileChanges({...conf, filePath: '/any/file/'});
+      assert.equal(conf.onChange.called, true);
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
Fixes https://github.com/mozilla/web-ext/issues/193

This lets you watch files and rebuild the extension, like:

    web-ext build --as-needed

It's not such an interesting feature itself but it is a stepping stone to re-installing an XPI which will be one way to reload changes in Firefox.