### PR TITLE
Use ./node_modules/.bin/grunt directly instead of inline Node scripts in package.json

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,7 @@
   "parser": "babel-eslint",
   "env": {
     "node": true,
-    "es6": true,
+    "es6": true
   },
   "ecmaFeatures": {
     "arrowFunctions": true,
@@ -12,7 +12,7 @@
     "defaultParams": true,
     "modules": true,
     "restParams": true,
-    "spread": true,
+    "spread": true
   },
   "globals": {
     "exports": false,
@@ -32,7 +32,7 @@
     "guard-for-in": 0,
     "indent": [2, 2],
     "keyword-spacing": 2,
-    "max-len": [2, 80, 2, {ignoreComments: true}],
+    "max-len": [2, 80, 2, {"ignoreComments": true}],
     "new-cap": [2, {"capIsNewExceptions": ["Deferred"]}],
     "no-bitwise": 2,
     "no-caller": 2,
@@ -68,8 +68,8 @@
     "no-with": 2,
     "one-var": [2, "never"],
     "prefer-template": 2,
-    "quotes": [2, "single", "avoid-escape"],
     "quote-props": [1, "consistent-as-needed"],
+    "quotes": [2, "single", "avoid-escape"],
     "semi": [2, "always"],
     "space-before-function-paren": [2, "never"],
     "space-infix-ops": 0,

--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
     "web-ext": "bin/web-ext"
   },
   "scripts": {
-    "build": "node -e \"require('grunt').cli()\" null build",
-    "start": "node -e \"require('grunt').cli()\" null develop",
-    "flow-check": "node -e \"require('grunt').cli()\" null flowbin:check",
-    "lint": "node -e \"require('grunt').cli()\" null lint",
-    "test": "node -e \"require('grunt').cli()\" null test",
-    "publish-coverage": "node -e \"require('grunt').cli()\" null coveralls",
+    "build": "grunt build",
+    "start": "grunt develop",
+    "flow-check": "grunt flowbin:check",
+    "lint": "grunt lint",
+    "test": "grunt test",
+    "publish-coverage": "grunt coveralls",
     "changelog": "conventional-changelog -p angular -u",
     "changelog-lint": "conventional-changelog-lint --from master"
   },


### PR DESCRIPTION
Use ./node_modules/.bin/grunt directly instead of inline Node scripts in package.json