### PR TITLE
fix: --firefox-binary to --firefox

### DIFF
--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -62,7 +62,7 @@ export function defaultWatcherCreator(
 
 export type ReloadStrategyParams = {
   addonId: string,
-  firefox: FirefoxProcess,
+  firefoxApp: FirefoxProcess,
   client: RemoteFirefox,
   profile: FirefoxProfile,
   sourceDir: string,

--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -62,7 +62,7 @@ export function defaultWatcherCreator(
 
 export type ReloadStrategyParams = {
   addonId: string,
-  firefoxApp: FirefoxProcess,
+  firefoxProcess: FirefoxProcess,
   client: RemoteFirefox,
   profile: FirefoxProfile,
   sourceDir: string,
@@ -75,7 +75,7 @@ export type ReloadStrategyOptions = {
 
 export function defaultReloadStrategy(
   {
-    addonId, firefoxApp, client, profile, sourceDir, artifactsDir,
+    addonId, firefoxProcess, client, profile, sourceDir, artifactsDir,
   }: ReloadStrategyParams,
   {
     createWatcher=defaultWatcherCreator,
@@ -83,7 +83,7 @@ export function defaultReloadStrategy(
 ): void {
   let watcher: Watchpack;
 
-  firefoxApp.on('close', () => {
+  firefoxProcess.on('close', () => {
     client.disconnect();
     watcher.close();
   });
@@ -261,7 +261,7 @@ export default function run(
         log.debug(
           `Reloading extension when the source changes; id=${addonId}`);
         reloadStrategy({
-          firefoxApp: runningFirefox,
+          firefoxProcess: runningFirefox,
           profile, client, sourceDir, artifactsDir, addonId,
         });
       }

--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -75,7 +75,7 @@ export type ReloadStrategyOptions = {
 
 export function defaultReloadStrategy(
   {
-    addonId, firefox, client, profile, sourceDir, artifactsDir,
+    addonId, firefoxApp, client, profile, sourceDir, artifactsDir,
   }: ReloadStrategyParams,
   {
     createWatcher=defaultWatcherCreator,
@@ -83,7 +83,7 @@ export function defaultReloadStrategy(
 ): void {
   let watcher: Watchpack;
 
-  firefox.on('close', () => {
+  firefoxApp.on('close', () => {
     client.disconnect();
     watcher.close();
   });

--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -146,25 +146,25 @@ export function defaultFirefoxClient(
 export type CmdRunParams = {
   sourceDir: string,
   artifactsDir: string,
-  firefoxBinary: string,
+  firefox: string,
   firefoxProfile: string,
   preInstall: boolean,
   noReload: boolean,
 };
 
 export type CmdRunOptions = {
-  firefox: typeof defaultFirefox,
+  firefoxApp: typeof defaultFirefox,
   firefoxClient: typeof defaultFirefoxClient,
   reloadStrategy: typeof defaultReloadStrategy,
 };
 
 export default function run(
   {
-    sourceDir, artifactsDir, firefoxBinary, firefoxProfile,
+    sourceDir, artifactsDir, firefox, firefoxProfile,
     preInstall=false, noReload=false,
   }: CmdRunParams,
   {
-    firefox=defaultFirefox,
+    firefoxApp=defaultFirefox,
     firefoxClient=defaultFirefoxClient,
     reloadStrategy=defaultReloadStrategy,
   }: CmdRunOptions = {}): Promise<Object> {
@@ -190,8 +190,8 @@ export default function run(
     .then((manifestData) => {
       return new ExtensionRunner({
         sourceDir,
+        firefoxApp,
         firefox,
-        firefoxBinary,
         manifestData,
         profilePath: firefoxProfile,
       });
@@ -261,11 +261,11 @@ export default function run(
         log.debug(
           `Reloading extension when the source changes; id=${addonId}`);
         reloadStrategy({
-          firefox: runningFirefox,
+          firefoxApp: runningFirefox,
           profile, client, sourceDir, artifactsDir, addonId,
         });
       }
-      return firefox;
+      return firefoxApp;
     });
 }
 
@@ -276,39 +276,39 @@ export type ExtensionRunnerParams = {
   sourceDir: string,
   manifestData: ExtensionManifest,
   profilePath: string,
-  firefox: typeof defaultFirefox,
-  firefoxBinary: string,
+  firefoxApp: typeof defaultFirefox,
+  firefox: string,
 };
 
 export class ExtensionRunner {
   sourceDir: string;
   manifestData: ExtensionManifest;
   profilePath: string;
-  firefox: typeof defaultFirefox;
-  firefoxBinary: string;
+  firefoxApp: typeof defaultFirefox;
+  firefox: string;
 
   constructor(
     {
-      firefox, sourceDir, manifestData,
-      profilePath, firefoxBinary,
+      firefoxApp, sourceDir, manifestData,
+      profilePath, firefox,
     }: ExtensionRunnerParams
   ) {
     this.sourceDir = sourceDir;
     this.manifestData = manifestData;
     this.profilePath = profilePath;
+    this.firefoxApp = firefoxApp;
     this.firefox = firefox;
-    this.firefoxBinary = firefoxBinary;
   }
 
   getProfile(): Promise<FirefoxProfile> {
-    const {firefox, profilePath} = this;
+    const {firefoxApp, profilePath} = this;
     return new Promise((resolve) => {
       if (profilePath) {
         log.debug(`Copying Firefox profile from ${profilePath}`);
-        resolve(firefox.copyProfile(profilePath));
+        resolve(firefoxApp.copyProfile(profilePath));
       } else {
         log.debug('Creating new Firefox profile');
-        resolve(firefox.createProfile());
+        resolve(firefoxApp.createProfile());
       }
     });
   }
@@ -320,8 +320,8 @@ export class ExtensionRunner {
   }
 
   installAsProxy(profile: FirefoxProfile): Promise<string|void> {
-    const {firefox, sourceDir, manifestData} = this;
-    return firefox.installExtension(
+    const {firefoxApp, sourceDir, manifestData} = this;
+    return firefoxApp.installExtension(
       {
         manifestData,
         asProxy: true,
@@ -332,7 +332,7 @@ export class ExtensionRunner {
   }
 
   run(profile: FirefoxProfile): Promise<FirefoxProcess> {
-    const {firefox, firefoxBinary} = this;
-    return firefox.run(profile, {firefoxBinary});
+    const {firefoxApp, firefox} = this;
+    return firefoxApp.run(profile, {firefox});
   }
 }

--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -1,5 +1,5 @@
 /* @flow */
-import * as defaultFirefox from '../firefox';
+import * as defaultFirefoxApp from '../firefox';
 import defaultFirefoxConnector from '../firefox/remote';
 import {
   onlyInstancesOf, onlyErrorsWithCode, RemoteTempInstallNotSupported,
@@ -153,7 +153,7 @@ export type CmdRunParams = {
 };
 
 export type CmdRunOptions = {
-  firefoxApp: typeof defaultFirefox,
+  firefoxApp: typeof defaultFirefoxApp,
   firefoxClient: typeof defaultFirefoxClient,
   reloadStrategy: typeof defaultReloadStrategy,
 };
@@ -164,7 +164,7 @@ export default function run(
     preInstall=false, noReload=false,
   }: CmdRunParams,
   {
-    firefoxApp=defaultFirefox,
+    firefoxApp=defaultFirefoxApp,
     firefoxClient=defaultFirefoxClient,
     reloadStrategy=defaultReloadStrategy,
   }: CmdRunOptions = {}): Promise<Object> {
@@ -276,7 +276,7 @@ export type ExtensionRunnerParams = {
   sourceDir: string,
   manifestData: ExtensionManifest,
   profilePath: string,
-  firefoxApp: typeof defaultFirefox,
+  firefoxApp: typeof defaultFirefoxApp,
   firefox: string,
 };
 
@@ -284,7 +284,7 @@ export class ExtensionRunner {
   sourceDir: string;
   manifestData: ExtensionManifest;
   profilePath: string;
-  firefoxApp: typeof defaultFirefox;
+  firefoxApp: typeof defaultFirefoxApp;
   firefox: string;
 
   constructor(

--- a/src/program.js
+++ b/src/program.js
@@ -216,7 +216,8 @@ Example: $0 --help run.
         },
       })
     .command('run', 'Run the web extension', commands.run, {
-      'firefox-binary': {
+      'firefox': {
+        alias: 'f',
         describe: 'Path to a Firefox executable such as firefox-bin. ' +
                   'If not specified, the default Firefox will be used.',
         demand: false,

--- a/tests/test-cmd/test.run.js
+++ b/tests/test-cmd/test.run.js
@@ -10,7 +10,7 @@ import {onlyInstancesOf, WebExtError, RemoteTempInstallNotSupported}
 import run, {
   defaultFirefoxClient, defaultWatcherCreator, defaultReloadStrategy,
 } from '../../src/cmd/run';
-import * as firefoxApp from '../../src/firefox';
+import * as defaultFirefoxApp from '../../src/firefox';
 import {RemoteFirefox} from '../../src/firefox/remote';
 import {TCPConnectError, fakeFirefoxClient, makeSureItFails, fake, fixturePath}
   from '../helpers';
@@ -69,7 +69,7 @@ describe('run', () => {
       run: () => Promise.resolve(),
       ...implementations,
     };
-    return fake(firefoxApp, allImplementations);
+    return fake(defaultFirefoxApp, allImplementations);
   }
 
   it('installs and runs the extension', () => {

--- a/tests/test-cmd/test.run.js
+++ b/tests/test-cmd/test.run.js
@@ -10,7 +10,7 @@ import {onlyInstancesOf, WebExtError, RemoteTempInstallNotSupported}
 import run, {
   defaultFirefoxClient, defaultWatcherCreator, defaultReloadStrategy,
 } from '../../src/cmd/run';
-import * as firefox from '../../src/firefox';
+import * as firefoxApp from '../../src/firefox';
 import {RemoteFirefox} from '../../src/firefox/remote';
 import {TCPConnectError, fakeFirefoxClient, makeSureItFails, fake, fixturePath}
   from '../helpers';
@@ -37,7 +37,7 @@ describe('run', () => {
       noReload: true,
     };
     let options = {
-      firefox: getFakeFirefox(),
+      firefoxApp: getFakeFirefox(),
       firefoxClient: sinon.spy(() => {
         return Promise.resolve(fake(RemoteFirefox.prototype, {
           installTemporaryAddon: () =>
@@ -69,7 +69,7 @@ describe('run', () => {
       run: () => Promise.resolve(),
       ...implementations,
     };
-    return fake(firefox, allImplementations);
+    return fake(firefoxApp, allImplementations);
   }
 
   it('installs and runs the extension', () => {
@@ -77,7 +77,7 @@ describe('run', () => {
     let profile = {};
 
     const cmd = prepareRun();
-    const {firefox} = cmd.options;
+    const {firefoxApp} = cmd.options;
     const firefoxClient = fake(RemoteFirefox.prototype, {
       installTemporaryAddon: () => Promise.resolve(tempInstallResult),
     });
@@ -91,8 +91,8 @@ describe('run', () => {
       assert.equal(install.called, true);
       assert.equal(install.firstCall.args[0], cmd.argv.sourceDir);
 
-      assert.equal(firefox.run.called, true);
-      assert.deepEqual(firefox.run.firstCall.args[0], profile);
+      assert.equal(firefoxApp.run.called, true);
+      assert.deepEqual(firefoxApp.run.firstCall.args[0], profile);
     });
   });
 
@@ -114,26 +114,26 @@ describe('run', () => {
   });
 
   it('passes a custom Firefox binary when specified', () => {
-    const firefoxBinary = '/pretend/path/to/Firefox/firefox-bin';
+    const firefox = '/pretend/path/to/Firefox/firefox-bin';
     const cmd = prepareRun();
-    const {firefox} = cmd.options;
+    const {firefoxApp} = cmd.options;
 
-    return cmd.run({firefoxBinary}).then(() => {
-      assert.equal(firefox.run.called, true);
-      assert.equal(firefox.run.firstCall.args[1].firefoxBinary,
-                   firefoxBinary);
+    return cmd.run({firefox}).then(() => {
+      assert.equal(firefoxApp.run.called, true);
+      assert.equal(firefoxApp.run.firstCall.args[1].firefox,
+                   firefox);
     });
   });
 
   it('passes a custom Firefox profile when specified', () => {
     const firefoxProfile = '/pretend/path/to/firefox/profile';
     const cmd = prepareRun();
-    const {firefox} = cmd.options;
+    const {firefoxApp} = cmd.options;
 
     return cmd.run({firefoxProfile}).then(() => {
-      assert.equal(firefox.createProfile.called, false);
-      assert.equal(firefox.copyProfile.called, true);
-      assert.equal(firefox.copyProfile.firstCall.args[0],
+      assert.equal(firefoxApp.createProfile.called, false);
+      assert.equal(firefoxApp.copyProfile.called, true);
+      assert.equal(firefoxApp.copyProfile.firstCall.args[0],
                    firefoxProfile);
     });
   });
@@ -144,19 +144,19 @@ describe('run', () => {
       installTemporaryAddon: () => Promise.resolve(tempInstallResult),
     });
     const fakeProfile = {};
-    const firefox = getFakeFirefox({
+    const firefoxApp = getFakeFirefox({
       copyProfile: () => fakeProfile,
     });
     const {sourceDir} = cmd.argv;
 
     return cmd.run({preInstall: true}, {
-      firefox,
+      firefoxApp,
       firefoxClient: sinon.spy(() => Promise.resolve(firefoxClient)),
     }).then(() => {
-      assert.equal(firefox.installExtension.called, true);
+      assert.equal(firefoxApp.installExtension.called, true);
       assert.equal(firefoxClient.installTemporaryAddon.called, false);
 
-      const install = firefox.installExtension.firstCall.args[0];
+      const install = firefoxApp.installExtension.firstCall.args[0];
       assert.equal(install.asProxy, true);
       assert.equal(install.manifestData.applications.gecko.id,
                    'minimal-example@web-ext-test-suite');

--- a/tests/test-cmd/test.run.js
+++ b/tests/test-cmd/test.run.js
@@ -308,7 +308,7 @@ describe('run', () => {
         addonId: 'some-addon@test-suite',
         client,
         // $FLOW_IGNORE: fake a Firefox ChildProcess using an EventEmitter for testing reasons.
-        firefox: new EventEmitter(),
+        firefoxApp: new EventEmitter(),
         profile: {},
         sourceDir: '/path/to/extension/source',
         artifactsDir: '/path/to/web-ext-artifacts/',
@@ -330,9 +330,9 @@ describe('run', () => {
     }
 
     it('cleans up connections when firefox closes', () => {
-      const {firefox, client, watcher, reloadStrategy} = prepare();
+      const {firefoxApp, client, watcher, reloadStrategy} = prepare();
       reloadStrategy();
-      firefox.emit('close');
+      firefoxApp.emit('close');
       assert.equal(client.client.disconnect.called, true);
       assert.equal(watcher.close.called, true);
     });

--- a/tests/test-cmd/test.run.js
+++ b/tests/test-cmd/test.run.js
@@ -308,7 +308,7 @@ describe('run', () => {
         addonId: 'some-addon@test-suite',
         client,
         // $FLOW_IGNORE: fake a Firefox ChildProcess using an EventEmitter for testing reasons.
-        firefoxApp: new EventEmitter(),
+        firefoxProcess: new EventEmitter(),
         profile: {},
         sourceDir: '/path/to/extension/source',
         artifactsDir: '/path/to/web-ext-artifacts/',
@@ -330,9 +330,9 @@ describe('run', () => {
     }
 
     it('cleans up connections when firefox closes', () => {
-      const {firefoxApp, client, watcher, reloadStrategy} = prepare();
+      const {firefoxProcess, client, watcher, reloadStrategy} = prepare();
       reloadStrategy();
-      firefoxApp.emit('close');
+      firefoxProcess.emit('close');
       assert.equal(client.client.disconnect.called, true);
       assert.equal(watcher.close.called, true);
     });


### PR DESCRIPTION
Fixes #116 
For some reason, changing `firefox` to `firefoxApp` even on just [this](https://github.com/mozilla/web-ext/blob/master/src/cmd/run.js#L167) line makes the tests fail. 