### PR TITLE
fix: Re-enabled support for running extensions in Firefox 48

### DIFF
--- a/src/cmd/build.js
+++ b/src/cmd/build.js
@@ -50,7 +50,7 @@ function defaultPackageCreator(
 
 
 export default function build(
-    {sourceDir, artifactsDir, asNeeded}: Object,
+    {sourceDir, artifactsDir, asNeeded=false}: Object,
     {manifestData, fileFilter=new FileFilter(),
      onSourceChange=defaultSourceWatcher,
      packageCreator=defaultPackageCreator}

--- a/src/errors.js
+++ b/src/errors.js
@@ -23,6 +23,16 @@ export class InvalidManifest extends WebExtError {
 
 
 /*
+ * The remote Firefox does not support temporary add-on installation.
+ */
+export class RemoteTempInstallNotSupported extends WebExtError {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+
+/*
  * Sugar-y way to catch only instances of a certain error.
  *
  * Usage:

--- a/src/firefox/remote.js
+++ b/src/firefox/remote.js
@@ -1,6 +1,6 @@
 /* @flow */
 import {createLogger} from '../util/logger';
-import {WebExtError} from '../errors';
+import {RemoteTempInstallNotSupported, WebExtError} from '../errors';
 import defaultFirefoxConnector from 'node-firefox-connect';
 
 const log = createLogger(__filename);
@@ -73,9 +73,10 @@ export class RemoteFirefox {
         if (!response.addonsActor) {
           log.debug(
             `listTabs returned a falsey addonsActor: ${response.addonsActor}`);
-          throw new WebExtError(
+          return reject(new RemoteTempInstallNotSupported(
             'This is an older version of Firefox that does not provide an ' +
-            'add-ons actor for remote installation. Try Firefox 49 or higher.');
+            'add-ons actor for remote installation. Try Firefox 49 or ' +
+            'higher.'));
         }
         this.client.client.makeRequest(
           {to: response.addonsActor, type: 'installTemporaryAddon', addonPath},
@@ -129,7 +130,8 @@ export class RemoteFirefox {
             log.debug(
               `Remote Firefox only supports: ${response.requestTypes}`);
             throw new WebExtError(
-              'This Firefox version does not support addon.reload() yet');
+              'This Firefox version does not support add-on reloading. ' +
+              'Re-run with --no-reload');
           } else {
             this.checkedForAddonReloading = true;
             return addon;

--- a/src/program.js
+++ b/src/program.js
@@ -196,7 +196,15 @@ Example: $0 --help run.
         type: 'string',
       },
       'no-reload': {
-        describe: 'Do not reload the extension as the source changes',
+        describe: 'Do not reload the extension when source files change',
+        demand: false,
+        type: 'boolean',
+      },
+      'pre-install': {
+        describe: 'Pre-install the extension into the profile before ' +
+                  'startup. This is only needed to support older versions ' +
+                  'of Firefox.',
+        demand: false,
         type: 'boolean',
       },
     });

--- a/tests/test-firefox/test.firefox.js
+++ b/tests/test-firefox/test.firefox.js
@@ -387,6 +387,47 @@ describe('firefox', () => {
       }
     ));
 
+    it('can install the extension as a proxy', () => setUp(
+      (data) => {
+        const sourceDir = fixturePath('minimal-web-ext');
+        return firefox.installExtension(
+          {
+            manifestData: basicManifest,
+            profile: data.profile,
+            extensionPath: sourceDir,
+            asProxy: true,
+          })
+          .then(() => {
+            const proxyFile = path.join(data.profile.extensionsDir,
+                                        'basic-manifest@web-ext-test-suite');
+            return fs.readFile(proxyFile);
+          })
+          .then((proxyData) => {
+            // The proxy file should contain the path to the extension.
+            assert.equal(proxyData.toString(), sourceDir);
+          });
+      }
+    ));
+
+    it('requires a directory path for proxy installs', () => setUp(
+      (data) => {
+        const xpiPath = fixturePath('minimal_extension-1.0.xpi');
+        return firefox.installExtension(
+          {
+            manifestData: basicManifest,
+            profile: data.profile,
+            extensionPath: xpiPath,
+            asProxy: true,
+          })
+          .then(makeSureItFails())
+          .catch(onlyInstancesOf(WebExtError, (error) => {
+            assert.match(error.message,
+                         /must be the extension source directory/);
+            assert.include(error.message, xpiPath);
+          }));
+      }
+    ));
+
     it('re-uses an existing extension directory', () => setUp(
       (data) => {
         return fs.mkdir(path.join(data.profile.extensionsDir))

--- a/tests/test-firefox/test.remote.js
+++ b/tests/test-firefox/test.remote.js
@@ -3,7 +3,8 @@ import {describe, it} from 'mocha';
 import {assert} from 'chai';
 import sinon from 'sinon';
 
-import {WebExtError, onlyInstancesOf} from '../../src/errors';
+import {RemoteTempInstallNotSupported, WebExtError, onlyInstancesOf}
+  from '../../src/errors';
 import {fakeFirefoxClient, makeSureItFails} from '../helpers';
 import {default as defaultConnector, RemoteFirefox}
   from '../../src/firefox/remote';
@@ -194,7 +195,7 @@ describe('firefox.remote', () => {
         return conn.checkForAddonReloading(addon)
           .then(makeSureItFails())
           .catch(onlyInstancesOf(WebExtError, (error) => {
-            assert.match(error.message, /does not support addon\.reload/);
+            assert.match(error.message, /does not support add-on reloading/);
           }));
       });
 
@@ -236,7 +237,7 @@ describe('firefox.remote', () => {
         const conn = makeInstance(client);
         return conn.installTemporaryAddon('/path/to/addon')
           .then(makeSureItFails())
-          .catch(onlyInstancesOf(WebExtError, (error) => {
+          .catch(onlyInstancesOf(RemoteTempInstallNotSupported, (error) => {
             assert.match(error.message, /does not provide an add-ons actor/);
           }));
       });


### PR DESCRIPTION
Fixes https://github.com/mozilla/web-ext/issues/286

With this patch, here is an example of running in Firefox 48:

````
$ web-ext run
Running web extension from /Users/kumar/dev/bookmarker-ext/moz-webext
Running Firefox with profile at /var/folders/h7/rttdqkks7fl_txp9_rr4j4840000gn/T/67d00895-ed01-41fe-9a04-05b775c1d97c
Use --verbose or open Tools > Web Developer > Browser Console to see logging
Connected to the Firefox remote debugger

run: WebExtError: Temporary add-on installation is not supported in this version of Firefox (you need Firefox 49 or higher). For older Firefox versions, use --pre-install
    at /Users/kumar/dev/web-ext/dist/webpack:/src/cmd/run.js:160:13
    at /Users/kumar/dev/web-ext/dist/webpack:/src/errors.js:52:14
    at process._tickCallback (node.js:368:9)
````

At which point, you are prompted to run it like:

````
web-ext run --pre-install
````

This works :) It implies `--no-reload` since only temporarily installed add-ons can be reloaded.

I haven't added any optimizations (such as ignoring the remote debugger) but I think this patch is good enough to quickly support Firefox 48 without auto-reloading.

We should also start hiding the stacktrace for these usage exceptions (see https://github.com/mozilla/web-ext/issues/310).