### PR TITLE
fix: disabled caching during npm run lint

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,7 +35,7 @@ module.exports = function(grunt) {
   grunt.registerTask('test', [
     'build-tests',
     'mochaTest',
-    'lint',
+    'newer:eslint',
     'flowbin:check',
     'check-for-smoke',
   ]);
@@ -53,7 +53,7 @@ module.exports = function(grunt) {
       grunt.log.writeln('task skipped because this version of Node is too old');
     } else {
       grunt.task.run([
-        'newer:eslint',
+        'eslint',
       ]);
     }
   });

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,7 +1,6 @@
 /*eslint prefer-template: 0*/
 var path = require('path');
 var spawn = require('child_process').spawn;
-var semver = require('semver');
 
 module.exports = function(grunt) {
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,7 +35,7 @@ module.exports = function(grunt) {
   grunt.registerTask('test', [
     'build-tests',
     'mochaTest',
-    'newer:eslint',
+    'eslint',
     'flowbin:check',
     'check-for-smoke',
   ]);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -48,9 +48,6 @@ module.exports = function(grunt) {
   grunt.registerTask('lint', 'checks for syntax errors', function() {
     if (process.env.SKIP_LINT) {
       grunt.log.writeln('lint task skipped because of $SKIP_LINT');
-    } else if (semver.satisfies(process.version, '< 4.0.0')) {
-      // eslint now requires a new-ish Node.
-      grunt.log.writeln('task skipped because this version of Node is too old');
     } else {
       grunt.task.run([
         'eslint',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,7 +35,7 @@ module.exports = function(grunt) {
   grunt.registerTask('test', [
     'build-tests',
     'mochaTest',
-    'eslint',
+    'lint',
     'flowbin:check',
     'check-for-smoke',
   ]);

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "load-grunt-tasks": "3.5.2",
     "mocha": "3.0.2",
     "mocha-multi": "0.9.1",
-    "semver": "5.3.0",
     "sinon": "1.17.5",
     "webpack": "1.13.1",
     "webpack-dev-server": "1.14.1",

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -16,7 +16,7 @@ module.exports = {
       'flowbin:status',
       'build-tests',
       'mochaTest',
-      'lint',
+      'newer:eslint',
     ],
   },
 };


### PR DESCRIPTION
Fixes #339 
The `.cache` directory is no longer created while running `npm run lint`