### PR TITLE
feat: `web-ext sign` now supports extensions without explicit IDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "babel-preset-es2015": "6.9.0",
     "babel-preset-stage-2": "6.11.0",
     "chai": "3.5.0",
+    "copy-dir": "0.3.0",
     "coveralls": "2.11.9",
     "deepcopy": "0.6.3",
     "eslint": "2.13.1",

--- a/src/cmd/sign.js
+++ b/src/cmd/sign.js
@@ -1,19 +1,21 @@
 /* @flow */
+import path from 'path';
+import fs from 'mz/fs';
 import {signAddon as defaultAddonSigner} from '../util/es6-modules';
 
 import defaultBuilder from './build';
-import {InvalidManifest} from '../errors';
 import {withTempDir} from '../util/temp-dir';
-import getValidatedManifest from '../util/manifest';
+import {onlyErrorsWithCode, WebExtError} from '../errors';
+import getValidatedManifest, {getManifestId} from '../util/manifest';
 import {prepareArtifactsDir} from '../util/artifacts';
 import {createLogger} from '../util/logger';
 
 const log = createLogger(__filename);
-
+export const extensionIdFile = '.web-extension-id';
 
 export default function sign(
     {verbose, sourceDir, artifactsDir, apiKey, apiSecret,
-     apiUrlPrefix, timeout}: Object,
+     apiUrlPrefix, id, timeout}: Object,
     {build=defaultBuilder, signAddon=defaultAddonSigner,
      preValidatedManifest=null}: Object = {}): Promise {
 
@@ -28,39 +30,102 @@ export default function sign(
           }
         })
         .then((manifestData) => {
-          if (!manifestData.applications) {
-            // TODO: remove this when signing supports manifests
-            // without IDs: https://github.com/mozilla/web-ext/issues/178
-            throw new InvalidManifest(
-              'applications.gecko.id in manifest.json is required for signing');
+          return Promise.all([
+            build({sourceDir, artifactsDir: tmpDir.path()}, {manifestData}),
+            getIdFromSourceDir(sourceDir),
+          ])
+          .then(([buildResult, idFromSourceDir]) => {
+            return {buildResult, manifestData, idFromSourceDir};
+          });
+        })
+        .then(({buildResult, manifestData, idFromSourceDir}) => {
+          const manifestId = getManifestId(manifestData);
+          if (id && manifestId) {
+            throw new WebExtError(
+              `Cannot set custom ID ${id} because manifest.json ` +
+              `declares ID ${manifestId}`);
           }
-          return manifestData;
+          if (manifestId) {
+            id = manifestId;
+          }
+          if (!id && idFromSourceDir) {
+            log.info(
+              'Using previously auto-generated extension ID: ' +
+              `${idFromSourceDir}`);
+            id = idFromSourceDir;
+          }
+          if (!id) {
+            log.warn('No extension ID specified (it will be auto-generated)');
+          }
+          return signAddon({
+            apiKey,
+            apiSecret,
+            apiUrlPrefix,
+            timeout,
+            verbose,
+            id,
+            xpiPath: buildResult.extensionPath,
+            version: manifestData.version,
+            downloadDir: artifactsDir,
+          });
         })
-        .then((manifestData) => {
-          return build(
-            {sourceDir, artifactsDir: tmpDir.path()},
-            {manifestData})
-            .then((buildResult) => {
-              return {buildResult, manifestData};
-            });
+        .then((signingResult) => {
+          if (signingResult.id) {
+            return saveIdToSourceDir(sourceDir, signingResult.id)
+              .then(() => signingResult);
+          } else {
+            return signingResult;
+          }
         })
-        .then(({buildResult, manifestData}) => signAddon({
-          apiKey,
-          apiSecret,
-          apiUrlPrefix,
-          timeout,
-          verbose,
-          xpiPath: buildResult.extensionPath,
-          id: manifestData.applications.gecko.id,
-          version: manifestData.version,
-          downloadDir: artifactsDir,
-        }))
         .then((signingResult) => {
           // All information about the downloaded files would have
           // already been logged by signAddon().
-          log.info(signingResult.success ? 'SUCCESS' : 'FAIL');
+          if (signingResult.success) {
+            log.info(`Extension ID: ${signingResult.id}`);
+            log.info('SUCCESS');
+          } else {
+            log.info('FAIL');
+          }
           return signingResult;
         });
     }
   );
+}
+
+
+export function getIdFromSourceDir(sourceDir: string): Promise {
+  const filePath = path.join(sourceDir, extensionIdFile);
+  return fs.readFile(filePath)
+    .then((content) => {
+      let lines = content.toString().split('\n');
+      lines = lines.filter((line) => {
+        line = line.trim();
+        if (line && !line.startsWith('#')) {
+          return line;
+        }
+      });
+      let id = lines[0];
+      log.debug(`Found extension ID ${id} in ${filePath}`);
+      if (!id) {
+        throw new WebExtError(`No ID found in extension ID file ${filePath}`);
+      }
+      return id;
+    })
+    .catch(onlyErrorsWithCode('ENOENT', () => {
+      log.debug(`No ID file found at: ${filePath}`);
+    }));
+}
+
+
+export function saveIdToSourceDir(sourceDir: string, id: string): Promise {
+  const filePath = path.join(sourceDir, extensionIdFile);
+  return fs.writeFile(filePath,
+    [
+      '# This file was created by https://github.com/mozilla/web-ext',
+      '# Your auto-generated extension ID for addons.mozilla.org is:',
+      id.toString(),
+    ].join('\n'))
+    .then(() => {
+      log.debug(`Saved auto-generated ID ${id} to ${filePath}`);
+    });
 }

--- a/src/program.js
+++ b/src/program.js
@@ -203,6 +203,13 @@ Example: $0 --help run.
           demand: true,
           type: 'string',
         },
+        'id': {
+          describe:
+            'A custom ID for the extension. This will override ' +
+            'any ID declared by manifest.json.',
+          demand: false,
+          type: 'string',
+        },
         'timeout' : {
           describe: 'Number of milliseconds to wait before giving up',
           type: 'number',

--- a/tests/test-cmd/test.sign.js
+++ b/tests/test-cmd/test.sign.js
@@ -1,13 +1,19 @@
 /* @flow */
 import path from 'path';
+import copyDir from 'copy-dir';
+import fs from 'mz/fs';
 import {describe, it} from 'mocha';
 import {assert} from 'chai';
 import sinon from 'sinon';
 
+import {promisify} from '../../src/util/es6-modules';
+import {onlyInstancesOf, WebExtError} from '../../src/errors';
+import {getManifestId} from '../../src/util/manifest';
 import {withTempDir} from '../../src/util/temp-dir';
 import {basicManifest, manifestWithoutApps} from '../test-util/test.manifest';
-import completeSignCommand from '../../src/cmd/sign';
-import {onlyInstancesOf, InvalidManifest} from '../../src/errors';
+import completeSignCommand, {
+  extensionIdFile, getIdFromSourceDir, saveIdToSourceDir,
+} from '../../src/cmd/sign';
 import {makeSureItFails, fixturePath} from '../helpers';
 
 
@@ -27,6 +33,7 @@ describe('sign', () => {
     const build = sinon.spy(() => Promise.resolve(buildResult));
 
     const signingResult = {
+      id: 'some-addon-id',
       success: true,
       downloadedFiles: [],
     };
@@ -46,12 +53,12 @@ describe('sign', () => {
    * Run the sign command with stubs for all dependencies.
    */
   function sign(
-      artifactsDir, stubs,
-      {extraArgs={}, extraOptions={}}: Object = {}) {
+      tmpDir: Object, stubs: Object,
+      {extraArgs={}, extraOptions={}}: Object = {}): Promise {
     return completeSignCommand({
-      sourceDir: '/fake/path/to/local/extension',
       verbose: false,
-      artifactsDir,
+      artifactsDir: path.join(tmpDir.path(), 'artifacts-dir'),
+      sourceDir: tmpDir.path(),
       ...stubs.signingConfig,
       ...extraArgs,
     }, {
@@ -64,16 +71,17 @@ describe('sign', () => {
     // This test only stubs out the signer in an effort to integrate
     // all other parts of the process.
     (tmpDir) => {
-      let stubs = getStubs();
-      const artifactsDir = path.join(tmpDir.path(), 'artifacts');
-      return completeSignCommand(
-        {
-          sourceDir: fixturePath('minimal-web-ext'),
-          artifactsDir,
+      const stubs = getStubs();
+      const sourceDir = path.join(tmpDir.path(), 'source-dir');
+      const copyDirAsPomised = promisify(copyDir);
+      return copyDirAsPomised(fixturePath('minimal-web-ext'), sourceDir)
+        .then(() => completeSignCommand({
+          sourceDir,
+          artifactsDir: path.join(tmpDir.path(), 'artifacts'),
           ...stubs.signingConfig,
         }, {
           signAddon: stubs.signAddon,
-        })
+        }))
         .then((result) => {
           assert.equal(result.success, true);
           // Do a sanity check that a built extension was passed to the
@@ -84,38 +92,172 @@ describe('sign', () => {
     }
   ));
 
-  it('requires an application ID when signing', () => withTempDir(
+  it('allows an empty application ID when signing', () => withTempDir(
     (tmpDir) => {
       const stubs = getStubs();
-      return sign(
-        path.join(tmpDir.path(), 'artifacts-dir'), stubs, {
+      return sign(tmpDir, stubs,
+        {
           extraOptions: {
             preValidatedManifest: manifestWithoutApps,
           },
         })
+        .then(() => {
+          assert.equal(stubs.signAddon.called, true);
+          assert.strictEqual(
+            stubs.signAddon.firstCall.args[0].id,
+            getManifestId(manifestWithoutApps));
+        });
+    }
+  ));
+
+  it('allows a custom ID when no ID in manifest.json', () => withTempDir(
+    (tmpDir) => {
+      const customId = 'some-custom-id';
+      const stubs = getStubs();
+      return sign(tmpDir, stubs,
+        {
+          extraArgs: {
+            id: customId,
+          },
+          extraOptions: {
+            preValidatedManifest: manifestWithoutApps,
+          },
+        })
+        .then(() => {
+          assert.equal(stubs.signAddon.called, true);
+          assert.equal(stubs.signAddon.firstCall.args[0].id,
+                       customId);
+        });
+    }
+  ));
+
+  it('prefers a custom ID over an ID file', () => withTempDir(
+    (tmpDir) => {
+      const sourceDir = path.join(tmpDir.path(), 'source-dir');
+      const customId = 'some-custom-id';
+      const stubs = getStubs();
+      // First, save an extension ID like a previous signing call.
+      return fs.mkdir(sourceDir)
+        .then(() => saveIdToSourceDir(sourceDir, 'some-other-id'))
+        // Now, make a signing call with a custom ID.
+        .then(() => sign(tmpDir, stubs, {
+          extraArgs: {
+            sourceDir,
+            id: customId,
+          },
+          extraOptions: {
+            preValidatedManifest: manifestWithoutApps,
+          },
+        }))
+        .then(() => {
+          assert.equal(stubs.signAddon.called, true);
+          assert.equal(stubs.signAddon.firstCall.args[0].id,
+                       customId);
+        });
+    }
+  ));
+
+  it('disallows a custom ID when manifest.json has ID', () => withTempDir(
+    (tmpDir) => {
+      const customId = 'some-custom-id';
+      const stubs = getStubs();
+      return sign(tmpDir, stubs,
+        {
+          extraArgs: {
+            id: customId,
+          },
+          extraOptions: {
+            // This manifest has an ID in it.
+            preValidatedManifest: basicManifest,
+          },
+        })
         .then(makeSureItFails())
-        .catch(onlyInstancesOf(InvalidManifest, (error) => {
-          assert.equal(
+        .catch(onlyInstancesOf(WebExtError, (error) => {
+          assert.match(error.message, /Cannot set custom ID some-custom-id/);
+          assert.match(
             error.message,
-            'applications.gecko.id in manifest.json is required for signing');
+            /manifest\.json declares ID basic-manifest@web-ext-test-suite/);
         }));
+    }
+  ));
+
+  it('remembers auto-generated IDs for successive signing', () => withTempDir(
+    (tmpDir) => {
+
+      function _sign() {
+        const signAddon = sinon.spy(() => Promise.resolve({
+          ...stubs.signingResult,
+          id: 'auto-generated-id',
+        }));
+
+        return sign(tmpDir,
+          {
+            ...stubs,
+            signAddon,
+          }, {
+            extraOptions: {
+              preValidatedManifest: manifestWithoutApps,
+            },
+          })
+          .then((signingResult) => {
+            return {signingResult, signAddon};
+          });
+      }
+
+      const stubs = getStubs();
+
+      // Run an initial sign command which will yield a server generated ID.
+      return _sign()
+        .then(({signAddon, signingResult}) => {
+          assert.equal(signAddon.called, true);
+          assert.strictEqual(signAddon.firstCall.args[0].id,
+                             undefined);
+          assert.equal(signingResult.id, 'auto-generated-id');
+
+          // Re-run the sign command again.
+          return _sign();
+        })
+        .then(({signAddon}) => {
+          assert.equal(signAddon.called, true);
+          // This should call signAddon() with the server generated
+          // ID that was saved to the source directory from the previous
+          // signing result.
+          assert.equal(signAddon.firstCall.args[0].id,
+                       'auto-generated-id');
+        });
     }
   ));
 
   it('returns a signing result', () => withTempDir(
     (tmpDir) => {
       let stubs = getStubs();
-      return sign(tmpDir.path(), stubs)
+      return sign(tmpDir, stubs)
         .then((realResult) => {
           assert.deepEqual(realResult, stubs.signingResult);
         });
     }
   ));
 
+  it('might fail', () => withTempDir(
+    (tmpDir) => {
+      return sign(
+        tmpDir, {
+          ...getStubs(),
+          signAddon: () => Promise.resolve({
+            success: false,
+          }),
+        })
+        .then((result) => {
+          assert.equal(result.success, false);
+        });
+    }
+  ));
+
   it('calls the add-on signer', () => withTempDir(
     (tmpDir) => {
-      let stubs = getStubs();
-      return sign(tmpDir.path(), stubs)
+      const stubs = getStubs();
+      const artifactsDir = path.join(tmpDir.path(), 'some-artifacts-dir');
+      return sign(tmpDir, stubs, {extraArgs: {artifactsDir}})
         .then(() => {
           assert.equal(stubs.signAddon.called, true);
           let signedAddonCall = stubs.signAddon.firstCall.args[0];
@@ -133,8 +275,7 @@ describe('sign', () => {
                        stubs.preValidatedManifest.applications.gecko.id);
           assert.equal(signedAddonCall.version,
                        stubs.preValidatedManifest.version);
-          assert.equal(signedAddonCall.downloadDir,
-                       tmpDir.path());
+          assert.equal(signedAddonCall.downloadDir, artifactsDir);
         });
     }
   ));
@@ -142,7 +283,7 @@ describe('sign', () => {
   it('passes the verbose flag to the signer', () => withTempDir(
     (tmpDir) => {
       let stubs = getStubs();
-      return sign(tmpDir.path(), stubs, {extraArgs: {verbose: true}})
+      return sign(tmpDir, stubs, {extraArgs: {verbose: true}})
         .then(() => {
           assert.equal(stubs.signAddon.called, true);
           assert.equal(stubs.signAddon.firstCall.args[0].verbose, true);
@@ -155,12 +296,76 @@ describe('sign', () => {
       let stubs = getStubs();
       stubs.signAddon = () => Promise.reject(new Error('some signing error'));
 
-      return sign(tmpDir.path(), stubs)
+      return sign(tmpDir, stubs)
         .then(makeSureItFails())
         .catch((error) => {
           assert.match(error.message, /signing error/);
         });
     }
   ));
+
+  describe('saveIdToSourceDir', () => {
+
+    it('saves an extension ID to file', () => withTempDir(
+      (tmpDir) => {
+        const sourceDir = tmpDir.path();
+        return saveIdToSourceDir(sourceDir, 'some-id')
+          .then(() => fs.readFile(path.join(sourceDir, extensionIdFile)))
+          .then((content) => {
+            assert.include(content.toString(), 'some-id');
+          });
+      }
+    ));
+
+    it('will overwrite an existing file', () => withTempDir(
+      (tmpDir) => {
+        const sourceDir = tmpDir.path();
+        return saveIdToSourceDir(sourceDir, 'first-id')
+          .then(() => saveIdToSourceDir(sourceDir, 'second-id'))
+          .then(() => getIdFromSourceDir(sourceDir))
+          .then((savedId) => {
+            assert.equal(savedId, 'second-id');
+          });
+      }
+    ));
+
+  });
+
+  describe('getIdFromSourceDir', () => {
+
+    it('gets a saved extension ID', () => withTempDir(
+      (tmpDir) => {
+        const sourceDir = tmpDir.path();
+        return saveIdToSourceDir(sourceDir, 'some-id')
+          .then(() => getIdFromSourceDir(sourceDir))
+          .then((extensionId) => {
+            assert.equal(extensionId, 'some-id');
+          });
+      }
+    ));
+
+    it('throws an error for empty files', () => withTempDir(
+      (tmpDir) => {
+        const sourceDir = tmpDir.path();
+        return fs.writeFile(path.join(sourceDir, extensionIdFile), '')
+          .then(() => getIdFromSourceDir(sourceDir))
+          .then(makeSureItFails())
+          .catch(onlyInstancesOf(WebExtError, (error) => {
+            assert.match(error.message, /No ID found in extension ID file/);
+          }));
+      }
+    ));
+
+    it('returns empty ID when extension file does not exist', () => withTempDir(
+      (tmpDir) => {
+        const sourceDir = tmpDir.path();
+        return getIdFromSourceDir(sourceDir)
+          .then((savedId) => {
+            assert.strictEqual(savedId, undefined);
+          });
+      }
+    ));
+
+  });
 
 });


### PR DESCRIPTION
Supports https://github.com/mozilla/web-ext/issues/178

This feature also requires the patch from https://github.com/mozilla/sign-addon/pull/114