### PR TITLE
feat: `web-ext run` now makes it clear when auto-reloading is turned on

### DIFF
--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -239,7 +239,7 @@ export default async function run(
         );
       }
 
-      log.debug(
+      log.info(
         `Reloading extension when the source changes; id=${addonId}`);
       reloadStrategy({
         firefoxProcess: runningFirefox,


### PR DESCRIPTION
I realized that it may not be clear to developers that their extension will be reloaded in the background