### PR TITLE
feat: Run now installs as temporary add-on

### DIFF
--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -1,9 +1,7 @@
 /* @flow */
-import buildExtension from './build';
 import * as defaultFirefox from '../firefox';
 import defaultFirefoxConnector from '../firefox/remote';
 import {onlyErrorsWithCode} from '../errors';
-import {withTempDir} from '../util/temp-dir';
 import {createLogger} from '../util/logger';
 import getValidatedManifest from '../util/manifest';
 import defaultSourceWatcher from '../watcher';
@@ -12,13 +10,12 @@ const log = createLogger(__filename);
 
 
 export function defaultWatcherCreator(
-    {profile, client, sourceDir, artifactsDir, createRunner,
+    {client, sourceDir, artifactsDir, createRunner,
      onSourceChange=defaultSourceWatcher}: Object): Object {
   return onSourceChange({
-    sourceDir, artifactsDir, onChange: () => createRunner(
-      (runner) => runner.buildExtension()
-        .then((buildResult) => runner.install(buildResult, {profile}))
-        .then(() => {
+    sourceDir, artifactsDir, onChange: () => {
+      return createRunner()
+        .then((runner) => {
           log.debug('Attempting to reload extension');
           const addonId = runner.manifestData.applications.gecko.id;
           log.debug(`Reloading add-on ID ${addonId}`);
@@ -27,40 +24,39 @@ export function defaultWatcherCreator(
         .catch((error) => {
           log.error(error.stack);
           throw error;
-        })
-    ),
+        });
+    },
   });
 }
 
 
 export function defaultReloadStrategy(
-    {firefox, profile, sourceDir, artifactsDir, createRunner}: Object,
-    {connectToFirefox=defaultFirefoxConnector,
-     maxRetries=25, retryInterval=120,
-     createWatcher=defaultWatcherCreator}: Object = {}): Promise {
-  var watcher;
-  var client;
-  var retries = 0;
+    {firefox, client, profile, sourceDir, artifactsDir, createRunner}: Object,
+    {createWatcher=defaultWatcherCreator}: Object = {}) {
+  let watcher;
 
   firefox.on('close', () => {
-    if (client) {
-      client.disconnect();
-    }
-    if (watcher) {
-      watcher.close();
-    }
+    client.disconnect();
+    watcher.close();
   });
+
+  watcher = createWatcher({
+    client, sourceDir, artifactsDir, createRunner,
+  });
+}
+
+
+export function defaultFirefoxClient(
+    {connectToFirefox=defaultFirefoxConnector,
+     maxRetries=25, retryInterval=120}: Object = {}) {
+  var retries = 0;
 
   function establishConnection() {
     return new Promise((resolve, reject) => {
       connectToFirefox()
         .then((connectedClient) => {
           log.debug('Connected to the Firefox debugger');
-          client = connectedClient;
-          watcher = createWatcher({
-            profile, client, sourceDir, artifactsDir, createRunner,
-          });
-          resolve();
+          resolve(connectedClient);
         })
         .catch(onlyErrorsWithCode('ECONNREFUSED', (error) => {
           if (retries >= maxRetries) {
@@ -88,70 +84,74 @@ export function defaultReloadStrategy(
 
 export default function run(
     {sourceDir, artifactsDir, firefoxBinary, firefoxProfile, noReload}: Object,
-    {firefox=defaultFirefox, reloadStrategy=defaultReloadStrategy}
+    {firefoxClient=defaultFirefoxClient, firefox=defaultFirefox,
+     reloadStrategy=defaultReloadStrategy}
     : Object = {}): Promise {
 
   log.info(`Running web extension from ${sourceDir}`);
 
-  function createRunner(callback) {
+  function createRunner() {
     return getValidatedManifest(sourceDir)
-      .then((manifestData) => withTempDir(
-        (tmpDir) => {
-          const runner = new ExtensionRunner({
-            sourceDir,
-            firefox,
-            firefoxBinary,
-            tmpDirPath: tmpDir.path(),
-            manifestData,
-            firefoxProfile,
-          });
-          return callback(runner);
-        }
-      ));
+      .then((manifestData) => {
+        return new ExtensionRunner({
+          sourceDir,
+          firefox,
+          firefoxBinary,
+          manifestData,
+          firefoxProfile,
+        });
+      });
   }
 
-  return createRunner(
-    (runner) => runner.buildExtension()
-      .then((buildResult) => runner.install(buildResult))
-      .then((profile) => runner.run(profile).then((firefox) => {
-        return {firefox, profile};
-      }))
-      .then(({firefox, profile}) => {
-        if (noReload) {
-          log.debug('Extension auto-reloading has been disabled');
-        } else {
-          log.debug('Reloading extension when the source changes');
-          reloadStrategy(
-            {firefox, profile, sourceDir, artifactsDir, createRunner});
-        }
-        return firefox;
-      })
-  );
+  return createRunner()
+    .then((runner) => {
+      return runner.getProfile().then((profile) => {
+        return {runner, profile};
+      });
+    })
+    .then(({runner, profile}) => {
+      return runner.run(profile).then((firefox) => {
+        return {runner, profile, firefox};
+      });
+    })
+    .then((config) => {
+      return firefoxClient().then((client) => {
+        return {client, ...config};
+      });
+    })
+    .then((config) => {
+      const {runner, client} = config;
+      return runner.install(client).then(() => {
+        return config;
+      });
+    })
+    .then(({firefox, profile, client}) => {
+      if (noReload) {
+        log.debug('Extension auto-reloading has been disabled');
+      } else {
+        log.debug('Reloading extension when the source changes');
+        reloadStrategy({firefox, profile, client, sourceDir,
+                        artifactsDir, createRunner});
+      }
+      return firefox;
+    });
 }
 
 
 export class ExtensionRunner {
   sourceDir: string;
-  tmpDirPath: string;
   manifestData: Object;
   firefoxProfile: Object;
   firefox: Object;
   firefoxBinary: string;
 
-  constructor({firefox, sourceDir, tmpDirPath, manifestData,
+  constructor({firefox, sourceDir, manifestData,
                firefoxProfile, firefoxBinary}: Object) {
     this.sourceDir = sourceDir;
-    this.tmpDirPath = tmpDirPath;
     this.manifestData = manifestData;
     this.firefoxProfile = firefoxProfile;
     this.firefox = firefox;
     this.firefoxBinary = firefoxBinary;
-  }
-
-  buildExtension(): Promise {
-    const {sourceDir, tmpDirPath, manifestData} = this;
-    return buildExtension({sourceDir, artifactsDir: tmpDirPath},
-                          {manifestData});
   }
 
   getProfile(): Promise {
@@ -167,16 +167,8 @@ export class ExtensionRunner {
     });
   }
 
-  install(buildResult: Object, {profile}: Object = {}): Promise {
-    const {firefox, manifestData} = this;
-    return Promise.resolve(profile ? profile : this.getProfile())
-      .then((profile) => firefox.installExtension(
-        {
-          manifestData,
-          extensionPath: buildResult.extensionPath,
-          profile,
-        })
-        .then(() => profile));
+  install(client: Object): Promise {
+    return client.installTemporaryAddon(this.sourceDir);
   }
 
   run(profile: Object): Promise {

--- a/src/firefox/remote.js
+++ b/src/firefox/remote.js
@@ -4,11 +4,15 @@ import {WebExtError} from '../errors';
 import defaultFirefoxConnector from 'node-firefox-connect';
 
 const log = createLogger(__filename);
+// The default port that Firefox's remote debugger will listen on and the
+// client will connect to.
+export const REMOTE_PORT = 6005;
 
 
 export default function connect(
-    port: number = 6000,
+    port: number = REMOTE_PORT,
     {connectToFirefox=defaultFirefoxConnector}: Object = {}): Promise {
+  log.debug(`Connecting to Firefox on port ${port}`);
   return connectToFirefox(port)
     .then((client) => {
       log.info('Connected to the Firefox remote debugger');
@@ -27,6 +31,17 @@ export class RemoteFirefox {
   constructor(client: Object) {
     this.client = client;
     this.checkedForAddonReloading = false;
+
+    client.client.on('disconnect', () => {
+      log.debug('Received "disconnect" from Firefox client');
+    });
+    client.client.on('end', () => {
+      log.debug('Received "end" from Firefox client');
+    });
+    client.client.on('message', (info) => {
+      // These are arbitrary messages that the client library ignores.
+      log.debug(`Received message from client: ${JSON.stringify(info)}`);
+    });
   }
 
   disconnect() {
@@ -43,6 +58,36 @@ export class RemoteFirefox {
         } else {
           resolve(response);
         }
+      });
+    });
+  }
+
+  installTemporaryAddon(addonPath: string) {
+    return new Promise((resolve, reject) => {
+      this.client.request('listTabs', (error, response) => {
+        if (error) {
+          return reject(new WebExtError(
+            `Remote Firefox: listTabs() error: ${error}`));
+        }
+        if (!response.addonsActor) {
+          log.debug(
+            `listTabs returned a falsey addonsActor: ${response.addonsActor}`);
+          throw new WebExtError(
+            'This is an older version of Firefox that does not provide an ' +
+            'add-ons actor for remote control');
+        }
+        this.client.client.makeRequest(
+          {to: response.addonsActor, type: 'installTemporaryAddon', addonPath},
+          (response) => {
+            if (response.error) {
+              return reject(new WebExtError(
+                'installTemporaryAddon: Error: ' +
+                `${response.error}: ${response.message}`));
+            }
+            log.debug(`installTemporaryAddon: ${JSON.stringify(response)}`);
+            log.info(`Installed ${addonPath} as a temporary add-on`);
+            resolve();
+          });
       });
     });
   }

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -13,11 +13,12 @@ export default function onSourceChange(
   // TODO: For network disks, we would need to add {poll: true}.
   const watcher = new Watchpack();
 
-  const onFileChange = (filePath) => {
-    proxyFileChanges({artifactsDir, onChange, filePath, shouldWatchFile});
-  };
   const executeImmediately = true;
-  watcher.on('change', debounce(onFileChange, 1000, executeImmediately));
+  onChange = debounce(onChange, 1000, executeImmediately);
+
+  watcher.on('change', (filePath) => {
+    proxyFileChanges({artifactsDir, onChange, filePath, shouldWatchFile});
+  });
 
   log.debug(`Watching for file changes in ${sourceDir}`);
   watcher.watch([], [sourceDir], Date.now());

--- a/tests/test-firefox/test.firefox.js
+++ b/tests/test-firefox/test.firefox.js
@@ -10,9 +10,10 @@ import * as firefox from '../../src/firefox';
 import {onlyInstancesOf, WebExtError} from '../../src/errors';
 import fs from 'mz/fs';
 import {withTempDir} from '../../src/util/temp-dir';
-import {fixturePath, makeSureItFails} from '../helpers';
+import {TCPConnectError, fixturePath, fake, makeSureItFails} from '../helpers';
 import {basicManifest} from '../test-util/test.manifest';
 import {defaultFirefoxEnv} from '../../src/firefox/';
+import {RemoteFirefox} from '../../src/firefox/remote';
 
 
 describe('firefox', () => {
@@ -45,20 +46,40 @@ describe('firefox', () => {
       }));
     }
 
+    function runFirefox({profile=fakeProfile, ...args}: Object = {}) {
+      return firefox.run(profile, {
+        fxRunner: createFakeFxRunner(),
+        findRemotePort: () => Promise.resolve(6000),
+        ...args,
+      });
+    }
+
     it('executes the Firefox runner with a given profile', () => {
-      let runner = createFakeFxRunner();
-      return firefox.run(fakeProfile, {fxRunner: runner})
+      const runner = createFakeFxRunner();
+      const profile = fakeProfile;
+      return runFirefox({fxRunner: runner, profile})
         .then(() => {
           assert.equal(runner.called, true);
           assert.equal(runner.firstCall.args[0].profile,
-                       fakeProfile.path());
+                       profile.path());
+        });
+    });
+
+    it('starts the remote debugger on a discovered port', () => {
+      const port = 6001;
+      const runner = createFakeFxRunner();
+      const findRemotePort = sinon.spy(() => Promise.resolve(port));
+      return runFirefox({fxRunner: runner, findRemotePort})
+        .then(() => {
+          assert.equal(runner.called, true);
+          assert.equal(runner.firstCall.args[0].listen, port);
         });
     });
 
     it('passes binary args to Firefox', () => {
       const fxRunner = createFakeFxRunner();
       const binaryArgs = '--safe-mode';
-      return firefox.run(fakeProfile, {fxRunner, binaryArgs})
+      return runFirefox({fxRunner, binaryArgs})
         .then(() => {
           assert.equal(fxRunner.called, true);
           assert.equal(fxRunner.firstCall.args[0]['binary-args'],
@@ -70,7 +91,7 @@ describe('firefox', () => {
       let runner = createFakeFxRunner();
       // Make sure it passes through process environment variables.
       process.env._WEB_EXT_FIREFOX_ENV_TEST = 'thing';
-      return firefox.run(fakeProfile, {fxRunner: runner})
+      return runFirefox({fxRunner: runner})
         .then(() => {
           let declaredEnv = runner.firstCall.args[0].env;
           for (let key in defaultFirefoxEnv) {
@@ -91,7 +112,7 @@ describe('firefox', () => {
         },
       });
 
-      return firefox.run(fakeProfile, {fxRunner: runner})
+      return runFirefox({fxRunner: runner})
         .then(makeSureItFails())
         .catch((error) => {
           assert.equal(error.message, someError.message);
@@ -101,7 +122,7 @@ describe('firefox', () => {
     it('passes a custom Firefox binary when specified', () => {
       let runner = createFakeFxRunner();
       let firefoxBinary = '/pretend/path/to/firefox-bin';
-      return firefox.run(fakeProfile, {fxRunner: runner, firefoxBinary})
+      return runFirefox({fxRunner: runner, firefoxBinary})
         .then(() => {
           assert.equal(runner.called, true);
           assert.equal(runner.firstCall.args[0].binary,
@@ -125,7 +146,7 @@ describe('firefox', () => {
         },
       });
 
-      return firefox.run(fakeProfile, {fxRunner: runner})
+      return runFirefox({fxRunner: runner})
         .then(() => {
           // This makes sure that when each handler writes to the
           // logger they don't raise any exceptions.
@@ -384,6 +405,46 @@ describe('firefox', () => {
           }));
       }
     ));
+
+  });
+
+  describe('defaultRemotePortFinder', () => {
+
+    function findRemotePort({...args}: Object = {}) {
+      return firefox.defaultRemotePortFinder({...args});
+    }
+
+    it('resolves to an open port', () => {
+      const connectToFirefox = sinon.spy(
+        () => Promise.reject(new TCPConnectError()));
+      return findRemotePort({connectToFirefox})
+        .then((port) => {
+          assert.isNumber(port);
+        });
+    });
+
+    it('throws an error when the port is occupied', () => {
+      // TODO: add a retry for occupied ports.
+      // https://github.com/mozilla/web-ext/issues/283
+      const client = fake(RemoteFirefox.prototype);
+      const connectToFirefox = sinon.spy(() => Promise.resolve(client));
+      return findRemotePort({connectToFirefox})
+        .then(makeSureItFails())
+        .catch(onlyInstancesOf(WebExtError, (error) => {
+          assert.match(error.message, /Cannot listen on port/);
+          assert.equal(client.disconnect.called, true);
+        }));
+    });
+
+    it('re-throws unexpected connection errors', () => {
+      const connectToFirefox = sinon.spy(
+        () => Promise.reject(new Error('not a connection error')));
+      return findRemotePort({connectToFirefox})
+        .then(makeSureItFails())
+        .catch((error) => {
+          assert.match(error.message, /not a connection error/);
+        });
+    });
 
   });
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/web-ext/issues/93

There has been a long platform battle to stabilize the reload add-on function. To keep it simple, https://bugzilla.mozilla.org/show_bug.cgi?id=1269889 introduced a new requirement that the add-on must be installed temporarily before it can be reloaded. This patch uses the remote actor to install the add-on temporarily. 

It's a bit brutal in that it fails hard if the Firefox is too old to allow temporary installation like this (it landed in 49). I think this approach is probably ok for now -- it's a lot easier to test and maintain!