### PR TITLE
fix: Missing command/option errors are reported better

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -30,6 +30,7 @@
     "dot-notation": [2, {"allowKeywords": true}],
     "eqeqeq": [2, "allow-null"],
     "guard-for-in": 0,
+    "indent": [2, 2],
     "keyword-spacing": 2,
     "max-len": [2, 80, 2, {ignoreComments: true}],
     "new-cap": [2, {"capIsNewExceptions": ["Deferred"]}],

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -55,23 +55,23 @@ module.exports = function(grunt) {
   });
 
   grunt.registerTask(
-      'check-for-smoke',
-      'checks to see if web-ext is completely broken', function() {
-    grunt.log.writeln('making sure web-ext is not catastrophically broken');
+    'check-for-smoke',
+    'checks to see if web-ext is completely broken', function() {
+      grunt.log.writeln('making sure web-ext is not catastrophically broken');
 
-    var done = this.async();
-    var webExt = path.join(path.resolve(__dirname), 'bin', 'web-ext');
-    var result = spawn(webExt, ['--help']);
+      var done = this.async();
+      var webExt = path.join(path.resolve(__dirname), 'bin', 'web-ext');
+      var result = spawn(webExt, ['--help']);
 
-    result.stderr.on('data', function(data) {
-      grunt.log.writeln(data);
+      result.stderr.on('data', function(data) {
+        grunt.log.writeln(data);
+      });
+
+      result.on('close', function(code) {
+        grunt.log.writeln('web-ext exited: ' + code);
+        var succeeded = code === 0;
+        done(succeeded);
+      });
     });
-
-    result.on('close', function(code) {
-      grunt.log.writeln('web-ext exited: ' + code);
-      var succeeded = code === 0;
-      done(succeeded);
-    });
-  });
 
 };

--- a/src/firefox/remote.js
+++ b/src/firefox/remote.js
@@ -51,15 +51,15 @@ export class RemoteFirefox {
   addonRequest(addon: Object, request: string): Promise {
     return new Promise((resolve, reject) => {
       this.client.client.makeRequest(
-          {to: addon.actor, type: request}, (response) => {
-        if (response.error) {
-          reject(
-            new WebExtError(`${request} response error: ` +
-                            `${response.error}: ${response.message}`));
-        } else {
-          resolve(response);
-        }
-      });
+        {to: addon.actor, type: request}, (response) => {
+          if (response.error) {
+            reject(
+              new WebExtError(`${request} response error: ` +
+                              `${response.error}: ${response.message}`));
+          } else {
+            resolve(response);
+          }
+        });
     });
   }
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/web-ext/issues/169

I also noticed a test was indented wrong -- we didn't have an eslint indent rule. This adds an indent rule (sorry for the noise).