### PR TITLE
Test: add more flow types

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,13 @@
 {
   "parser": "babel-eslint",
+  "plugins": [
+    "flowtype"
+  ],
+  "settings": {
+    "flowtype": {
+      "onlyFilesWithFlowAnnotation": true
+    }
+  },
   "env": {
     "node": true,
     "es6": true
@@ -75,6 +83,10 @@
     "space-infix-ops": 0,
     "strict": [2, "never"],
     "valid-typeof": 2,
-    "wrap-iife": [2, "inside"]
+    "wrap-iife": [2, "inside"],
+
+    "flowtype/define-flow-type": 1,
+    "flowtype/use-flow-type": 1,
+    "flowtype/space-after-type-colon": [1, "always"]
   }
 }

--- a/.flowconfig
+++ b/.flowconfig
@@ -5,6 +5,8 @@
 [options]
 module.system=node
 log.file=./artifacts/flow.log
+suppress_comment= \\(.\\|\n\\)*\\$FLOW_FIXME
+suppress_comment= \\(.\\|\n\\)*\\$FLOW_IGNORE 
 
 [ignore]
 <PROJECT_ROOT>/dist/.*

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "copy-dir": "0.3.0",
     "coveralls": "2.11.12",
     "deepcopy": "0.6.3",
+    "firefox-client": "0.3.0",
     "flow-bin": "0.30.0",
     "grunt": "1.0.1",
     "grunt-contrib-clean": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "copy-dir": "0.3.0",
     "coveralls": "2.11.12",
     "deepcopy": "0.6.3",
+    "eslint-plugin-flowtype": "2.4.1",
     "firefox-client": "0.3.0",
     "flow-bin": "0.30.0",
     "grunt": "1.0.1",

--- a/src/cmd/build.js
+++ b/src/cmd/build.js
@@ -31,23 +31,6 @@ export type PackageCreatorParams = {
   artifactsDir: string,
 };
 
-export type BuildCmdParams = {
-  sourceDir: string,
-  artifactsDir: string,
-  asNeeded?: boolean,
-};
-
-export type BuildCmdOptions = {
-  manifestData?: ExtensionManifest,
-  fileFilter?: FileFilter,
-  onSourceChange?: OnSourceChangeFn,
-  packageCreator?: PackageCreatorFn,
-};
-
-export type FileFilterOptions = {
-  filesToIgnore?: Array<string>,
-};
-
 // Module internals & exports
 
 function defaultPackageCreator(
@@ -87,6 +70,18 @@ function defaultPackageCreator(
     });
 }
 
+export type BuildCmdParams = {
+  sourceDir: string,
+  artifactsDir: string,
+  asNeeded?: boolean,
+};
+
+export type BuildCmdOptions = {
+  manifestData?: ExtensionManifest,
+  fileFilter?: FileFilter,
+  onSourceChange?: OnSourceChangeFn,
+  packageCreator?: PackageCreatorFn,
+};
 
 export default function build(
   {sourceDir, artifactsDir, asNeeded=false}: BuildCmdParams,
@@ -128,6 +123,9 @@ export function safeFileName(name: string): string {
   return name.toLowerCase().replace(/[^a-z0-9\.-]+/g, '_');
 }
 
+export type FileFilterOptions = {
+  filesToIgnore?: Array<string>,
+};
 
 /*
  * Allows or ignores files when creating a ZIP archive.

--- a/src/cmd/build.js
+++ b/src/cmd/build.js
@@ -37,7 +37,7 @@ export type BuildCmdParams = {
   asNeeded?: boolean,
 };
 
-export type BuildCmdExtraParams = {
+export type BuildCmdOptions = {
   manifestData?: ExtensionManifest,
   fileFilter?: FileFilter,
   onSourceChange?: OnSourceChangeFn,
@@ -94,7 +94,7 @@ export default function build(
     manifestData, fileFilter=new FileFilter(),
     onSourceChange=defaultSourceWatcher,
     packageCreator=defaultPackageCreator,
-  }: BuildCmdExtraParams = {}
+  }: BuildCmdOptions = {}
 ): Promise<ExtensionBuildResult> {
   const rebuildAsNeeded = asNeeded; // alias for `build --as-needed`
   log.info(`Building web extension from ${sourceDir}`);

--- a/src/cmd/build.js
+++ b/src/cmd/build.js
@@ -10,15 +10,17 @@ import getValidatedManifest, {getManifestId} from '../util/manifest';
 import {prepareArtifactsDir} from '../util/artifacts';
 import {createLogger} from '../util/logger';
 
+
 const log = createLogger(__filename);
 
-// Flow Types
+
+// Import flow types.
 
 import type {OnSourceChangeFn} from '../watcher';
 import type {ExtensionManifest} from '../util/manifest';
 
-export type PackageCreatorFn =
-    (params: PackageCreatorParams) => Promise<ExtensionBuildResult>;
+
+// defaultPackageCreator types and implementation.
 
 export type ExtensionBuildResult = {
   extensionPath: string,
@@ -31,7 +33,8 @@ export type PackageCreatorParams = {
   artifactsDir: string,
 };
 
-// Module internals & exports
+export type PackageCreatorFn =
+    (params: PackageCreatorParams) => Promise<ExtensionBuildResult>;
 
 function defaultPackageCreator(
   {manifestData, sourceDir, fileFilter, artifactsDir}: PackageCreatorParams
@@ -69,6 +72,9 @@ function defaultPackageCreator(
         });
     });
 }
+
+
+// Build command types and implementation.
 
 export type BuildCmdParams = {
   sourceDir: string,
@@ -119,9 +125,14 @@ export default function build(
 }
 
 
+// safeFileName helper implementation.
+
 export function safeFileName(name: string): string {
   return name.toLowerCase().replace(/[^a-z0-9\.-]+/g, '_');
 }
+
+
+// FileFilter types and implementation.
 
 export type FileFilterOptions = {
   filesToIgnore?: Array<string>,

--- a/src/cmd/build.js
+++ b/src/cmd/build.js
@@ -13,6 +13,10 @@ import {createLogger} from '../util/logger';
 
 const log = createLogger(__filename);
 
+export function safeFileName(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9\.-]+/g, '_');
+}
+
 
 // Import flow types.
 
@@ -122,13 +126,6 @@ export default function build(
       }
       return result;
     });
-}
-
-
-// safeFileName helper implementation.
-
-export function safeFileName(name: string): string {
-  return name.toLowerCase().replace(/[^a-z0-9\.-]+/g, '_');
 }
 
 

--- a/src/cmd/lint.js
+++ b/src/cmd/lint.js
@@ -41,7 +41,7 @@ export type LintCmdParams = {
   pretty?: boolean,
 };
 
-export type LintCmdExtraParams = {
+export type LintCmdOptions = {
   createLinter: LinterCreatorFn,
   fileFilter: FileFilter,
 };
@@ -56,7 +56,7 @@ export default function lint(
   {
     createLinter=defaultLinterCreator,
     fileFilter=new FileFilter(),
-  }: LintCmdExtraParams = {}
+  }: LintCmdOptions = {}
 ): Promise<void> {
   log.debug(`Running addons-linter on ${sourceDir}`);
   const linter = createLinter({

--- a/src/cmd/lint.js
+++ b/src/cmd/lint.js
@@ -5,11 +5,59 @@ import {FileFilter} from './build';
 
 const log = createLogger(__filename);
 
+// Flow types
+
+export type LinterLogLevel = 'debug' | 'fatal';
+export type LinterOutputType = 'text' | 'json';
+
+export type LinterCreatorParams = {
+  config: {
+    logLevel: LinterLogLevel,
+    stack: boolean,
+    pretty?: boolean,
+    metadata?: boolean,
+    output?: LinterOutputType,
+    boring?: boolean,
+    selfHosted?: boolean,
+    shouldScanFile: (fileName: string) => boolean,
+    _: Array<string>,
+  },
+};
+
+export type Linter = {
+  run: () => Promise<void>,
+};
+
+export type LinterCreatorFn = (params: LinterCreatorParams) => Linter;
+
+
+export type LintCmdParams = {
+  sourceDir: string,
+  verbose?: boolean,
+  selfHosted?: boolean,
+  boring?: boolean,
+  output?: LinterOutputType,
+  metadata?: boolean,
+  pretty?: boolean,
+};
+
+export type LintCmdExtraParams = {
+  createLinter: LinterCreatorFn,
+  fileFilter: FileFilter,
+};
+
+// Module internals & exports
+
 export default function lint(
-    {verbose, sourceDir, selfHosted, boring, output,
-     metadata, pretty}: Object,
-    {createLinter=defaultLinterCreator, fileFilter=new FileFilter()}
-    : Object = {}): Promise<void> {
+  {
+    verbose, sourceDir, selfHosted, boring, output,
+    metadata, pretty,
+  }: LintCmdParams,
+  {
+    createLinter=defaultLinterCreator,
+    fileFilter=new FileFilter(),
+  }: LintCmdExtraParams = {}
+): Promise<void> {
   log.debug(`Running addons-linter on ${sourceDir}`);
   const linter = createLinter({
     config: {

--- a/src/cmd/lint.js
+++ b/src/cmd/lint.js
@@ -3,7 +3,9 @@ import {createInstance as defaultLinterCreator} from 'addons-linter';
 import {createLogger} from '../util/logger';
 import {FileFilter} from './build';
 
+
 const log = createLogger(__filename);
+
 
 // Define the needed 'addons-linter' module flow types.
 
@@ -29,7 +31,8 @@ export type Linter = {
 
 export type LinterCreatorFn = (params: LinterCreatorParams) => Linter;
 
-// Define the './cmd/lint' flow types.
+
+// Lint command types and implementation.
 
 export type LintCmdParams = {
   sourceDir: string,
@@ -45,8 +48,6 @@ export type LintCmdOptions = {
   createLinter?: LinterCreatorFn,
   fileFilter?: FileFilter,
 };
-
-// Module internals & exports
 
 export default function lint(
   {

--- a/src/cmd/lint.js
+++ b/src/cmd/lint.js
@@ -7,6 +7,8 @@ const log = createLogger(__filename);
 
 // Flow types
 
+// Define the needed 'addons-linter' module flow types.
+
 export type LinterOutputType = 'text' | 'json';
 
 export type LinterCreatorParams = {
@@ -29,6 +31,7 @@ export type Linter = {
 
 export type LinterCreatorFn = (params: LinterCreatorParams) => Linter;
 
+// Define the './cmd/lint' flow types.
 
 export type LintCmdParams = {
   sourceDir: string,
@@ -41,8 +44,8 @@ export type LintCmdParams = {
 };
 
 export type LintCmdOptions = {
-  createLinter: LinterCreatorFn,
-  fileFilter: FileFilter,
+  createLinter?: LinterCreatorFn,
+  fileFilter?: FileFilter,
 };
 
 // Module internals & exports

--- a/src/cmd/lint.js
+++ b/src/cmd/lint.js
@@ -5,8 +5,6 @@ import {FileFilter} from './build';
 
 const log = createLogger(__filename);
 
-// Flow types
-
 // Define the needed 'addons-linter' module flow types.
 
 export type LinterOutputType = 'text' | 'json';

--- a/src/cmd/lint.js
+++ b/src/cmd/lint.js
@@ -7,12 +7,11 @@ const log = createLogger(__filename);
 
 // Flow types
 
-export type LinterLogLevel = 'debug' | 'fatal';
 export type LinterOutputType = 'text' | 'json';
 
 export type LinterCreatorParams = {
   config: {
-    logLevel: LinterLogLevel,
+    logLevel: 'debug' | 'fatal',
     stack: boolean,
     pretty?: boolean,
     metadata?: boolean,

--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -253,7 +253,7 @@ export default function run(
         log.debug('Extension auto-reloading has been disabled');
       } else {
         if (!addonId) {
-          throw new Error(
+          throw new WebExtError(
             'Unexpected missing addonId in the installAsTemporaryAddon result'
           );
         }

--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -249,15 +249,15 @@ export default function run(
         'versions, use --pre-install');
     }))
     .then(() => {
-      if (!addonId) {
-        throw new WebExtError(
-          'Missing addonId in the installAsTemporaryAddon result'
-        );
-      }
-
       if (noReload) {
         log.debug('Extension auto-reloading has been disabled');
       } else {
+        if (!addonId) {
+          throw new Error(
+            'Unexpected missing addonId in the installAsTemporaryAddon result'
+          );
+        }
+
         log.debug(
           `Reloading extension when the source changes; id=${addonId}`);
         reloadStrategy({

--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -11,7 +11,6 @@ import defaultSourceWatcher from '../watcher';
 
 const log = createLogger(__filename);
 
-// Flow types
 
 // Import objects that are only used as Flow types.
 import type FirefoxProfile from 'firefox-profile';
@@ -26,6 +25,9 @@ import type {
 } from '../firefox/remote';
 import type {ExtensionManifest} from '../util/manifest';
 
+
+// defaultWatcherCreator types and implementation.
+
 export type WatcherCreatorParams = {
   addonId: string,
   client: RemoteFirefox,
@@ -34,28 +36,7 @@ export type WatcherCreatorParams = {
   onSourceChange?: OnSourceChangeFn,
 };
 
-export type ReloadStrategyParams = {
-  addonId: string,
-  firefox: FirefoxProcess,
-  client: RemoteFirefox,
-  profile: FirefoxProfile,
-  sourceDir: string,
-  artifactsDir: string,
-};
-
 export type WatcherCreatorFn = (params: WatcherCreatorParams) => Watchpack;
-
-export type ReloadStrategyOptions = {
-  createWatcher?: WatcherCreatorFn,
-};
-
-export type CreateFirefoxClientParams = {
-  connectToFirefox?: FirefoxConnectorFn,
-  maxRetries: number,
-  retryInterval: number,
-};
-
-// Module internals & exports
 
 export function defaultWatcherCreator(
   {
@@ -76,6 +57,21 @@ export function defaultWatcherCreator(
 }
 
 
+// defaultReloadStrategy types and implementation.
+
+export type ReloadStrategyParams = {
+  addonId: string,
+  firefox: FirefoxProcess,
+  client: RemoteFirefox,
+  profile: FirefoxProfile,
+  sourceDir: string,
+  artifactsDir: string,
+};
+
+export type ReloadStrategyOptions = {
+  createWatcher?: WatcherCreatorFn,
+};
+
 export function defaultReloadStrategy(
   {
     addonId, firefox, client, profile, sourceDir, artifactsDir,
@@ -94,6 +90,14 @@ export function defaultReloadStrategy(
   watcher = createWatcher({addonId, client, sourceDir, artifactsDir});
 }
 
+
+// defaultFirefoxClient types and implementation.
+
+export type CreateFirefoxClientParams = {
+  connectToFirefox?: FirefoxConnectorFn,
+  maxRetries: number,
+  retryInterval: number,
+};
 
 export function defaultFirefoxClient(
   {
@@ -135,6 +139,9 @@ export function defaultFirefoxClient(
   return establishConnection();
 }
 
+
+// Run command types and implementation.
+
 export type CmdRunParams = {
   sourceDir: string,
   artifactsDir: string,
@@ -143,7 +150,6 @@ export type CmdRunParams = {
   preInstall: boolean,
   noReload: boolean,
 };
-
 
 export type CmdRunOptions = {
   firefox: typeof defaultFirefox,
@@ -262,6 +268,8 @@ export default function run(
     });
 }
 
+
+// ExtensionRunner types and implementation.
 
 export type ExtensionRunnerParams = {
   sourceDir: string,

--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -40,7 +40,7 @@ export type ReloadStrategyParams = {
 
 export type WatcherCreatorFn = (params: WatcherCreatorParams) => Watchpack;
 
-export type ReloadStrategyExtraParams = {
+export type ReloadStrategyOptions = {
   createWatcher?: WatcherCreatorFn,
 };
 
@@ -77,7 +77,7 @@ export function defaultReloadStrategy(
   }: ReloadStrategyParams,
   {
     createWatcher=defaultWatcherCreator,
-  }: ReloadStrategyExtraParams = {}
+  }: ReloadStrategyOptions = {}
 ): void {
   let watcher;
 

--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -9,6 +9,7 @@ import {createLogger} from '../util/logger';
 import getValidatedManifest, {getManifestId} from '../util/manifest';
 import defaultSourceWatcher from '../watcher';
 
+
 const log = createLogger(__filename);
 
 

--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -15,15 +15,14 @@ const log = createLogger(__filename);
 
 // Import objects that are only used as Flow types.
 import type FirefoxProfile from 'firefox-profile';
-import type FirefoxClient from 'firefox-client';
 import type {OnSourceChangeFn} from '../watcher';
 import type Watchpack from 'watchpack';
 import type {EventEmitter} from 'events';
-import type {FirefoxConnectorFn} from '../firefox/remote';
+import type {FirefoxConnectorFn, RemoteFirefox} from '../firefox/remote';
 
 export type WatcherCreatorParams = {
   addonId: string,
-  client: FirefoxClient,
+  client: RemoteFirefox,
   sourceDir: string,
   artifactsDir: string,
   onSourceChange?: OnSourceChangeFn,
@@ -32,7 +31,7 @@ export type WatcherCreatorParams = {
 export type ReloadStrategyParams = {
   addonId: string,
   firefox: EventEmitter,
-  client: FirefoxClient,
+  client: RemoteFirefox,
   profile: FirefoxProfile,
   sourceDir: string,
   artifactsDir: string,
@@ -96,7 +95,7 @@ export function defaultFirefoxClient(
     // A max of 250 will try connecting for 30 seconds.
     maxRetries=250, retryInterval=120,
   }: CreateFirefoxClientParams = {}
-): Promise<FirefoxClient> {
+): Promise<RemoteFirefox> {
   var retries = 0;
 
   function establishConnection() {

--- a/src/cmd/sign.js
+++ b/src/cmd/sign.js
@@ -10,14 +10,19 @@ import getValidatedManifest, {getManifestId} from '../util/manifest';
 import {prepareArtifactsDir} from '../util/artifacts';
 import {createLogger} from '../util/logger';
 
+
 const log = createLogger(__filename);
 export const extensionIdFile = '.web-extension-id';
 
-// Flow Types
+
+// Import flow types.
 
 import type {ExtensionManifest} from  '../util/manifest';
 
-export type SignCmdParams = {
+
+// Sign command types and implementation.
+
+export type SignParams = {
   id?: string,
   verbose?: boolean,
   sourceDir: string,
@@ -28,31 +33,28 @@ export type SignCmdParams = {
   timeout: number,
 };
 
-export type SignCmdOptions = {
+export type SignOptions = {
   build?: typeof defaultBuilder,
   signAddon?: typeof defaultAddonSigner,
   preValidatedManifest?: ExtensionManifest,
 };
 
-export type SignCmdResult = {
+export type SignResult = {
   success: boolean,
   id: string,
   downloadedFiles: Array<string>,
 };
 
-
-// Module internals & exports
-
 export default function sign(
   {
     verbose, sourceDir, artifactsDir, apiKey, apiSecret,
     apiUrlPrefix, id, timeout,
-  }: SignCmdParams,
+  }: SignParams,
   {
     build=defaultBuilder, signAddon=defaultAddonSigner,
     preValidatedManifest,
-  }: SignCmdOptions = {}
-): Promise<SignCmdResult> {
+  }: SignOptions = {}
+): Promise<SignResult> {
   return withTempDir(
     (tmpDir) => {
       return prepareArtifactsDir(artifactsDir)
@@ -127,6 +129,8 @@ export default function sign(
 }
 
 
+// getIdFromSourceDir helper implementation.
+
 export function getIdFromSourceDir(sourceDir: string): Promise<string> {
   const filePath = path.join(sourceDir, extensionIdFile);
   return fs.readFile(filePath)
@@ -150,6 +154,8 @@ export function getIdFromSourceDir(sourceDir: string): Promise<string> {
     }));
 }
 
+
+// getIdFromSourceDir helper implementation.
 
 export function saveIdToSourceDir(sourceDir: string, id: string)
     : Promise<void> {

--- a/src/cmd/sign.js
+++ b/src/cmd/sign.js
@@ -13,12 +13,46 @@ import {createLogger} from '../util/logger';
 const log = createLogger(__filename);
 export const extensionIdFile = '.web-extension-id';
 
-export default function sign(
-    {verbose, sourceDir, artifactsDir, apiKey, apiSecret,
-     apiUrlPrefix, id, timeout}: Object,
-    {build=defaultBuilder, signAddon=defaultAddonSigner,
-     preValidatedManifest=null}: Object = {}): Promise<Object> {
+// Flow Types
 
+import type {ExtensionManifest} from  '../util/manifest';
+
+export type SignCmdParams = {
+  id?: string,
+  verbose?: boolean,
+  sourceDir: string,
+  artifactsDir: string,
+  apiKey: string,
+  apiSecret: string,
+  apiUrlPrefix: string,
+  timeout: number,
+};
+
+export type SignCmdExtraParams = {
+  build?: typeof defaultBuilder,
+  signAddon?: typeof defaultAddonSigner,
+  preValidatedManifest?: ExtensionManifest,
+};
+
+export type SignCmdResult = {
+  success: boolean,
+  id: string,
+  downloadedFiles: Array<string>,
+};
+
+
+// Module internals & exports
+
+export default function sign(
+  {
+    verbose, sourceDir, artifactsDir, apiKey, apiSecret,
+    apiUrlPrefix, id, timeout,
+  }: SignCmdParams,
+  {
+    build=defaultBuilder, signAddon=defaultAddonSigner,
+    preValidatedManifest,
+  }: SignCmdExtraParams = {}
+): Promise<SignCmdResult> {
   return withTempDir(
     (tmpDir) => {
       return prepareArtifactsDir(artifactsDir)

--- a/src/cmd/sign.js
+++ b/src/cmd/sign.js
@@ -28,7 +28,7 @@ export type SignCmdParams = {
   timeout: number,
 };
 
-export type SignCmdExtraParams = {
+export type SignCmdOptions = {
   build?: typeof defaultBuilder,
   signAddon?: typeof defaultAddonSigner,
   preValidatedManifest?: ExtensionManifest,
@@ -51,7 +51,7 @@ export default function sign(
   {
     build=defaultBuilder, signAddon=defaultAddonSigner,
     preValidatedManifest,
-  }: SignCmdExtraParams = {}
+  }: SignCmdOptions = {}
 ): Promise<SignCmdResult> {
   return withTempDir(
     (tmpDir) => {

--- a/src/cmd/sign.js
+++ b/src/cmd/sign.js
@@ -12,6 +12,7 @@ import {createLogger} from '../util/logger';
 
 
 const log = createLogger(__filename);
+
 export const extensionIdFile = '.web-extension-id';
 
 
@@ -129,8 +130,6 @@ export default function sign(
 }
 
 
-// getIdFromSourceDir helper implementation.
-
 export function getIdFromSourceDir(sourceDir: string): Promise<string> {
   const filePath = path.join(sourceDir, extensionIdFile);
   return fs.readFile(filePath)
@@ -154,8 +153,6 @@ export function getIdFromSourceDir(sourceDir: string): Promise<string> {
     }));
 }
 
-
-// getIdFromSourceDir helper implementation.
 
 export function saveIdToSourceDir(sourceDir: string, id: string)
     : Promise<void> {

--- a/src/firefox/index.js
+++ b/src/firefox/index.js
@@ -28,6 +28,8 @@ import type {
 
 import type {ExtensionManifest} from '../util/manifest';
 
+// Declare the needed 'fx-runner' module flow types.
+
 export type FirefoxRunnerParams = {
   binary?: string,
   profile?: string,
@@ -51,6 +53,8 @@ export type FirefoxRunnerResults = {
 export type FirefoxRunnerFn =
   (params: FirefoxRunnerParams) => Promise<FirefoxRunnerResults>;
 
+// Declare the 'port finder'-related types
+
 export type RemotePortFinderParams = {
   portToTry?: number,
   connectToFirefox?: DefaultFirefoxConnectorFn,
@@ -59,42 +63,7 @@ export type RemotePortFinderParams = {
 export type RemotePortFinderFn =
   (params?: RemotePortFinderParams) => Promise<number>;
 
-export type FirefoxRunOptions = {
-  fxRunner?: FirefoxRunnerFn,
-  findRemotePort?: RemotePortFinderFn,
-  firefoxBinary?: string,
-  binaryArgs?: Array<string>,
-};
-
-export type ConfigureProfileOptions = {
-  app?: PreferencesAppName,
-  getPrefs?: PreferencesGetterFn,
-};
-
-export type ConfigureProfileFn = (
-  profile: FirefoxProfile,
-  options?: ConfigureProfileOptions
-) => Promise<FirefoxProfile>;
-
-export type CreateProfileParams = {
-  app?: PreferencesAppName,
-  configureThisProfile?: ConfigureProfileFn,
-};
-
-export type CopyProfileOptions = {
-  app?: PreferencesAppName,
-  copyFromUserProfile?: Function,
-  configureThisProfile?: ConfigureProfileFn,
-};
-
-export type InstallExtensionParams = {
-  asProxy?: boolean,
-  manifestData: ExtensionManifest,
-  profile: FirefoxProfile,
-  extensionPath: string,
-};
-
-// Exports
+// Module internals & exports
 
 export const defaultFirefoxEnv = {
   XPCOM_DEBUG_BREAK: 'stack',
@@ -126,6 +95,13 @@ export function defaultRemotePortFinder(
     }));
 }
 
+
+export type FirefoxRunOptions = {
+  fxRunner?: FirefoxRunnerFn,
+  findRemotePort?: RemotePortFinderFn,
+  firefoxBinary?: string,
+  binaryArgs?: Array<string>,
+};
 
 /*
  * Runs Firefox with the given profile object and resolves a promise on exit.
@@ -193,6 +169,16 @@ export function run(
 }
 
 
+export type ConfigureProfileOptions = {
+  app?: PreferencesAppName,
+  getPrefs?: PreferencesGetterFn,
+};
+
+export type ConfigureProfileFn = (
+  profile: FirefoxProfile,
+  options?: ConfigureProfileOptions
+) => Promise<FirefoxProfile>;
+
 /*
  * Configures a profile with common preferences that are required to
  * activate extension development.
@@ -221,6 +207,11 @@ export function configureProfile(
 }
 
 
+export type CreateProfileParams = {
+  app?: PreferencesAppName,
+  configureThisProfile?: ConfigureProfileFn,
+};
+
 /*
  * Creates a new temporary profile and resolves with the profile object.
  *
@@ -237,6 +228,12 @@ export function createProfile(
     .then((profile) => configureThisProfile(profile, {app}));
 }
 
+
+export type CopyProfileOptions = {
+  app?: PreferencesAppName,
+  copyFromUserProfile?: Function,
+  configureThisProfile?: ConfigureProfileFn,
+};
 
 /*
  * Copies an existing Firefox profile and creates a new temporary profile.
@@ -279,6 +276,13 @@ export function copyProfile(
     });
 }
 
+
+export type InstallExtensionParams = {
+  asProxy?: boolean,
+  manifestData: ExtensionManifest,
+  profile: FirefoxProfile,
+  extensionPath: string,
+};
 
 /*
  * Installs an extension into the given Firefox profile object.

--- a/src/firefox/index.js
+++ b/src/firefox/index.js
@@ -26,6 +26,8 @@ import type {
   PreferencesGetterFn,
 } from './preferences';
 
+import type {ExtensionManifest} from '../util/manifest';
+
 export type FirefoxRunnerParams = {
   binary?: string,
   profile?: string,
@@ -85,7 +87,7 @@ export type CopyProfileExtraParams = {
 
 export type InstallExtensionParams = {
   asProxy?: boolean,
-  manifestData: Object,
+  manifestData: ExtensionManifest,
   profile: FirefoxProfile,
   extensionPath: string,
 };

--- a/src/firefox/index.js
+++ b/src/firefox/index.js
@@ -59,31 +59,33 @@ export type RemotePortFinderParams = {
 export type RemotePortFinderFn =
   (params?: RemotePortFinderParams) => Promise<number>;
 
-export type FirefoxRunExtraParams = {
+export type FirefoxRunOptions = {
   fxRunner?: FirefoxRunnerFn,
   findRemotePort?: RemotePortFinderFn,
   firefoxBinary?: string,
   binaryArgs?: Array<string>,
-}
+};
 
-export type ConfigureProfileExtraParams = {
+export type ConfigureProfileOptions = {
   app?: PreferencesAppName,
   getPrefs?: PreferencesGetterFn,
-}
+};
 
-export type ConfigureProfileFn = (profile: FirefoxProfile,
-  extraParams?: ConfigureProfileExtraParams) => Promise<FirefoxProfile>
+export type ConfigureProfileFn = (
+  profile: FirefoxProfile,
+  options?: ConfigureProfileOptions
+) => Promise<FirefoxProfile>;
 
 export type CreateProfileParams = {
   app?: PreferencesAppName,
   configureThisProfile?: ConfigureProfileFn,
 };
 
-export type CopyProfileExtraParams = {
+export type CopyProfileOptions = {
   app?: PreferencesAppName,
   copyFromUserProfile?: Function,
   configureThisProfile?: ConfigureProfileFn,
-}
+};
 
 export type InstallExtensionParams = {
   asProxy?: boolean,
@@ -134,7 +136,7 @@ export function run(
     fxRunner=defaultFxRunner,
     findRemotePort=defaultRemotePortFinder,
     firefoxBinary, binaryArgs,
-  }: FirefoxRunExtraParams = {}
+  }: FirefoxRunOptions = {}
 ): Promise<ChildProcess> {
 
   log.info(`Running Firefox with profile at ${profile.path()}`);
@@ -202,7 +204,7 @@ export function configureProfile(
   {
     app='firefox',
     getPrefs=defaultPrefGetter,
-  }: ConfigureProfileExtraParams = {}
+  }: ConfigureProfileOptions = {}
 ): Promise<FirefoxProfile> {
   return new Promise((resolve) => {
     // Set default preferences. Some of these are required for the add-on to
@@ -254,7 +256,7 @@ export function copyProfile(
     copyFromUserProfile=defaultUserProfileCopier,
     configureThisProfile=configureProfile,
     app,
-  }: CopyProfileExtraParams = {}
+  }: CopyProfileOptions = {}
 ): Promise<FirefoxProfile> {
 
   let copy = promisify(FirefoxProfile.copy);

--- a/src/firefox/index.js
+++ b/src/firefox/index.js
@@ -15,9 +15,15 @@ import {getManifestId} from '../util/manifest';
 import {createLogger} from '../util/logger';
 import {default as defaultFirefoxConnector, REMOTE_PORT} from './remote';
 
+
 const log = createLogger(__filename);
 
-// Flow Types
+export const defaultFirefoxEnv = {
+  XPCOM_DEBUG_BREAK: 'stack',
+  NS_TRACE_MALLOC_DISABLE_STACKS: '1',
+};
+
+// Import flow types.
 
 import type {DefaultFirefoxConnectorFn} from './remote';
 import type {ChildProcess} from 'child_process';
@@ -28,32 +34,8 @@ import type {
 
 import type {ExtensionManifest} from '../util/manifest';
 
-// Declare the needed 'fx-runner' module flow types.
 
-export type FirefoxRunnerParams = {
-  binary?: string,
-  profile?: string,
-  'new-instance'?: boolean,
-  'no-remote'?: boolean,
-  'foreground'?: boolean,
-  'listen': number,
-  'binary-args'?: Array<string> | string,
-  'env'?: {
-    [key: string]: string
-  },
-  'verbose'?: boolean,
-};
-
-export type FirefoxRunnerResults = {
-  process: ChildProcess,
-  binary: string,
-  args: Array<string>,
-};
-
-export type FirefoxRunnerFn =
-  (params: FirefoxRunnerParams) => Promise<FirefoxRunnerResults>;
-
-// Declare the 'port finder'-related types
+// defaultRemotePortFinder types and implementation.
 
 export type RemotePortFinderParams = {
   portToTry?: number,
@@ -62,14 +44,6 @@ export type RemotePortFinderParams = {
 
 export type RemotePortFinderFn =
   (params?: RemotePortFinderParams) => Promise<number>;
-
-// Module internals & exports
-
-export const defaultFirefoxEnv = {
-  XPCOM_DEBUG_BREAK: 'stack',
-  NS_TRACE_MALLOC_DISABLE_STACKS: '1',
-};
-
 
 export function defaultRemotePortFinder(
   {
@@ -96,15 +70,43 @@ export function defaultRemotePortFinder(
 }
 
 
+// Declare the needed 'fx-runner' module flow types.
+
+export type FirefoxRunnerParams = {
+  binary?: string,
+  profile?: string,
+  'new-instance'?: boolean,
+  'no-remote'?: boolean,
+  'foreground'?: boolean,
+  'listen': number,
+  'binary-args'?: Array<string> | string,
+  'env'?: {
+    [key: string]: string
+  },
+  'verbose'?: boolean,
+};
+
+// NOTE: alias FirefoxProcess to a node ChildProcess type
+export type FirefoxProcess = ChildProcess;
+
+export type FirefoxRunnerResults = {
+  process: FirefoxProcess,
+  binary: string,
+  args: Array<string>,
+};
+
+export type FirefoxRunnerFn =
+  (params: FirefoxRunnerParams) => Promise<FirefoxRunnerResults>;
+
+
+// Run command types and implementaion.
+
 export type FirefoxRunOptions = {
   fxRunner?: FirefoxRunnerFn,
   findRemotePort?: RemotePortFinderFn,
   firefoxBinary?: string,
   binaryArgs?: Array<string>,
 };
-
-// NOTE: alias FirefoxProcess to a node ChildProcess type
-export type FirefoxProcess = ChildProcess;
 
 /*
  * Runs Firefox with the given profile object and resolves a promise on exit.
@@ -172,6 +174,8 @@ export function run(
 }
 
 
+// configureProfile types and implementation.
+
 export type ConfigureProfileOptions = {
   app?: PreferencesAppName,
   getPrefs?: PreferencesGetterFn,
@@ -210,6 +214,8 @@ export function configureProfile(
 }
 
 
+// createProfile types and implementation.
+
 export type CreateProfileParams = {
   app?: PreferencesAppName,
   configureThisProfile?: ConfigureProfileFn,
@@ -231,6 +237,8 @@ export function createProfile(
     .then((profile) => configureThisProfile(profile, {app}));
 }
 
+
+// copyProfile types and implementation.
 
 export type CopyProfileOptions = {
   app?: PreferencesAppName,
@@ -279,6 +287,8 @@ export function copyProfile(
     });
 }
 
+
+// installExtension types and implementation.
 
 export type InstallExtensionParams = {
   asProxy?: boolean,

--- a/src/firefox/index.js
+++ b/src/firefox/index.js
@@ -103,6 +103,9 @@ export type FirefoxRunOptions = {
   binaryArgs?: Array<string>,
 };
 
+// NOTE: alias FirefoxProcess to a node ChildProcess type
+export type FirefoxProcess = ChildProcess;
+
 /*
  * Runs Firefox with the given profile object and resolves a promise on exit.
  */
@@ -113,7 +116,7 @@ export function run(
     findRemotePort=defaultRemotePortFinder,
     firefoxBinary, binaryArgs,
   }: FirefoxRunOptions = {}
-): Promise<ChildProcess> {
+): Promise<FirefoxProcess> {
 
   log.info(`Running Firefox with profile at ${profile.path()}`);
   return findRemotePort()

--- a/src/firefox/index.js
+++ b/src/firefox/index.js
@@ -25,7 +25,7 @@ export const defaultFirefoxEnv = {
 
 // Import flow types.
 
-import type {DefaultFirefoxConnectorFn} from './remote';
+import type {FirefoxConnectorFn} from './remote';
 import type {ChildProcess} from 'child_process';
 import type {
   PreferencesAppName,
@@ -39,7 +39,7 @@ import type {ExtensionManifest} from '../util/manifest';
 
 export type RemotePortFinderParams = {
   portToTry?: number,
-  connectToFirefox?: DefaultFirefoxConnectorFn,
+  connectToFirefox?: FirefoxConnectorFn,
 };
 
 export type RemotePortFinderFn =

--- a/src/firefox/index.js
+++ b/src/firefox/index.js
@@ -23,6 +23,7 @@ export const defaultFirefoxEnv = {
   NS_TRACE_MALLOC_DISABLE_STACKS: '1',
 };
 
+
 // Import flow types.
 
 import type {FirefoxConnectorFn} from './remote';

--- a/src/firefox/index.js
+++ b/src/firefox/index.js
@@ -31,15 +31,15 @@ import type {ExtensionManifest} from '../util/manifest';
 export type FirefoxRunnerParams = {
   binary?: string,
   profile?: string,
-  "new-instance"?: boolean,
-  "no-remote"?: boolean,
-  "foreground"?: boolean,
-  "listen"?: number,
-  "binary-args"?: Array<string> | string,
-  "env"?: {
+  'new-instance'?: boolean,
+  'no-remote'?: boolean,
+  'foreground'?: boolean,
+  'listen': number,
+  'binary-args'?: Array<string> | string,
+  'env'?: {
     [key: string]: string
   },
-  "verbose"?: boolean,
+  'verbose'?: boolean,
 };
 
 export type FirefoxRunnerResults = {

--- a/src/firefox/index.js
+++ b/src/firefox/index.js
@@ -203,8 +203,8 @@ export function copyProfile(
  * text file that contains the path to the extension source.
  */
 export function installExtension(
-    {asProxy=false, manifestData, profile, extensionPath}: Object): Promise<*> {
-
+  {asProxy=false, manifestData, profile, extensionPath}: Object
+): Promise<any> {
   // This more or less follows
   // https://github.com/saadtazi/firefox-profile-js/blob/master/lib/firefox_profile.js#L531
   // (which is broken for web extensions).

--- a/src/firefox/index.js
+++ b/src/firefox/index.js
@@ -49,7 +49,7 @@ export type FirefoxRunnerResults = {
 };
 
 export type FirefoxRunnerFn =
-  (params: FirefoxRunnerParams) => FirefoxRunnerResults;
+  (params: FirefoxRunnerParams) => Promise<FirefoxRunnerResults>;
 
 export type RemotePortFinderParams = {
   portToTry?: number,

--- a/src/firefox/preferences.js
+++ b/src/firefox/preferences.js
@@ -63,13 +63,13 @@ const prefsCommon: FirefoxPreferences = {
 };
 
 // Prefs specific to Firefox for Android.
-const prefsFennec:FirefoxPreferences = {
+const prefsFennec: FirefoxPreferences = {
   'browser.console.showInPanel': true,
   'browser.firstrun.show.uidiscovery': false,
 };
 
 // Prefs specific to Firefox for desktop.
-const prefsFirefox:FirefoxPreferences = {
+const prefsFirefox: FirefoxPreferences = {
   'browser.startup.homepage' : 'about:blank',
   'startup.homepage_welcome_url' : 'about:blank',
   'startup.homepage_welcome_url.additional' : '',

--- a/src/firefox/preferences.js
+++ b/src/firefox/preferences.js
@@ -9,9 +9,6 @@ export type FirefoxPreferences = {
 
 export type PreferencesAppName = 'firefox' | 'fennec';
 
-export type PreferencesGetterFn =
-  (appName: PreferencesAppName) => FirefoxPreferences;
-
 // Preferences Maps
 
 const prefsCommon: FirefoxPreferences = {
@@ -100,7 +97,10 @@ const prefs = {
   firefox: prefsFirefox,
 };
 
-// Exports
+// Module exports
+
+export type PreferencesGetterFn =
+  (appName: PreferencesAppName) => FirefoxPreferences;
 
 export function getPrefs(
   app: PreferencesAppName = 'firefox'

--- a/src/firefox/preferences.js
+++ b/src/firefox/preferences.js
@@ -1,6 +1,7 @@
 /* @flow */
 import {WebExtError} from '../errors';
 
+
 // Flow Types
 
 export type FirefoxPreferences = {
@@ -8,6 +9,7 @@ export type FirefoxPreferences = {
 };
 
 export type PreferencesAppName = 'firefox' | 'fennec';
+
 
 // Preferences Maps
 
@@ -96,6 +98,7 @@ const prefs = {
   fennec: prefsFennec,
   firefox: prefsFirefox,
 };
+
 
 // Module exports
 

--- a/src/firefox/preferences.js
+++ b/src/firefox/preferences.js
@@ -7,13 +7,7 @@ export type FirefoxPreferences = {
   [key: string]: bool | string | number,
 };
 
-// NOTE: 'thuderbird' prefs are not defined on purpose, it is used in the tests to
-// be sure that if flow checks are not running and web-ext is used as a library,
-// an unknown app name raises the expected exception at runtime.
-// Preferences Maps
-
-// $FLOW_IGNORE: suppress property 'thuderbird' Property not found
-export type PreferencesAppName = 'firefox' | 'fennec' | 'thunderbird';
+export type PreferencesAppName = 'firefox' | 'fennec';
 
 export type PreferencesGetterFn =
   (appName: PreferencesAppName) => FirefoxPreferences;
@@ -104,7 +98,6 @@ const prefs = {
   common: prefsCommon,
   fennec: prefsFennec,
   firefox: prefsFirefox,
-  thuderbird: undefined,
 };
 
 // Exports

--- a/src/firefox/preferences.js
+++ b/src/firefox/preferences.js
@@ -1,22 +1,26 @@
 /* @flow */
 import {WebExtError} from '../errors';
 
+// Flow Types
 
-export function getPrefs(app: string = 'firefox'): Object {
-  let appPrefs = prefs[app];
-  if (!appPrefs) {
-    throw new WebExtError(`Unsupported application: ${app}`);
-  }
-  return {
-    ...prefs.common,
-    ...appPrefs,
-  };
-}
+export type FirefoxPreferences = {
+  [key: string]: bool | string | number,
+};
 
+// NOTE: 'thuderbird' prefs are not defined on purpose, it is used in the tests to
+// be sure that if flow checks are not running and web-ext is used as a library,
+// an unknown app name raises the expected exception at runtime.
+// Preferences Maps
 
-var prefs = {};
+// $FLOW_IGNORE: suppress property 'thuderbird' Property not found
+export type PreferencesAppName = 'firefox' | 'fennec' | 'thunderbird';
 
-prefs.common = {
+export type PreferencesGetterFn =
+  (appName: PreferencesAppName) => FirefoxPreferences;
+
+// Preferences Maps
+
+const prefsCommon: FirefoxPreferences = {
   // Allow debug output via dump to be printed to the system console
   'browser.dom.window.dump.enabled': true,
   // Warn about possibly incorrect code.
@@ -65,13 +69,13 @@ prefs.common = {
 };
 
 // Prefs specific to Firefox for Android.
-prefs.fennec = {
+const prefsFennec:FirefoxPreferences = {
   'browser.console.showInPanel': true,
   'browser.firstrun.show.uidiscovery': false,
 };
 
 // Prefs specific to Firefox for desktop.
-prefs.firefox = {
+const prefsFirefox:FirefoxPreferences = {
   'browser.startup.homepage' : 'about:blank',
   'startup.homepage_welcome_url' : 'about:blank',
   'startup.homepage_welcome_url.additional' : '',
@@ -95,3 +99,25 @@ prefs.firefox = {
   // Disable Reader Mode UI tour
   'browser.reader.detectedFirstArticle': true,
 };
+
+const prefs = {
+  common: prefsCommon,
+  fennec: prefsFennec,
+  firefox: prefsFirefox,
+  thuderbird: undefined,
+};
+
+// Exports
+
+export function getPrefs(
+  app: PreferencesAppName = 'firefox'
+): FirefoxPreferences {
+  const appPrefs = prefs[app];
+  if (!appPrefs) {
+    throw new WebExtError(`Unsupported application: ${app}`);
+  }
+  return {
+    ...prefsCommon,
+    ...appPrefs,
+  };
+}

--- a/src/firefox/remote.js
+++ b/src/firefox/remote.js
@@ -11,7 +11,7 @@ const log = createLogger(__filename);
 import type FirefoxClient from 'firefox-client';
 
 export type FirefoxConnectorFn =
-  (port: number) => Promise<FirefoxClient>;
+  (port?: number) => Promise<FirefoxClient>;
 
 export type ConnectExtraParams = {
   connectToFirefox: FirefoxConnectorFn,

--- a/src/firefox/remote.js
+++ b/src/firefox/remote.js
@@ -28,11 +28,12 @@ export type FirefoxRDPResponseError = {
   },
 };
 
-export type FirefoxRDPResponseAny = Object;
-
 export type FirefoxRDPResponseAddon = {
   addon: FirefoxRDPAddonActor,
 };
+
+// NOTE: this type aliases Object to catch any other possible reponse.
+export type FirefoxRDPResponseAny = Object;
 
 export type FirefoxRDPResponseMaybe =
   FirefoxRDPResponseError | FirefoxRDPResponseAddon | FirefoxRDPResponseAny;

--- a/src/firefox/remote.js
+++ b/src/firefox/remote.js
@@ -36,7 +36,7 @@ export type FirefoxRDPResponseRequestTypes = {
   requestTypes: Array<string>,
 };
 
-// NOTE: this type aliases Object to catch any other possible reponse.
+// NOTE: this type aliases Object to catch any other possible response.
 export type FirefoxRDPResponseAny = Object;
 
 export type FirefoxRDPResponseMaybe =
@@ -184,8 +184,8 @@ export type ConnectOptions = {
   connectToFirefox: FirefoxConnectorFn,
 };
 
-// NOTE: this fix an issue with flow and default exports (which currently
-// lose their type signatures) by explicitly declare the default export
+// NOTE: this fixes an issue with flow and default exports (which currently
+// lose their type signatures) by explicitly declaring the default export
 // signature. Reference: https://github.com/facebook/flow/issues/449
 declare function exports(
   port: number, options?: ConnectOptions

--- a/src/firefox/remote.js
+++ b/src/firefox/remote.js
@@ -40,24 +40,11 @@ export type FirefoxRDPResponseMaybe =
 export type DefaultFirefoxConnectorFn =
   (port: number, options?: ConnectOptions) => Promise<RemoteFirefox>;
 
-// Exports
+// Module internals & exports
 
 // The default port that Firefox's remote debugger will listen on and the
 // client will connect to.
 export const REMOTE_PORT = 6005;
-
-
-export default function connect(
-  port: number = REMOTE_PORT,
-  {connectToFirefox=defaultFirefoxConnector}: ConnectOptions = {}
-): Promise<RemoteFirefox> {
-  log.debug(`Connecting to Firefox on port ${port}`);
-  return connectToFirefox(port)
-    .then((client) => {
-      log.debug('Connected to the remote Firefox debugger');
-      return new RemoteFirefox(client);
-    });
-}
 
 
 export class RemoteFirefox {
@@ -197,9 +184,22 @@ export class RemoteFirefox {
   }
 }
 
+
 // NOTE: this fix an issue with flow and default exports (which currently
 // lose their type signatures) by explicitly declare the default export
 // signature. Reference: https://github.com/facebook/flow/issues/449
 declare function exports(
   port: number, options?: ConnectOptions
 ): Promise<RemoteFirefox>;
+
+export default function connect(
+  port: number = REMOTE_PORT,
+  {connectToFirefox=defaultFirefoxConnector}: ConnectOptions = {}
+): Promise<RemoteFirefox> {
+  log.debug(`Connecting to Firefox on port ${port}`);
+  return connectToFirefox(port)
+    .then((client) => {
+      log.debug('Connected to the remote Firefox debugger');
+      return new RemoteFirefox(client);
+    });
+}

--- a/src/firefox/remote.js
+++ b/src/firefox/remote.js
@@ -5,6 +5,7 @@ import defaultFirefoxConnector from 'node-firefox-connect';
 
 
 const log = createLogger(__filename);
+
 // The default port that Firefox's remote debugger will listen on and the
 // client will connect to.
 export const REMOTE_PORT = 6005;

--- a/src/firefox/remote.js
+++ b/src/firefox/remote.js
@@ -200,6 +200,6 @@ export class RemoteFirefox {
 // NOTE: this fix an issue with flow and default exports (which currently
 // lose their type signatures) by explicitly declare the default export
 // signature. Reference: https://github.com/facebook/flow/issues/449
-declare function exports( // eslint-disable-line no-unused-vars
+declare function exports(
   port: number, options?: ConnectOptions
 ): Promise<RemoteFirefox>;

--- a/src/firefox/remote.js
+++ b/src/firefox/remote.js
@@ -13,7 +13,7 @@ import type FirefoxClient from 'firefox-client';
 export type FirefoxConnectorFn =
   (port?: number) => Promise<FirefoxClient>;
 
-export type ConnectExtraParams = {
+export type ConnectOptions = {
   connectToFirefox: FirefoxConnectorFn,
 };
 
@@ -38,7 +38,7 @@ export type FirefoxRDPResponseMaybe =
   FirefoxRDPResponseError | FirefoxRDPResponseAddon | FirefoxRDPResponseAny;
 
 export type DefaultFirefoxConnectorFn =
-  (port: number, extraParams?: ConnectExtraParams) => Promise<RemoteFirefox>;
+  (port: number, options?: ConnectOptions) => Promise<RemoteFirefox>;
 
 // Exports
 
@@ -49,7 +49,7 @@ export const REMOTE_PORT = 6005;
 
 export default function connect(
   port: number = REMOTE_PORT,
-  {connectToFirefox=defaultFirefoxConnector}: ConnectExtraParams = {}
+  {connectToFirefox=defaultFirefoxConnector}: ConnectOptions = {}
 ): Promise<RemoteFirefox> {
   log.debug(`Connecting to Firefox on port ${port}`);
   return connectToFirefox(port)
@@ -201,5 +201,5 @@ export class RemoteFirefox {
 // lose their type signatures) by explicitly declare the default export
 // signature. Reference: https://github.com/facebook/flow/issues/449
 declare function exports( // eslint-disable-line no-unused-vars
-  port: number, extraParams?: ConnectExtraParams
+  port: number, options?: ConnectOptions
 ): Promise<RemoteFirefox>;

--- a/src/program.js
+++ b/src/program.js
@@ -68,7 +68,7 @@ export class Program {
   run(absolutePackageDir: string,
       {systemProcess=process, logStream=defaultLogStream,
        getVersion=defaultVersionGetter, shouldExitProgram=true}
-      : Object = {}): Promise<*> {
+      : Object = {}): Promise<any> {
 
     this.shouldExitProgram = shouldExitProgram;
     let argv;
@@ -127,7 +127,7 @@ export function defaultVersionGetter(absolutePackageDir: string): string {
 export function main(
     absolutePackageDir: string,
     {getVersion=defaultVersionGetter, commands=defaultCommands, argv,
-     runOptions={}}: Object = {}): Promise<*> {
+     runOptions={}}: Object = {}): Promise<any> {
   let program = new Program(argv);
   // yargs uses magic camel case expansion to expose options on the
   // final argv object. For example, the 'artifacts-dir' option is alternatively

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -2,6 +2,7 @@
 import bunyan, {nameFromLevel, createLogger as defaultLogCreator}
   from 'bunyan';
 
+
 // Bunyan-related Flow types
 
 export type TRACE = 10;
@@ -13,10 +14,6 @@ export type FATAL = 60;
 
 export type BunyanLogLevel =
   TRACE | DEBUG | INFO | WARN | ERROR | FATAL;
-
-export type ConsoleStreamParams = {
-  verbose?: boolean,
-};
 
 export type BunyanLogEntry = {
   name: string,
@@ -31,7 +28,12 @@ export type Logger = {
   warn: (msg: string) => void,
 };
 
-// Module internals & exports
+
+// ConsoleStream types and implementation.
+
+export type ConsoleStreamParams = {
+  verbose?: boolean,
+};
 
 export type ConsoleOptions = {
   localProcess?: typeof process,
@@ -90,6 +92,9 @@ export class ConsoleStream {
 }
 
 export const consoleStream = new ConsoleStream();
+
+
+// createLogger types and implementation.
 
 export type BunyanStreamConfig = {
   type: string,

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -2,20 +2,7 @@
 import bunyan, {nameFromLevel, createLogger as defaultLogCreator}
   from 'bunyan';
 
-// Flow types
-
-import type {Writable} from 'stream';
-import type {WriteStream} from 'tty';
-
-export type FakeProcess = {
-  stdout: Writable | WriteStream;
-};
-
-export type ConsoleOptions = {
-  localProcess?: FakeProcess,
-};
-
-// Bunyan-related types
+// Bunyan-related Flow types
 
 export type TRACE = 10;
 export type DEBUG = 20;
@@ -45,6 +32,10 @@ export type Logger = {
 };
 
 // Module internals & exports
+
+export type ConsoleOptions = {
+  localProcess?: typeof process,
+};
 
 export class ConsoleStream {
   verbose: boolean;

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -33,7 +33,7 @@ export type ConsoleStreamParams = {
   verbose?: boolean,
 };
 
-export type ConsoleFormatParams = {
+export type BunyanLogEntry = {
   name: string,
   msg: string,
   level: BunyanLogLevel,
@@ -69,7 +69,7 @@ export class ConsoleStream {
     this.capturedMessages = [];
   }
 
-  format({name, msg, level}: ConsoleFormatParams): string {
+  format({name, msg, level}: BunyanLogEntry): string {
     const prefix = this.verbose ? `[${name}][${nameFromLevel[level]}] ` : '';
     return `${prefix}${msg}\n`;
   }
@@ -79,7 +79,7 @@ export class ConsoleStream {
   }
 
   write(
-    packet: ConsoleFormatParams,
+    packet: BunyanLogEntry,
     {localProcess=process}: ConsoleOptions = {}
   ): void {
     const thisLevel = this.verbose ? bunyan.TRACE : bunyan.INFO;

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -4,8 +4,6 @@ import bunyan, {nameFromLevel, createLogger as defaultLogCreator}
 
 // Flow types
 
-import type {Logger} from 'bunyan';
-
 import type {Writable} from 'stream';
 import type {WriteStream} from 'tty';
 
@@ -19,7 +17,7 @@ export type ConsoleOptions = {
 
 // Bunyan-related types
 
-export type TRACE = 10
+export type TRACE = 10;
 export type DEBUG = 20;
 export type INFO = 30;
 export type WARN = 40;
@@ -37,6 +35,13 @@ export type BunyanLogEntry = {
   name: string,
   msg: string,
   level: BunyanLogLevel,
+};
+
+export type Logger = {
+  debug: (msg: string) => void,
+  error: (msg: string) => void,
+  info: (msg: string) => void,
+  warn: (msg: string) => void,
 };
 
 // Module internals & exports
@@ -65,7 +70,7 @@ export class ConsoleStream {
     packet: BunyanLogEntry,
     {localProcess=process}: ConsoleOptions = {}
   ): void {
-    const thisLevel = this.verbose ? bunyan.TRACE : bunyan.INFO;
+    const thisLevel: BunyanLogLevel = this.verbose ? bunyan.TRACE : bunyan.INFO;
     if (packet.level >= thisLevel) {
       const msg = this.format(packet);
       if (this.isCapturing) {

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -13,7 +13,7 @@ export type FakeProcess = {
   stdout: Writable | WriteStream;
 };
 
-export type ConsoleExtraParams = {
+export type ConsoleOptions = {
   localProcess?: FakeProcess,
 };
 
@@ -52,7 +52,7 @@ export type CreateBunyanLogParams = {
 
 export type CreateBunyanLogFn = (params: CreateBunyanLogParams) => Logger;
 
-export type CreateLoggerExtraParams = {
+export type CreateLoggerOptions = {
   createBunyanLog: CreateBunyanLogFn,
 };
 
@@ -80,7 +80,7 @@ export class ConsoleStream {
 
   write(
     packet: ConsoleFormatParams,
-    {localProcess=process}: ConsoleExtraParams = {}
+    {localProcess=process}: ConsoleOptions = {}
   ): void {
     const thisLevel = this.verbose ? bunyan.TRACE : bunyan.INFO;
     if (packet.level >= thisLevel) {
@@ -102,7 +102,7 @@ export class ConsoleStream {
     this.capturedMessages = [];
   }
 
-  flushCapturedLogs({localProcess=process}: ConsoleExtraParams = {}) {
+  flushCapturedLogs({localProcess=process}: ConsoleOptions = {}) {
     for (let msg of this.capturedMessages) {
       localProcess.stdout.write(msg);
     }
@@ -115,7 +115,7 @@ export const consoleStream = new ConsoleStream();
 
 export function createLogger(
   filename: string,
-  {createBunyanLog=defaultLogCreator}: CreateLoggerExtraParams = {}
+  {createBunyanLog=defaultLogCreator}: CreateLoggerOptions = {}
 ): Logger {
   return createBunyanLog({
     // Strip the leading src/ from file names (which is in all file names) to

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -39,24 +39,7 @@ export type BunyanLogEntry = {
   level: BunyanLogLevel,
 };
 
-export type BunyanStreamConfig = {
-  type: string,
-  stream: ConsoleStream,
-};
-
-export type CreateBunyanLogParams = {
-  name: string,
-  level: BunyanLogLevel,
-  streams: Array<BunyanStreamConfig>,
-};
-
-export type CreateBunyanLogFn = (params: CreateBunyanLogParams) => Logger;
-
-export type CreateLoggerOptions = {
-  createBunyanLog: CreateBunyanLogFn,
-};
-
-// Exports
+// Module internals & exports
 
 export class ConsoleStream {
   verbose: boolean;
@@ -112,6 +95,22 @@ export class ConsoleStream {
 
 export const consoleStream = new ConsoleStream();
 
+export type BunyanStreamConfig = {
+  type: string,
+  stream: ConsoleStream,
+};
+
+export type CreateBunyanLogParams = {
+  name: string,
+  level: BunyanLogLevel,
+  streams: Array<BunyanStreamConfig>,
+};
+
+export type CreateBunyanLogFn = (params: CreateBunyanLogParams) => Logger;
+
+export type CreateLoggerOptions = {
+  createBunyanLog: CreateBunyanLogFn,
+};
 
 export function createLogger(
   filename: string,

--- a/src/util/manifest.js
+++ b/src/util/manifest.js
@@ -7,9 +7,18 @@ import {createLogger} from './logger';
 
 const log = createLogger(__filename);
 
+// Flow Types
 
-export default function getValidatedManifest(sourceDir: string)
-    : Promise<Object> {
+export type ExtensionManifest = {
+  name: string,
+  version: string,
+};
+
+// Exports
+
+export default function getValidatedManifest(
+  sourceDir: string
+): Promise<ExtensionManifest> {
   let manifestFile = path.join(sourceDir, 'manifest.json');
   log.debug(`Validating manifest at ${manifestFile}`);
   return fs.readFile(manifestFile)
@@ -50,7 +59,7 @@ export default function getValidatedManifest(sourceDir: string)
 }
 
 
-export function getManifestId(manifestData: Object): string|void {
+export function getManifestId(manifestData: ExtensionManifest): string|void {
   return manifestData.applications ?
     manifestData.applications.gecko.id : undefined;
 }

--- a/src/util/manifest.js
+++ b/src/util/manifest.js
@@ -14,7 +14,7 @@ export type ExtensionManifest = {
   version: string,
 };
 
-// Exports
+// Module internals & exports
 
 export default function getValidatedManifest(
   sourceDir: string

--- a/src/util/manifest.js
+++ b/src/util/manifest.js
@@ -5,16 +5,16 @@ import {fs} from 'mz';
 import {InvalidManifest} from '../errors';
 import {createLogger} from './logger';
 
+
 const log = createLogger(__filename);
 
-// Flow Types
+
+// getValidatedManifest helper types and implementation
 
 export type ExtensionManifest = {
   name: string,
   version: string,
 };
-
-// Module internals & exports
 
 export default function getValidatedManifest(
   sourceDir: string
@@ -58,6 +58,8 @@ export default function getValidatedManifest(
     });
 }
 
+
+// getManifestId helper implementation.
 
 export function getManifestId(manifestData: ExtensionManifest): string|void {
   return manifestData.applications ?

--- a/src/util/manifest.js
+++ b/src/util/manifest.js
@@ -59,8 +59,6 @@ export default function getValidatedManifest(
 }
 
 
-// getManifestId helper implementation.
-
 export function getManifestId(manifestData: ExtensionManifest): string|void {
   return manifestData.applications ?
     manifestData.applications.gecko.id : undefined;

--- a/src/util/temp-dir.js
+++ b/src/util/temp-dir.js
@@ -22,7 +22,7 @@ const log = createLogger(__filename);
  * );
  *
  */
-export function withTempDir(makePromise: Function): Promise<*> {
+export function withTempDir(makePromise: Function): Promise<any> {
   let tmpDir = new TempDir();
   return tmpDir.create()
     .then(() => {

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -5,9 +5,11 @@ import debounce from 'debounce';
 import {createLogger} from './util/logger';
 import {FileFilter} from './cmd/build';
 
+
 const log = createLogger(__filename);
 
-// Flow Types
+
+// onSourceChange types and implementation
 
 export type ShouldWatchFn = (filePath: string) => boolean;
 
@@ -20,14 +22,12 @@ export type OnSourceChangeParams = {
   shouldWatchFile?: ShouldWatchFn,
 };
 
-export type OnSourceChangeFn = (params: OnSourceChangeParams) => Watchpack;
-
-// Module implementation & exports
-
 // NOTE: this fix an issue with flow and default exports (which currently
 // lose their type signatures) by explicitly declare the default export
 // signature. Reference: https://github.com/facebook/flow/issues/449
 declare function exports(params: OnSourceChangeParams): Watchpack;
+
+export type OnSourceChangeFn = (params: OnSourceChangeParams) => Watchpack;
 
 export default function onSourceChange(
   {sourceDir, artifactsDir, onChange, shouldWatchFile}: OnSourceChangeParams
@@ -50,6 +50,9 @@ export default function onSourceChange(
   process.on('SIGINT', () => watcher.close());
   return watcher;
 }
+
+
+// proxyFileChanges types and implementation.
 
 export type ProxyFileChangesParams = {
   artifactsDir: string,

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -32,7 +32,7 @@ export type OnSourceChangeFn = (params: OnSourceChangeParams) => Watchpack;
 // NOTE: this fix an issue with flow and default exports (which currently
 // lose their type signatures) by explicitly declare the default export
 // signature. Reference: https://github.com/facebook/flow/issues/449
-declare function exports(params: OnSourceChangeParams): Watchpack; // eslint-disable-line no-unused-vars
+declare function exports(params: OnSourceChangeParams): Watchpack;
 
 // Exports
 

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -7,9 +7,38 @@ import {FileFilter} from './cmd/build';
 
 const log = createLogger(__filename);
 
+// Flow Types
+
+export type ShouldWatchFn = (filePath: string) => boolean;
+
+export type OnChangeFn = () => any;
+
+export type OnSourceChangeParams = {
+  sourceDir: string,
+  artifactsDir: string,
+  onChange: OnChangeFn,
+  shouldWatchFile?: ShouldWatchFn,
+};
+
+export type ProxyFileChangesParams = {
+  artifactsDir: string,
+  onChange: OnChangeFn,
+  filePath: string,
+  shouldWatchFile?: ShouldWatchFn,
+};
+
+export type OnSourceChangeFn = (params: OnSourceChangeParams) => Watchpack;
+
+// NOTE: this fix an issue with flow and default exports (which currently
+// lose their type signatures) by explicitly declare the default export
+// signature. Reference: https://github.com/facebook/flow/issues/449
+declare function exports(params: OnSourceChangeParams): Watchpack; // eslint-disable-line no-unused-vars
+
+// Exports
 
 export default function onSourceChange(
-    {sourceDir, artifactsDir, onChange, shouldWatchFile}: Object): Watchpack {
+  {sourceDir, artifactsDir, onChange, shouldWatchFile}: OnSourceChangeParams
+): Watchpack {
   // TODO: For network disks, we would need to add {poll: true}.
   const watcher = new Watchpack();
 
@@ -31,7 +60,8 @@ export default function onSourceChange(
 
 
 export function proxyFileChanges(
-    {artifactsDir, onChange, filePath, shouldWatchFile}: Object) {
+  {artifactsDir, onChange, filePath, shouldWatchFile}: ProxyFileChangesParams
+): void {
   if (!shouldWatchFile) {
     const fileFilter = new FileFilter();
     shouldWatchFile = (...args) => fileFilter.wantFile(...args);

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -20,21 +20,14 @@ export type OnSourceChangeParams = {
   shouldWatchFile?: ShouldWatchFn,
 };
 
-export type ProxyFileChangesParams = {
-  artifactsDir: string,
-  onChange: OnChangeFn,
-  filePath: string,
-  shouldWatchFile?: ShouldWatchFn,
-};
-
 export type OnSourceChangeFn = (params: OnSourceChangeParams) => Watchpack;
+
+// Module implementation & exports
 
 // NOTE: this fix an issue with flow and default exports (which currently
 // lose their type signatures) by explicitly declare the default export
 // signature. Reference: https://github.com/facebook/flow/issues/449
 declare function exports(params: OnSourceChangeParams): Watchpack;
-
-// Exports
 
 export default function onSourceChange(
   {sourceDir, artifactsDir, onChange, shouldWatchFile}: OnSourceChangeParams
@@ -58,6 +51,12 @@ export default function onSourceChange(
   return watcher;
 }
 
+export type ProxyFileChangesParams = {
+  artifactsDir: string,
+  onChange: OnChangeFn,
+  filePath: string,
+  shouldWatchFile?: ShouldWatchFn,
+};
 
 export function proxyFileChanges(
   {artifactsDir, onChange, filePath, shouldWatchFile}: ProxyFileChangesParams

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -134,7 +134,8 @@ export function makeSureItFails(): Function {
  * assert.equal(fakeProcess.exit.called, true);
  *
  */
-export function fake(original: Object, methods: Object = {}): Object {
+ // $FLOW_IGNORE: fake can return any kind of object and fake a defined set of methods for testing.
+export function fake<T>(original: Object, methods: Object = {}): T {
   var stub = {};
 
   // Provide stubs for all original members:

--- a/tests/test-cmd/test.lint.js
+++ b/tests/test-cmd/test.lint.js
@@ -22,6 +22,7 @@ describe('lint', () => {
       createLinter,
       runLinter,
       lint: ({...args}) => {
+        // $FLOW_IGNORE: type checks skipped for testing purpose
         return defaultLintCommand(args, {createLinter, fileFilter});
       },
     };
@@ -85,10 +86,15 @@ describe('lint', () => {
   it('passes through linter configuration', () => {
     const {lint, createLinter} = setUp();
     return lint({
+      // $FLOW_IGNORE: wrong type used for testing purpose
       pretty: 'pretty flag',
+      // $FLOW_IGNORE: wrong type used for testing purpose
       metadata: 'metadata flag',
+      // $FLOW_IGNORE: wrong type used for testing purpose
       output: 'output value',
+      // $FLOW_IGNORE: wrong type used for testing purpose
       boring: 'boring flag',
+      // $FLOW_IGNORE: wrong type used for testing purpose
       selfHosted: 'self-hosted flag',
     }).then(() => {
       const config = createLinter.firstCall.args[0].config;

--- a/tests/test-cmd/test.run.js
+++ b/tests/test-cmd/test.run.js
@@ -281,6 +281,7 @@ describe('run', () => {
       const args = {
         addonId: 'some-addon@test-suite',
         client,
+        // $FLOW_IGNORE: fake a Firefox ChildProcess using an EventEmitter for testing reasons.
         firefox: new EventEmitter(),
         profile: {},
         sourceDir: '/path/to/extension/source',

--- a/tests/test-cmd/test.run.js
+++ b/tests/test-cmd/test.run.js
@@ -186,10 +186,16 @@ describe('run', () => {
 
       return cmd.run({noReload: false})
         .catch((error) => error)
-        .then((error) => assert.equal(
-          error.message,
-          'Unexpected missing addonId in the installAsTemporaryAddon result'
-        ));
+        .then((error) => {
+          assert.equal(
+            error instanceof WebExtError,
+            true
+          );
+          assert.equal(
+            error.message,
+            'Unexpected missing addonId in the installAsTemporaryAddon result'
+          );
+        });
     }
   );
 

--- a/tests/test-cmd/test.run.js
+++ b/tests/test-cmd/test.run.js
@@ -21,11 +21,15 @@ const log = createLogger(__filename);
 const tempInstallResult = {
   addon: {id: 'some-addon@test-suite'},
 };
+// Fake missing addon id result for client.installTemporaryAddon
+const tempInstallResultMissingAddonId = {
+  addon: {id: null},
+};
 
 
 describe('run', () => {
 
-  function prepareRun() {
+  function prepareRun(fakeInstallResult) {
     const sourceDir = fixturePath('minimal-web-ext');
     let argv = {
       artifactsDir: path.join(sourceDir, 'web-ext-artifacts'),
@@ -36,7 +40,10 @@ describe('run', () => {
       firefox: getFakeFirefox(),
       firefoxClient: sinon.spy(() => {
         return Promise.resolve(fake(RemoteFirefox.prototype, {
-          installTemporaryAddon: () => Promise.resolve(tempInstallResult),
+          installTemporaryAddon: () =>
+            Promise.resolve(
+              fakeInstallResult || tempInstallResult
+            ),
         }));
       }),
       reloadStrategy: sinon.spy(() => {
@@ -172,6 +179,19 @@ describe('run', () => {
       assert.equal(args.addonId, tempInstallResult.addon.id);
     });
   });
+
+  it('raise an error on addonId missing from installTemporaryAddon result',
+    () => {
+      const cmd = prepareRun(tempInstallResultMissingAddonId);
+
+      return cmd.run({noReload: false})
+        .catch((error) => error)
+        .then((error) => assert.equal(
+          error.message,
+          'Unexpected missing addonId in the installAsTemporaryAddon result'
+        ));
+    }
+  );
 
   it('will not reload when using --pre-install', () => {
     const cmd = prepareRun();

--- a/tests/test-firefox/test.preferences.js
+++ b/tests/test-firefox/test.preferences.js
@@ -27,6 +27,7 @@ describe('firefox/preferences', () => {
     });
 
     it('throws an error for unsupported apps', () => {
+      // $FLOW_IGNORE: ignore type errors on testing nonexistent 'thunderbird' prefs
       assert.throws(() => getPrefs('thunderbird'),
                     WebExtError, /Unsupported application: thunderbird/);
     });

--- a/tests/test-firefox/test.remote.js
+++ b/tests/test-firefox/test.remote.js
@@ -172,6 +172,7 @@ describe('firefox.remote', () => {
         const stubResponse = {requestTypes: ['reload']};
 
         const conn = makeInstance();
+        // $FLOW_IGNORE: override class method for testing reasons.
         conn.addonRequest = sinon.spy(() => Promise.resolve(stubResponse));
 
         return conn.checkForAddonReloading(addon)
@@ -190,6 +191,7 @@ describe('firefox.remote', () => {
         const addon = fakeAddon();
         const stubResponse = {requestTypes: ['install']};
         const conn = makeInstance();
+        // $FLOW_IGNORE: override class method for testing reasons.
         conn.addonRequest = () => Promise.resolve(stubResponse);
 
         return conn.checkForAddonReloading(addon)
@@ -202,6 +204,7 @@ describe('firefox.remote', () => {
       it('only checks for reloading once', () => {
         const addon = fakeAddon();
         const conn = makeInstance();
+        // $FLOW_IGNORE: override class method for testing reasons.
         conn.addonRequest =
           sinon.spy(() => Promise.resolve({requestTypes: ['reload']}));
         return conn.checkForAddonReloading(addon)
@@ -285,8 +288,11 @@ describe('firefox.remote', () => {
       it('asks the actor to reload the add-on', () => {
         const addon = fakeAddon();
         const conn = makeInstance();
+        // $FLOW_IGNORE: override class method for testing reasons.
         conn.getInstalledAddon = sinon.spy(() => Promise.resolve(addon));
+        // $FLOW_IGNORE: override class method for testing reasons.
         conn.checkForAddonReloading = (addon) => Promise.resolve(addon);
+        // $FLOW_IGNORE: override class method for testing reasons.
         conn.addonRequest = sinon.spy(() => Promise.resolve({}));
 
         return conn.reloadAddon('some-id')
@@ -304,7 +310,9 @@ describe('firefox.remote', () => {
       it('makes sure the addon can be reloaded', () => {
         const addon = fakeAddon();
         const conn = makeInstance();
+        // $FLOW_IGNORE: override class method for testing reasons.
         conn.getInstalledAddon = () => Promise.resolve(addon);
+        // $FLOW_IGNORE: override class method for testing reasons.
         conn.checkForAddonReloading =
           sinon.spy((addon) => Promise.resolve(addon));
 

--- a/tests/test-util/test.logger.js
+++ b/tests/test-util/test.logger.js
@@ -3,6 +3,7 @@ import {it, describe} from 'mocha';
 import {assert} from 'chai';
 import bunyan from 'bunyan';
 import sinon from 'sinon';
+import {WriteStream} from 'tty';
 
 import {createLogger, ConsoleStream} from '../../src/util/logger';
 
@@ -30,11 +31,17 @@ describe('logger', () => {
       };
     }
 
+    // NOTE: create a fake process that makes flow happy.
     function fakeProcess() {
+      class FakeWritableStream extends WriteStream {
+        write(): boolean { return true; }
+      }
+
+      let fakeWritableStream = new FakeWritableStream();
+      sinon.spy(fakeWritableStream, 'write');
+
       return {
-        stdout: {
-          write: sinon.spy(() => {}),
-        },
+        stdout: fakeWritableStream,
       };
     }
 

--- a/tests/test-util/test.logger.js
+++ b/tests/test-util/test.logger.js
@@ -72,6 +72,7 @@ describe('logger', () => {
     it('does not log debug packets unless verbose', () => {
       const log = new ConsoleStream({verbose: false});
       const localProcess = fakeProcess();
+      // $FLOW_IGNORE: fake process for testing reasons.
       log.write(packet({level: bunyan.DEBUG}), {localProcess});
       assert.equal(localProcess.stdout.write.called, false);
     });
@@ -79,6 +80,7 @@ describe('logger', () => {
     it('does not log trace packets unless verbose', () => {
       const log = new ConsoleStream({verbose: false});
       const localProcess = fakeProcess();
+      // $FLOW_IGNORE: fake process for testing reasons.
       log.write(packet({level: bunyan.TRACE}), {localProcess});
       assert.equal(localProcess.stdout.write.called, false);
     });
@@ -86,6 +88,7 @@ describe('logger', () => {
     it('logs debug packets when verbose', () => {
       const log = new ConsoleStream({verbose: true});
       const localProcess = fakeProcess();
+      // $FLOW_IGNORE: fake process for testing reasons.
       log.write(packet({level: bunyan.DEBUG}), {localProcess});
       assert.equal(localProcess.stdout.write.called, true);
     });
@@ -93,6 +96,7 @@ describe('logger', () => {
     it('logs trace packets when verbose', () => {
       const log = new ConsoleStream({verbose: true});
       const localProcess = fakeProcess();
+      // $FLOW_IGNORE: fake process for testing reasons.
       log.write(packet({level: bunyan.TRACE}), {localProcess});
       assert.equal(localProcess.stdout.write.called, true);
     });
@@ -100,8 +104,10 @@ describe('logger', () => {
     it('logs info packets when verbose or not', () => {
       const log = new ConsoleStream({verbose: false});
       const localProcess = fakeProcess();
+      // $FLOW_IGNORE: fake process for testing reasons.
       log.write(packet({level: bunyan.INFO}), {localProcess});
       log.makeVerbose();
+      // $FLOW_IGNORE: fake process for testing reasons.
       log.write(packet({level: bunyan.INFO}), {localProcess});
       assert.equal(localProcess.stdout.write.callCount, 2);
     });
@@ -111,9 +117,10 @@ describe('logger', () => {
       const localProcess = fakeProcess();
 
       log.startCapturing();
+      // $FLOW_IGNORE: fake process for testing reasons.
       log.write(packet({msg: 'message'}), {localProcess});
       assert.equal(localProcess.stdout.write.called, false);
-
+      // $FLOW_IGNORE: fake process for testing reasons.
       log.flushCapturedLogs({localProcess});
       assert.equal(localProcess.stdout.write.called, true);
       assert.equal(localProcess.stdout.write.firstCall.args[0],
@@ -125,11 +132,14 @@ describe('logger', () => {
       let localProcess = fakeProcess();
 
       log.startCapturing();
+      // $FLOW_IGNORE: fake process for testing reasons.
       log.write(packet(), {localProcess});
+      // $FLOW_IGNORE: fake process for testing reasons.
       log.flushCapturedLogs({localProcess});
 
       // Make sure there is nothing more to flush.
       localProcess = fakeProcess();
+      // $FLOW_IGNORE: fake process for testing reasons.
       log.flushCapturedLogs({localProcess});
       assert.equal(localProcess.stdout.write.callCount, 0);
     });
@@ -139,10 +149,12 @@ describe('logger', () => {
       let localProcess = fakeProcess();
 
       log.startCapturing();
+      // $FLOW_IGNORE: fake process for testing reasons.
       log.write(packet(), {localProcess});
       assert.equal(localProcess.stdout.write.callCount, 0);
 
       log.stopCapturing();
+      // $FLOW_IGNORE: fake process for testing reasons.
       log.write(packet(), {localProcess});
       assert.equal(localProcess.stdout.write.callCount, 1);
 
@@ -151,6 +163,7 @@ describe('logger', () => {
       log.startCapturing();
       log.write(packet());
       localProcess = fakeProcess();
+      // $FLOW_IGNORE: fake process for testing reasons.
       log.flushCapturedLogs({localProcess});
       assert.equal(localProcess.stdout.write.callCount, 1);
     });


### PR DESCRIPTION
In this PR there are the changes related to the additional flow type checking (that are currently part of #411) extracted and extended with much more flow types checks.

Once we complete this PR, #411 will be rebased on the final version of these changes and it will be limited to the introduction of the `async/await` syntax (with the additional safety net provided by the additional static analysis that flow will be able to provide).