### PR TITLE
fix: show an error if an argument is passed to the lint command

### DIFF
--- a/src/program.js
+++ b/src/program.js
@@ -38,6 +38,7 @@ export class Program {
         return;
       }
       return yargs
+        .demand(0, 0, 'This command does not take any arguments')
         .strict()
         .exitProcess(this.shouldExitProgram)
         // Calling env() will be unnecessary after

--- a/tests/test.program.js
+++ b/tests/test.program.js
@@ -67,6 +67,16 @@ describe('program.Program', () => {
       });
   });
 
+  it('throws an error if sub-command is given an argument', () => {
+    const program = new Program(['thing', 'nope'])
+      .command('thing', '', () => {});
+    return run(program)
+      .then(makeSureItFails())
+      .catch((error) => {
+        assert.match(error.message, /This command does not take any arguments/);
+      });
+  });
+
   it('handles errors that have codes', () => {
 
     class ErrorWithCode extends Error {


### PR DESCRIPTION
Fixes #398 
Also added a test for checking if an argument is passed to a sub-command.