### PR TITLE
Show usage on missing or wrong command.

### DIFF
--- a/src/program.js
+++ b/src/program.js
@@ -120,7 +120,9 @@ Example: $0 --help run.
     .help('help')
     .alias('h', 'help')
     .env(envPrefix)
-    .version(() => version(absolutePackageDir));
+    .version(() => version(absolutePackageDir))
+    .demand(1)
+    .strict();
 
   program.setGlobalOptions({
     'source-dir': {


### PR DESCRIPTION
It's pretty annoying that you only get a stack trace when simply running `web-ext` without any arguments for the first time, so I added help messages.