### PR TITLE
fix: Fixed `web-ext --help build`

### DIFF
--- a/src/program.js
+++ b/src/program.js
@@ -142,7 +142,7 @@ Example: $0 --help run.
   program
     .command('build',
              'Create a web extension package from source',
-             commands.build)
+             commands.build, {})
     .command('sign',
              'Sign the web extension so it can be installed in Firefox',
              commands.sign, {


### PR DESCRIPTION
Fixes #199 

From what I could figure out the build operation accepts no extra options as of now hence the empty object as the argument.

This is my first code contribution here. Let me know if any changes are required for this, thanks!