### PR TITLE
fix: Fixed commit format verification prompt for Windows users

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,11 +159,6 @@ If you want to use scopes then it would look more like:
 The commit message formatting described above is automatically enforced
 each time you commit to your work branch to make continuous integration smoother.
 
-**If you're on Windows**, the commit message verification currently doesn't
-work (sorry!). You will need to commit to your branch using this command:
-
-    git commit --no-verify
-
 ## Creating a release
 
 To release a new version of `web-ext`, follow these steps:

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "eslint-plugin-flowtype": "2.20.0",
     "firefox-client": "0.3.0",
     "flow-bin": "0.33.0",
-    "git-hooks": "1.1.1",
     "git-hooks-win": "1.1.11",
     "grunt": "1.0.1",
     "grunt-contrib-clean": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "firefox-client": "0.3.0",
     "flow-bin": "0.33.0",
     "git-hooks": "1.1.1",
+    "git-hooks-win": "1.1.11",
     "grunt": "1.0.1",
     "grunt-contrib-clean": "1.0.0",
     "grunt-contrib-copy": "1.0.0",


### PR DESCRIPTION
Fixes #551

Added the [git-hooks-win](https://www.npmjs.com/package/git-hooks-win) package to package.json under developer dependencies. This package has zero dependencies and supports the current model of format verification prompt that is available to Mac OS users for Windows users as well. 


This was the error message I got before adding the package

![before](https://cloud.githubusercontent.com/assets/6593585/19213020/5a0c38d2-8d69-11e6-85ce-317947b5e6f3.jpg)

And after installing the package, prompt works correctly

![after](https://cloud.githubusercontent.com/assets/6593585/19213027/758bfcaa-8d69-11e6-93d5-3c545959643e.jpg)

Tested on Windows 10. 
