### PR TITLE
chore: Added a changelog script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,16 @@ To release a new version of `web-ext`, follow these steps:
 * Pull from master to make sure you're up to date.
 * Bump the version in `package.json`.
 * Commit and push the version change.
-* Tag master (example: `git tag 0.0.1`) and run `git push --tags upstream`.
+* Tag master with the new release you're about to create
+  (example: `git tag 1.0.1`) and run `git push --tags upstream`.
+* Create a changelog by running `grunt changelog:1.0.0` where
+  `1.0.0` is the *last published* release tag. This will output a Markdown list
+  of changes that you can paste into the tag notes on github. It may
+  require some editing. For example, the *Uncategorized* section may need
+  rearranging.
+* Go to the github
+  [releases page](https://github.com/mozilla/web-ext/releases),
+  edit the tag you just created, and enter in the changelog notes.
 * When TravisCI builds the tag,
   it will automatically publish the package to
-  [npm](https://www.npmjs.com/package/web-ext):
+  [npm](https://www.npmjs.com/package/web-ext).

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -74,4 +74,108 @@ module.exports = function(grunt) {
       });
     });
 
+  grunt.registerTask(
+    'changelog', 'Create a changelog from commits', function(tag) {
+      // See https://github.com/mozilla/web-ext/blob/master/CONTRIBUTING.md#writing-commit-messages
+      var done = this.async();
+      var results = {};
+
+      if (tag === undefined) {
+        grunt.log.writeln(
+          'Missing first agument: the current git release tag ' +
+          '(before the next release)');
+        return done(false);
+      }
+
+      function processLine(line) {
+        // First, get the commit hash.
+        var metaMatch = /commit:\{([^\}]+)\} (.*)/.exec(line);
+        if (!metaMatch) {
+          throw new Error('Could not find commit hash in ' + line);
+        }
+        var commitHash = metaMatch[1];
+        line = metaMatch[2]; // strip off the commit hash part.
+
+        // Parse the semantic commit message.
+        // e.g. fix(): Fixed some stuff
+        var match = /^([a-zA-Z0-9]+)\(?.*\)?: (.*)$/g.exec(line);
+        var bucket;
+        var message = line;
+        if (!match) {
+          bucket = results.uncategorized = results.uncategorized || [];
+        } else {
+          var type = match[1].toLowerCase();
+          bucket = results[type] = results[type] || [];
+          message = match[2];
+        }
+
+        bucket.push({msg: message, commit: commitHash});
+      }
+
+      function commitLink(commit) {
+        // Create a Markdown link to the commit.
+        return '[' + commit + ']' +
+          '(https://github.com/mozilla/web-ext/commit/' + commit + ')';
+      }
+
+      function bullet(text) {
+        // Create a Markdown bullet point.
+        return '  * ' + text;
+      }
+
+      function writeChangelog() {
+        [
+          ['New features:', 'feat'],
+          ['Fixes:', 'fix'],
+          ['Performance enhancements:', 'perf'],
+          ['Uncategorized:', 'uncategorized'],
+        ].forEach(function(conf) {
+          var header = conf[0];
+          var key = conf[1];
+
+          if ((results[key] || []).length) {
+            grunt.log.writeln(header);
+            results[key].forEach(function(data) {
+              grunt.log.writeln(
+                bullet(data.msg + ' (' + commitLink(data.commit) + ')'));
+            });
+            grunt.log.writeln('');
+          }
+        });
+        grunt.log.writeln('General maintenance:');
+        grunt.log.writeln(bullet(
+          results.chore.length + ' dependency updates (or other chores)'));
+        grunt.log.writeln(bullet(
+          results.docs.length + ' documentation updates'));
+      }
+
+      var git = spawn(
+        'git',
+        ['log', '--no-merges', '--format=commit:{%h} %s', tag + '...master']);
+
+      git.stderr.on('data', function(data) {
+        grunt.log.writeln(data);
+        done(false);
+      });
+
+      git.stdout.on('data', function(data) {
+        data.toString().split('\n').forEach(function(line) {
+          if (line !== '') {
+            processLine(line);
+          }
+        });
+      });
+
+      git.on('close', function(code) {
+        if (code !== 0) {
+          grunt.log.writeln('git exited: ' + code);
+          done(false);
+        } else {
+          writeChangelog();
+          done(true);
+        }
+      });
+
+    });
+
 };


### PR DESCRIPTION
This is a helper script to generate a changelog from actual commits. It won't be perfect and will likely require some editing but it should make releases easier. Example of a changelog I just generated:

New features:
  * Started ignoring node_modules folders by default ([5eff6d5](https://github.com/mozilla/web-ext/commit/5eff6d5))
  * Run now installs as temporary add-on ([79c6bf5](https://github.com/mozilla/web-ext/commit/79c6bf5))
  * output version when run in verbose mode ([e4280dd](https://github.com/mozilla/web-ext/commit/e4280dd))
  * run watches source, reloads addon in Firefox ([61c5087](https://github.com/mozilla/web-ext/commit/61c5087))
  * Added --timeout option for signing ([2c176b2](https://github.com/mozilla/web-ext/commit/2c176b2))
  * Added remote Firefox reloading support ([4559654](https://github.com/mozilla/web-ext/commit/4559654))
  * Added build --as-needed to watch and rebuild ([d458dcc](https://github.com/mozilla/web-ext/commit/d458dcc))

Fixes:
  * Missing command/option errors are reported better ([33a9e01](https://github.com/mozilla/web-ext/commit/33a9e01))
  * Re-enabled support for running extensions in Firefox 48 ([2622d73](https://github.com/mozilla/web-ext/commit/2622d73))
  * Configured yargs without boolean negation, fixed --no-reload ([0bf887f](https://github.com/mozilla/web-ext/commit/0bf887f))
  * Explicitly note Firefox 49 for temp-installs ([1252028](https://github.com/mozilla/web-ext/commit/1252028))
  * Displayed remote actor errors better ([b3250c8](https://github.com/mozilla/web-ext/commit/b3250c8))
  * Fixed using env variables for non-global options ([5b6aa43](https://github.com/mozilla/web-ext/commit/5b6aa43))
  * Fixed error on unknown commands ([1c3ef8d](https://github.com/mozilla/web-ext/commit/1c3ef8d))
  * Fixed `web-ext --help build` ([1fbfd17](https://github.com/mozilla/web-ext/commit/1fbfd17))

Uncategorized:
  * Show usage on missing or wrong command. ([f6a2a26](https://github.com/mozilla/web-ext/commit/f6a2a26))
  * fix typo ([44791e9](https://github.com/mozilla/web-ext/commit/44791e9))

General maintenance:
  * 76 dependency updates (or other chores)
  * 10 documentation updates
