### PR TITLE
fix: print a development version when using a custom web-ext build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 - git checkout master
 - git checkout -
 script:
-- COVERAGE=y npm test
+- COVERAGE=y NODE_ENV=production npm test
 # Run changelog-lint but only on newer versions of Node (because of syntax errors)
 - if [[ ${TRAVIS_NODE_VERSION:0:1} -ge "4" ]]; then
     npm run changelog-lint;

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "eslint-plugin-flowtype": "2.18.2",
     "firefox-client": "0.3.0",
     "flow-bin": "0.32.0",
+    "git-rev-sync": "1.6.0",
     "grunt": "1.0.1",
     "grunt-contrib-clean": "1.0.0",
     "grunt-contrib-copy": "1.0.0",

--- a/src/program.js
+++ b/src/program.js
@@ -119,9 +119,14 @@ export class Program {
 
 
 export function defaultVersionGetter(absolutePackageDir: string): string {
-  let packageData: any = readFileSync(
+  if (process.env.NODE_ENV === 'production') {
+    let packageData: any = readFileSync(
     path.join(absolutePackageDir, 'package.json'));
-  return JSON.parse(packageData).version;
+    return JSON.parse(packageData).version;
+  } else {
+    var git = require('git-rev-sync');
+    return `${git.branch()}-${git.long()}`;
+  }
 }
 
 

--- a/tests/unit/test.program.js
+++ b/tests/unit/test.program.js
@@ -313,7 +313,8 @@ describe('program.main', () => {
 
 describe('program.defaultVersionGetter', () => {
 
-  it('returns the package version', () => {
+  it('returns the production package version', () => {
+    process.env.NODE_ENV = 'production';
     let root = path.join(__dirname, '..', '..');
     let pkgFile = path.join(root, 'package.json');
     return fs.readFile(pkgFile)
@@ -321,6 +322,15 @@ describe('program.defaultVersionGetter', () => {
         assert.equal(defaultVersionGetter(root),
                      JSON.parse(pkgData).version);
       });
+  });
+
+  it('returns the development package version', () => {
+    process.env.NODE_ENV = 'development';
+    let root = path.join(__dirname, '..', '..');
+    let git = require('git-rev-sync');
+    var devVersion = `${git.branch()}-${git.long()}`;
+    assert.equal(defaultVersionGetter(root),
+                     devVersion);
   });
 
 });


### PR DESCRIPTION
Fixes #481
