### PR TITLE
chore: Run Flow checks before running tests

### DIFF
--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -14,8 +14,8 @@ module.exports = {
     ],
     tasks: [
       'build-tests',
-      'mochaTest:unit',
       'flowbin:status',
+      'mochaTest:unit',
       'newer:eslint',
     ],
   },


### PR DESCRIPTION
Originally I thought Flow errors would get in the way and that tests should be your first point of feedback. I now think Flow errors are more helpful as early feedback. However, I still think lint errors should continue to come after test suite errors because those tend to be less crucial (like style nits).