### PR TITLE
test: introducing flowtype exact object types

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "grunt-contrib-watch": "1.0.0",
     "grunt-coveralls": "1.0.1",
     "grunt-eslint": "19.0.0",
-    "grunt-flowbin": "0.0.6",
+    "grunt-flowbin": "rpl/grunt-flowbin#fix/flow-bin-dep",
     "grunt-mocha-test": "0.13.2",
     "grunt-newer": "1.2.0",
     "grunt-webpack": "1.0.15",

--- a/src/cmd/build.js
+++ b/src/cmd/build.js
@@ -26,16 +26,14 @@ import type {ExtensionManifest} from '../util/manifest';
 
 // defaultPackageCreator types and implementation.
 
-export type ExtensionBuildResult = {
-  extensionPath: string,
-};
+export type ExtensionBuildResult = {| extensionPath: string |};
 
-export type PackageCreatorParams = {
+export type PackageCreatorParams = {|
   manifestData?: ExtensionManifest,
   sourceDir: string,
   fileFilter: FileFilter,
   artifactsDir: string,
-};
+|};
 
 export type PackageCreatorFn =
     (params: PackageCreatorParams) => Promise<ExtensionBuildResult>;
@@ -72,18 +70,18 @@ async function defaultPackageCreator(
 
 // Build command types and implementation.
 
-export type BuildCmdParams = {
+export type BuildCmdParams = {|
   sourceDir: string,
   artifactsDir: string,
   asNeeded?: boolean,
-};
+|};
 
-export type BuildCmdOptions = {
+export type BuildCmdOptions = {|
   manifestData?: ExtensionManifest,
   fileFilter?: FileFilter,
   onSourceChange?: OnSourceChangeFn,
   packageCreator?: PackageCreatorFn,
-};
+|};
 
 export default async function build(
   {sourceDir, artifactsDir, asNeeded = false}: BuildCmdParams,
@@ -123,9 +121,9 @@ export default async function build(
 
 // FileFilter types and implementation.
 
-export type FileFilterOptions = {
+export type FileFilterOptions = {|
   filesToIgnore?: Array<string>,
-};
+|};
 
 /*
  * Allows or ignores files when creating a ZIP archive.

--- a/src/util/manifest.js
+++ b/src/util/manifest.js
@@ -14,6 +14,11 @@ const log = createLogger(__filename);
 export type ExtensionManifest = {
   name: string,
   version: string,
+  applications: {
+    gecko: {
+      id: string
+    }
+  }
 };
 
 export default async function getValidatedManifest(

--- a/tests/unit/test-cmd/test.build.js
+++ b/tests/unit/test-cmd/test.build.js
@@ -43,8 +43,9 @@ describe('build', () => {
         // Make sure a manifest without an ID doesn't throw an error.
         return build({
           sourceDir: fixturePath('minimal-web-ext'),
-          manifestData: manifestWithoutApps,
           artifactsDir: tmpDir.path(),
+        }, {
+          manifestData: manifestWithoutApps,
         });
       }
     );

--- a/tests/unit/test-cmd/test.run.js
+++ b/tests/unit/test-cmd/test.run.js
@@ -1,6 +1,6 @@
 /* @flow */
 import path from 'path';
-import {EventEmitter} from 'events';
+import EventEmitter from 'events';
 import {describe, it} from 'mocha';
 import {assert} from 'chai';
 import sinon from 'sinon';


### PR DESCRIPTION
Flow supports a new syntax for exact object types, starting from v.0.32.0:
- [Release notes Flow v. 0.32.0](https://github.com/facebook/flow/releases/tag/v0.32.0)

Using the new `{| prop: type |}` syntax, flow checks that the objects of this type contains only exactly the defined properties, and using this additional restriction (where it is appropriate), flow will be able to catch additional classes of issues early.

This PR contains an initial proposal of the changes needed to introduce this new flowtype feature, and it is composed of:
- a temporary change in the npm dependency to be able to use the proposed change to grunt-flowbin from kumar303/grunt-flowbin#41
- minor fixes related to flow 0.33.0 (the flowchecks were currently running on flow 0.30.0, see the above grunt-flowbin PR for a rationale)
- "exact objects types" introduced only in src/cmd/build.js (as an initial evaluation of the impact of the change)
- fix new flowtype validation error caught by flow in tests/unit/test-cmd/test.build.js, related to the above change in src/cmd/build.js types
