### PR TITLE
handle extensions without IDs in build/run

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -61,7 +61,7 @@
     "no-redeclare": 0,
     "no-script-url": 2,
     "no-sequences": 2,
-    "no-trailing-spaces": [2, {"skipBlankLines": true}],
+    "no-trailing-spaces": [2, {"skipBlankLines": false}],
     "no-undef": 2,
     "no-underscore-dangle": 0,
     "no-unused-vars": 2,

--- a/src/cmd/build.js
+++ b/src/cmd/build.js
@@ -6,7 +6,7 @@ import streamToPromise from 'stream-to-promise';
 
 import defaultSourceWatcher from '../watcher';
 import {zipDir} from '../util/zip-dir';
-import getValidatedManifest from '../util/manifest';
+import getValidatedManifest, {getManifestId} from '../util/manifest';
 import {prepareArtifactsDir} from '../util/artifacts';
 import {createLogger} from '../util/logger';
 
@@ -19,7 +19,8 @@ function defaultPackageCreator(
   return new Promise(
     (resolve) => {
       if (manifestData) {
-        log.debug(`Using manifest id=${manifestData.applications.gecko.id}`);
+        const id = getManifestId(manifestData);
+        log.debug(`Using manifest id=${id || '[not specified]'}`);
         resolve(manifestData);
       } else {
         resolve(getValidatedManifest(sourceDir));

--- a/src/cmd/sign.js
+++ b/src/cmd/sign.js
@@ -2,6 +2,7 @@
 import {signAddon as defaultAddonSigner} from '../util/es6-modules';
 
 import defaultBuilder from './build';
+import {InvalidManifest} from '../errors';
 import {withTempDir} from '../util/temp-dir';
 import getValidatedManifest from '../util/manifest';
 import {prepareArtifactsDir} from '../util/artifacts';
@@ -25,6 +26,15 @@ export default function sign(
           } else {
             return getValidatedManifest(sourceDir);
           }
+        })
+        .then((manifestData) => {
+          if (!manifestData.applications) {
+            // TODO: remove this when signing supports manifests
+            // without IDs: https://github.com/mozilla/web-ext/issues/178
+            throw new InvalidManifest(
+              'applications.gecko.id in manifest.json is required for signing');
+          }
+          return manifestData;
         })
         .then((manifestData) => {
           return build(

--- a/src/firefox/remote.js
+++ b/src/firefox/remote.js
@@ -63,7 +63,7 @@ export class RemoteFirefox {
     });
   }
 
-  installTemporaryAddon(addonPath: string) {
+  installTemporaryAddon(addonPath: string): Promise {
     return new Promise((resolve, reject) => {
       this.client.request('listTabs', (error, response) => {
         if (error) {
@@ -88,7 +88,7 @@ export class RemoteFirefox {
             }
             log.debug(`installTemporaryAddon: ${JSON.stringify(response)}`);
             log.info(`Installed ${addonPath} as a temporary add-on`);
-            resolve();
+            resolve(response);
           });
       });
     });

--- a/src/util/manifest.js
+++ b/src/util/manifest.js
@@ -33,18 +33,11 @@ export default function getValidatedManifest(sourceDir: string): Promise {
         errors.push('missing "version" property');
       }
 
-      // Make sure the manifest defines a gecko id.
-      let idProps = ['applications', 'gecko', 'id'];
-      var propPath = '';
-      var objectToCheck = manifestData;
-
-      for (let nextProp of idProps) {
-        propPath = propPath ? `${propPath}.${nextProp}` : nextProp;
-        objectToCheck = objectToCheck[nextProp];
-        if (!objectToCheck) {
-          errors.push(`missing "${propPath}" property`);
-          break;
-        }
+      if (manifestData.applications && !manifestData.applications.gecko) {
+        // Since the applications property only applies to gecko, make
+        // sure 'gecko' exists when 'applications' is defined. This should
+        // make introspection of gecko properties easier.
+        errors.push('missing "applications.gecko" property');
       }
 
       if (errors.length) {
@@ -53,4 +46,10 @@ export default function getValidatedManifest(sourceDir: string): Promise {
       }
       return manifestData;
     });
+}
+
+
+export function getManifestId(manifestData: Object): string|void {
+  return manifestData.applications ?
+    manifestData.applications.gecko.id : undefined;
 }

--- a/tests/test-cmd/test.build.js
+++ b/tests/test-cmd/test.build.js
@@ -8,7 +8,7 @@ import sinon from 'sinon';
 import build, {safeFileName, FileFilter} from '../../src/cmd/build';
 import {withTempDir} from '../../src/util/temp-dir';
 import {fixturePath, makeSureItFails, ZipFile} from '../helpers';
-import {basicManifest} from '../test-util/test.manifest';
+import {basicManifest, manifestWithoutApps} from '../test-util/test.manifest';
 
 
 describe('build', () => {
@@ -34,6 +34,19 @@ describe('build', () => {
           assert.deepEqual(fileNames,
                            ['background-script.js', 'manifest.json']);
         })
+    );
+  });
+
+  it('can build an extension without an ID', () => {
+    return withTempDir(
+      (tmpDir) => {
+        // Make sure a manifest without an ID doesn't throw an error.
+        return build({
+          sourceDir: fixturePath('minimal-web-ext'),
+          manifestData: manifestWithoutApps,
+          artifactsDir: tmpDir.path(),
+        });
+      }
     );
   });
 
@@ -209,7 +222,7 @@ describe('build', () => {
       assert.equal(filter.wantFile('some.xpi'), true);
       assert.equal(filter.wantFile('manifest.json'), false);
     });
-    
+
     it('ignores node_modules by default', () => {
       assert.equal(defaultFilter.wantFile('path/to/node_modules'), false);
     });

--- a/tests/test-firefox/test.firefox.js
+++ b/tests/test-firefox/test.firefox.js
@@ -11,7 +11,7 @@ import {onlyInstancesOf, WebExtError} from '../../src/errors';
 import fs from 'mz/fs';
 import {withTempDir} from '../../src/util/temp-dir';
 import {TCPConnectError, fixturePath, fake, makeSureItFails} from '../helpers';
-import {basicManifest} from '../test-util/test.manifest';
+import {basicManifest, manifestWithoutApps} from '../test-util/test.manifest';
 import {defaultFirefoxEnv} from '../../src/firefox/';
 import {RemoteFirefox} from '../../src/firefox/remote';
 
@@ -384,6 +384,22 @@ describe('firefox', () => {
             assert.deepEqual(
               files, ['basic-manifest@web-ext-test-suite.xpi']);
           });
+      }
+    ));
+
+    it('requires a manifest ID', () => setUp(
+      (data) => {
+        return firefox.installExtension(
+          {
+            manifestData: manifestWithoutApps,
+            profile: data.profile,
+            extensionPath: data.extensionPath,
+          })
+          .then(makeSureItFails())
+          .catch(onlyInstancesOf(WebExtError, (error) => {
+            assert.match(error.message,
+                         /explicit extension ID is required/);
+          }));
       }
     ));
 

--- a/tests/test-firefox/test.remote.js
+++ b/tests/test-firefox/test.remote.js
@@ -249,11 +249,15 @@ describe('firefox.remote', () => {
             addonsActor: 'addons1.actor.conn',
           },
           // installTemporaryAddon response:
-          makeRequestResult: {},
+          makeRequestResult: {
+            addon: {id: 'abc123@temporary-addon'},
+          },
         });
         const conn = makeInstance(client);
-        // Make sure this resolves Okay.
-        return conn.installTemporaryAddon('/path/to/addon');
+        return conn.installTemporaryAddon('/path/to/addon')
+          .then((response) => {
+            assert.equal(response.addon.id, 'abc123@temporary-addon');
+          });
       });
 
       it('throws install errors', () => {


### PR DESCRIPTION
Fixes https://github.com/mozilla/web-ext/issues/132, fixes https://github.com/mozilla/web-ext/issues/177

Changes:
* `build`, `run`, and auto-reloading work for manifests without an ID
* `run --pre-install` will error if the manifest doesn't have an ID
* `sign` will error if the manifest doesn't have an ID but this is just temporary until https://github.com/mozilla/web-ext/issues/178 is fixed