### PR TITLE
fix: The `web-ext run` command is a little less chatty now

### DIFF
--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -135,7 +135,7 @@ export function defaultFirefoxClient(
     throw lastError;
   }
 
-  log.info('Connecting to the remote Firefox debugger');
+  log.debug('Connecting to the remote Firefox debugger');
   return establishConnection();
 }
 
@@ -231,7 +231,7 @@ export default async function run(
     }
 
     if (noReload) {
-      log.debug('Extension auto-reloading has been disabled');
+      log.info('Automatic extension reloading has been disabled');
     } else {
       if (!addonId) {
         throw new WebExtError(
@@ -239,8 +239,7 @@ export default async function run(
         );
       }
 
-      log.info(
-        `Reloading extension when the source changes; id=${addonId}`);
+      log.info('The extension will reload if any source file changes');
       reloadStrategy({
         firefoxProcess: runningFirefox,
         profile, client, sourceDir, artifactsDir, addonId,

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -71,7 +71,7 @@ export function proxyFileChanges(
   if (filePath.indexOf(artifactsDir) === 0 || !shouldWatchFile(filePath)) {
     log.debug(`Ignoring change to: ${filePath}`);
   } else {
-    log.info(`Changed: ${filePath}`);
+    log.debug(`Changed: ${filePath}`);
     log.debug(`Last change detection: ${(new Date()).toTimeString()}`);
     onChange();
   }


### PR DESCRIPTION
I think this looks a little nicer:
````
$ web-ext run
Running web extension from /Users/kumar/dev/webextensions-examples/borderify
Running Firefox with profile at /var/folders/h7/rttdqkks7fl_txp9_rr4j4840000gn/T/92fcc202-9d94-4007-8408-e266a4038d1b
Use --verbose or open Tools > Web Developer > Browser Console to see logging
Installed /Users/kumar/dev/webextensions-examples/borderify as a temporary add-on
The extension will reload if any source file changes
14:27:38 GMT-0500 (CDT): Reloaded extension: borderify@mozilla.org
14:27:48 GMT-0500 (CDT): Reloaded extension: borderify@mozilla.org
14:27:53 GMT-0500 (CDT): Reloaded extension: borderify@mozilla.org
````