### PR TITLE
fix: Hide reader mode UI tour and Normandy CDN errors

### DIFF
--- a/src/firefox/preferences.js
+++ b/src/firefox/preferences.js
@@ -89,4 +89,9 @@ prefs.firefox = {
     'http://localhost/safebrowsing-dummy/newkey',
   'browser.safebrowsing.provider.0.updateURL' :
     'http://localhost/safebrowsing-dummy/update',
+
+  // Disable self repair/SHIELD
+  'browser.selfsupport.url': 'https://localhost/selfrepair',
+  // Disable Reader Mode UI tour
+  'browser.reader.detectedFirstArticle': true,
 };


### PR DESCRIPTION
This is a port of https://github.com/mozilla-jetpack/jpm/pull/561 and fixes #406.