### PR TITLE
Add feature to automatically generate updateManifest files from previous updateManifests

### DIFF
--- a/src/program.js
+++ b/src/program.js
@@ -215,6 +215,14 @@ Example: $0 --help run.
           describe: 'Number of milliseconds to wait before giving up',
           type: 'number',
         },
+        'update-link': {
+          describe:
+            'A URL to where your XPI files will be hosted. ' +
+            'ex: https://example.com/plugins/{xpiFileName} ' +
+            'if you select this option, an updateManifest ' +
+            'file will be generated ' +
+            'in the web-ext-artifacts folder',
+        },
       })
     .command('run', 'Run the web extension', commands.run, {
       'firefox': {

--- a/src/util/net.js
+++ b/src/util/net.js
@@ -1,0 +1,20 @@
+/* @flow */
+let http = require('http');
+let https = require('https');
+
+/**
+ * Fetch a file from a given url
+ * Returns a promise resolving to a tuple of [body, statusCode]
+ * Will throw an error on connection errors
+ */
+export function httpFetchFile(url: string): Promise<[string, number]> {
+  return new Promise((resolve, reject) => {
+    const lib = url.startsWith('https') ? https : http;
+    const request = lib.get(url, (response) => {
+      const body = [];
+      response.on('data', (chunk) => body.push(chunk));
+      response.on('end', () => resolve([body.join(''), response.statusCode]));
+    });
+    request.on('error', (err) => reject(err));
+  });
+}

--- a/tests/unit/test-cmd/test.sign.js
+++ b/tests/unit/test-cmd/test.sign.js
@@ -25,6 +25,7 @@ describe('sign', () => {
       apiSecret: 'AMO JWT secret',
       apiUrlPrefix: 'http://not-the-real-amo.com/api/v3',
       timeout: 999,
+      updateLink: '',
     };
 
     const buildResult = {


### PR DESCRIPTION
https://github.com/mozilla/web-ext/issues/507

This pull request is not ready. Tests need to be written, documentation needs to be updated, and a short code-review would be really helpful. I've done some ad-hoc testing with this command 

## Usage and testing:

This feature expects a manifest.json to exist. For it to generate a new updateManifest, an older one needs to exist on a web server somewhere. This is configured in the manifest.json's `applications.gecko.update_url` property. For my ad-hoc tests I've simply used my personal web-server.

## The command that I used

`./web-ext sign --api-key {YOUR-USER} --api-secret {YOUR-API} --api-url-prefix https://addons-dev.allizom.org/api/v3 --update-link https://example.com/{xpiFileName}`

## What I did

- [x] src/cmd/sign.js, add function generateNewUpdateManifest(...)
    - [x] Fetch an updateManifest.json from the location pointed to by manifest.applications.gecko.update_url
    - [x] Error messages (show the user an error message, and exit with error code)
        - [x] the old, fetched updateManifest.json is invalid
        - [x] unable to fetch updateManifest.json due to connection error
        - [x] argument passed to --update-link flag is invalid (== is missing `{xpiFileName}`)
    - [x] Warning messages
        - [x] The user passed the --update-link flag, but manifest.json lacks an applications.gecko.update_url property
        - [x] The fetched updateManifest.json had no previous release of an addon with this extension-id. Warn the user that if this should not be the case to check her extension-id
    - [x] Export the generated update manifest to the artifacts directory
- [x] all code complies to flow
- [x] all code complies to the linter
- [ ] test cases?
- [x] program.js, add --update-link param to `sign` .command
- [ ] documentation
    - [x] add description of the --update-link param
    - [ ] add explanation on how to auto-generate updateManifest

## What still needs to be done:

1. Automated tests
2. Code review
3. Additions to the official documentation