### PR TITLE
fix: `web-ext lint`: ignore node_modules and other artifacts

### DIFF
--- a/src/cmd/lint.js
+++ b/src/cmd/lint.js
@@ -1,13 +1,15 @@
 /* @flow */
 import {createLinter as defaultLinterCreator} from '../util/es6-modules';
 import {createLogger} from '../util/logger';
+import {FileFilter} from './build';
 
 const log = createLogger(__filename);
 
 export default function lint(
     {verbose, sourceDir, selfHosted, boring, output,
      metadata, pretty}: Object,
-    {createLinter=defaultLinterCreator}: Object = {}): Promise {
+    {createLinter=defaultLinterCreator, fileFilter=new FileFilter()}
+    : Object = {}): Promise {
   log.debug(`Running addons-linter on ${sourceDir}`);
   const linter = createLinter({
     config: {
@@ -18,6 +20,7 @@ export default function lint(
       output,
       boring,
       selfHosted,
+      shouldScanFile: (fileName) => fileFilter.wantFile(fileName),
       // This mimics the first command line argument from yargs,
       // which should be the directory to the extension.
       _: [sourceDir],


### PR DESCRIPTION
Fixes https://github.com/mozilla/web-ext/issues/397

Tasks:
* [x] merge the linter patch to get a new callback: https://github.com/mozilla/addons-linter/pull/862
* [x] hook up the callback
* [x] make sure the babel-polyfill patch (https://github.com/mozilla/addons-linter/issues/864) is in the linter
* [x] bump package.json after linter release (https://github.com/mozilla/web-ext/pull/414)