### PR TITLE
Update firefox-profile dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "debounce": "1.0.0",
     "es6-error": "3.0.0",
     "es6-promisify": "4.1.0",
-    "firefox-profile": "0.3.13",
+    "firefox-profile": "0.4.0",
     "fx-runner": "1.0.1",
     "minimatch": "3.0.0",
     "mz": "2.4.0",


### PR DESCRIPTION
...to get rid of the deprecated warning for `wrench`, see https://github.com/saadtazi/firefox-profile-js/issues/61