### PR TITLE
fix: firefox binary path not passed in the run method exported by 'src/firefox/index'

### DIFF
--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -333,6 +333,6 @@ export class ExtensionRunner {
 
   run(profile: FirefoxProfile): Promise<FirefoxProcess> {
     const {firefoxApp, firefox} = this;
-    return firefoxApp.run(profile, {firefox});
+    return firefoxApp.run(profile, {firefoxBinary: firefox});
   }
 }

--- a/src/firefox/index.js
+++ b/src/firefox/index.js
@@ -74,7 +74,7 @@ export function defaultRemotePortFinder(
 // Declare the needed 'fx-runner' module flow types.
 
 export type FirefoxRunnerParams = {
-  binary?: string,
+  binary: ?string,
   profile?: string,
   'new-instance'?: boolean,
   'no-remote'?: boolean,
@@ -105,7 +105,7 @@ export type FirefoxRunnerFn =
 export type FirefoxRunOptions = {
   fxRunner?: FirefoxRunnerFn,
   findRemotePort?: RemotePortFinderFn,
-  firefoxBinary?: string,
+  firefoxBinary: ?string,
   binaryArgs?: Array<string>,
 };
 

--- a/tests/test-cmd/test.run.js
+++ b/tests/test-cmd/test.run.js
@@ -120,7 +120,7 @@ describe('run', () => {
 
     return cmd.run({firefox}).then(() => {
       assert.equal(firefoxApp.run.called, true);
-      assert.equal(firefoxApp.run.firstCall.args[1].firefox,
+      assert.equal(firefoxApp.run.firstCall.args[1].firefoxBinary,
                    firefox);
     });
   });


### PR DESCRIPTION
This PR fixes an issue with the optional Firefox binary path option and contains some tweaks to the related declared flow types, which shows how we can force flow to raise errors on this kind of issues (missing optional parameters in the `parameters` and `options` objects)