### PR TITLE
fix: Relative `--source-dir` paths are handled correctly now

### DIFF
--- a/src/program.js
+++ b/src/program.js
@@ -78,6 +78,13 @@ export class Program {
       (resolve) => {
         this.yargs.exitProcess(this.shouldExitProgram);
         argv = this.yargs.argv;
+
+        // Fix up sourceDir. This can hopefully move to option configuration
+        // soon. See https://github.com/yargs/yargs/issues/535
+        if (argv.sourceDir) {
+          argv.sourceDir = path.resolve(argv.sourceDir);
+        }
+
         cmd = argv._[0];
         if (cmd === undefined) {
           throw new WebExtError('No sub-command was specified in the args');
@@ -147,6 +154,7 @@ Example: $0 --help run.
       alias: 's',
       describe: 'Web extension source directory.',
       default: process.cwd(),
+      normalize: true,
       requiresArg: true,
       type: 'string',
     },
@@ -154,6 +162,7 @@ Example: $0 --help run.
       alias: 'a',
       describe: 'Directory where artifacts will be saved.',
       default: path.join(process.cwd(), 'web-ext-artifacts'),
+      normalize: true,
       requiresArg: true,
       type: 'string',
     },

--- a/tests/test.program.js
+++ b/tests/test.program.js
@@ -269,6 +269,34 @@ describe('program.main', () => {
       });
   });
 
+  it('turns sourceDir into an absolute path', () => {
+    const fakeCommands = fake(commands, {
+      build: () => Promise.resolve(),
+    });
+    return run(
+      ['build', '--source-dir', '..'], {commands: fakeCommands})
+      .then(() => {
+        assert.equal(fakeCommands.build.called, true);
+        assert.equal(fakeCommands.build.firstCall.args[0].sourceDir,
+                     path.resolve(path.join(process.cwd(), '..')));
+      });
+  });
+
+  it('normalizes the artifactsDir path', () => {
+    const fakeCommands = fake(commands, {
+      build: () => Promise.resolve(),
+    });
+    return run(
+      // Add a double slash to the path, which will be fixed by normalization.
+      ['build', '--artifacts-dir', process.cwd() + path.sep + path.sep],
+      {commands: fakeCommands})
+      .then(() => {
+        assert.equal(fakeCommands.build.called, true);
+        assert.equal(fakeCommands.build.firstCall.args[0].artifactsDir,
+                     process.cwd() + path.sep);
+      });
+  });
+
 });
 
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/web-ext/issues/332