### PR TITLE
Sign command exits with zero status when signing fails

### DIFF
--- a/src/cmd/sign.js
+++ b/src/cmd/sign.js
@@ -120,6 +120,8 @@ export default function sign(
         log.info('SUCCESS');
       } else {
         log.info('FAIL');
+        throw new UsageError(
+            'Add on could not be signed, exiting with status 1');
       }
 
       return signingResult;

--- a/src/cmd/sign.js
+++ b/src/cmd/sign.js
@@ -5,7 +5,7 @@ import defaultAddonSigner from 'sign-addon';
 
 import defaultBuilder from './build';
 import {withTempDir} from '../util/temp-dir';
-import {isErrorWithCode, UsageError} from '../errors';
+import {isErrorWithCode, UsageError, WebExtError} from '../errors';
 import getValidatedManifest, {getManifestId} from '../util/manifest';
 import {prepareArtifactsDir} from '../util/artifacts';
 import {createLogger} from '../util/logger';
@@ -120,8 +120,8 @@ export default function sign(
         log.info('SUCCESS');
       } else {
         log.info('FAIL');
-        throw new UsageError(
-            'Add on could not be signed, exiting with status 1');
+        throw new WebExtError(
+          'The WebExtension could not be signed');
       }
 
       return signingResult;

--- a/tests/unit/test-cmd/test.sign.js
+++ b/tests/unit/test-cmd/test.sign.js
@@ -248,8 +248,11 @@ describe('sign', () => {
             success: false,
           }),
         })
-        .then((result) => {
-          assert.equal(result.success, false);
+        .then(makeSureItFails())
+        .catch((error) => {
+          assert.instanceOf(error, UsageError);
+          assert.match(error.message,
+            /Add on could not be signed, exiting with status 1/);
         });
     }
   ));

--- a/tests/unit/test-cmd/test.sign.js
+++ b/tests/unit/test-cmd/test.sign.js
@@ -7,7 +7,7 @@ import {assert} from 'chai';
 import sinon from 'sinon';
 import promisify from 'es6-promisify';
 
-import {onlyInstancesOf, UsageError} from '../../../src/errors';
+import {onlyInstancesOf, UsageError, WebExtError} from '../../../src/errors';
 import {getManifestId} from '../../../src/util/manifest';
 import {withTempDir} from '../../../src/util/temp-dir';
 import {basicManifest, manifestWithoutApps} from '../test-util/test.manifest';
@@ -250,9 +250,9 @@ describe('sign', () => {
         })
         .then(makeSureItFails())
         .catch((error) => {
-          assert.instanceOf(error, UsageError);
+          assert.instanceOf(error, WebExtError);
           assert.match(error.message,
-            /Add on could not be signed, exiting with status 1/);
+            /The WebExtension could not be signed/);
         });
     }
   ));


### PR DESCRIPTION
Fixes #585 
- throw a `UsageError` when the sign command fails to sign an add on
- modified the current test which makes the test fail to check for the error
- verified the output of `$ echo $?`, it prints 1

@kumar303, will this work? I don't think we need a wrapper or am I missing something?