### PR TITLE
chore: improve linting rules for brace styles

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -54,6 +54,7 @@
         "body": 1
       }
     }],
+    "key-spacing": 2,
     "keyword-spacing": 2,
     "max-len": [2, 80, 2, {"ignoreComments": true}],
     "new-cap": [2, {"capIsNewExceptions": ["Deferred"]}],

--- a/.eslintrc
+++ b/.eslintrc
@@ -39,7 +39,20 @@
     "dot-notation": [2, {"allowKeywords": true}],
     "eqeqeq": [2, "allow-null"],
     "guard-for-in": 0,
-    "indent": [2, 2],
+    "indent": [2, 2, {
+      "SwitchCase": 1,
+      "VariableDeclarator": 1,
+      "outerIIFEBody": 1,
+      "MemberExpression": 1,
+      "FunctionDeclaration": {
+        "parameters": 1,
+        "body": 1
+      },
+      "FunctionExpression": {
+        "parameters": 1,
+        "body": 1
+      }
+    }],
     "keyword-spacing": 2,
     "max-len": [2, 80, 2, {"ignoreComments": true}],
     "new-cap": [2, {"capIsNewExceptions": ["Deferred"]}],

--- a/.eslintrc
+++ b/.eslintrc
@@ -31,6 +31,7 @@
   "rules": {
     "arrow-parens": 2,
     "block-scoped-var": 0,
+    "brace-style": ["error", "1tbs", {"allowSingleLine": false}],
     "camelcase": 0,
     "comma-dangle": [2, "always-multiline"],
     "comma-spacing": 2,

--- a/.eslintrc
+++ b/.eslintrc
@@ -31,7 +31,7 @@
   "rules": {
     "arrow-parens": 2,
     "block-scoped-var": 0,
-    "brace-style": ["error", "1tbs", {"allowSingleLine": false}],
+    "brace-style": [2, "1tbs", {"allowSingleLine": false}],
     "camelcase": 0,
     "comma-dangle": [2, "always-multiline"],
     "comma-spacing": 2,
@@ -90,7 +90,7 @@
     "no-underscore-dangle": 0,
     "no-unused-vars": 2,
     "no-with": 2,
-    "object-property-newline": ["error", {
+    "object-property-newline": [2, {
       "allowMultiplePropertiesPerLine": true
     }],
     "one-var": [2, "never"],

--- a/.eslintrc
+++ b/.eslintrc
@@ -89,6 +89,9 @@
     "no-underscore-dangle": 0,
     "no-unused-vars": 2,
     "no-with": 2,
+    "object-property-newline": ["error", {
+      "allowMultiplePropertiesPerLine": true
+    }],
     "one-var": [2, "never"],
     "prefer-template": 2,
     "quote-props": [1, "consistent-as-needed"],

--- a/src/cmd/build.js
+++ b/src/cmd/build.js
@@ -54,8 +54,7 @@ export async function getDefaultLocalizedName(
 
   try {
     messageData = JSON.parse(await fs.readFile(messageFile));
-  }
-  catch (error) {
+  } catch (error) {
     throw new UsageError(
       `Error reading or parsing file ${messageFile}: ${error}`);
   }
@@ -67,8 +66,7 @@ export async function getDefaultLocalizedName(
           `The locale file ${messageFile} ` +
             `is missing key: ${messageName}`);
         throw error;
-      }
-      else {
+      } else {
         return messageData[messageName].message;
       }
     });

--- a/src/cmd/build.js
+++ b/src/cmd/build.js
@@ -156,7 +156,8 @@ export default async function build(
   if (rebuildAsNeeded) {
     log.info('Rebuilding when files change...');
     onSourceChange({
-      sourceDir, artifactsDir,
+      sourceDir,
+      artifactsDir,
       onChange: () => {
         return createPackage().catch((error) => {
           log.error(error.stack);

--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -47,7 +47,9 @@ export function defaultWatcherCreator(
   }: WatcherCreatorParams
  ): Watchpack {
   return onSourceChange({
-    sourceDir, artifactsDir, onChange: () => {
+    sourceDir,
+    artifactsDir,
+    onChange: () => {
       log.debug(`Reloading add-on ID ${addonId}`);
       return client.reloadAddon(addonId)
         .catch((error) => {
@@ -242,7 +244,11 @@ export default async function run(
       log.info('The extension will reload if any source file changes');
       reloadStrategy({
         firefoxProcess: runningFirefox,
-        profile, client, sourceDir, artifactsDir, addonId,
+        profile,
+        client,
+        sourceDir,
+        artifactsDir,
+        addonId,
       });
     }
   }

--- a/src/errors.js
+++ b/src/errors.js
@@ -100,8 +100,7 @@ export function onlyErrorsWithCode(
           codeWanted.indexOf(error.errno) !== -1) {
         throwError = false;
       }
-    }
-    else if (error.code === codeWanted || error.errno === codeWanted) {
+    } else if (error.code === codeWanted || error.errno === codeWanted) {
       throwError = false;
     }
 

--- a/src/errors.js
+++ b/src/errors.js
@@ -56,7 +56,8 @@ export class RemoteTempInstallNotSupported extends WebExtError {
  *
  */
 export function onlyInstancesOf(
-    predicate: Function, errorHandler: Function): Function {
+  predicate: Function, errorHandler: Function
+): Function {
   return (error) => {
     if (error instanceof predicate) {
       return errorHandler(error);
@@ -88,8 +89,9 @@ export function onlyInstancesOf(
  *
  */
 export function onlyErrorsWithCode(
-    codeWanted: (string|number) | Array<string|number>,
-      errorHandler: Function): Function {
+  codeWanted: (string|number) | Array<string|number>,
+  errorHandler: Function
+): Function {
   return (error) => {
     let throwError = true;
 

--- a/src/firefox/preferences.js
+++ b/src/firefox/preferences.js
@@ -21,32 +21,32 @@ const prefsCommon: FirefoxPreferences = {
   'javascript.options.showInConsole': true,
 
   // Allow remote connections to the debugger.
-  'devtools.debugger.remote-enabled' : true,
+  'devtools.debugger.remote-enabled': true,
   // Disable the prompt for allowing connections.
-  'devtools.debugger.prompt-connection' : false,
+  'devtools.debugger.prompt-connection': false,
 
   // Turn off platform logging because it is a lot of info.
   'extensions.logging.enabled': false,
 
   // Disable extension updates and notifications.
-  'extensions.checkCompatibility.nightly' : false,
-  'extensions.update.enabled' : false,
-  'extensions.update.notifyUser' : false,
+  'extensions.checkCompatibility.nightly': false,
+  'extensions.update.enabled': false,
+  'extensions.update.notifyUser': false,
 
   // From:
   // http://hg.mozilla.org/mozilla-central/file/1dd81c324ac7/build/automation.py.in//l372
   // Only load extensions from the application and user profile.
   // AddonManager.SCOPE_PROFILE + AddonManager.SCOPE_APPLICATION
-  'extensions.enabledScopes' : 5,
+  'extensions.enabledScopes': 5,
   // Disable metadata caching for installed add-ons by default.
-  'extensions.getAddons.cache.enabled' : false,
+  'extensions.getAddons.cache.enabled': false,
   // Disable intalling any distribution add-ons.
-  'extensions.installDistroAddons' : false,
+  'extensions.installDistroAddons': false,
   // Allow installing extensions dropped into the profile folder.
-  'extensions.autoDisableScopes' : 10,
+  'extensions.autoDisableScopes': 10,
 
   // Disable app update.
-  'app.update.enabled' : false,
+  'app.update.enabled': false,
 
   // Point update checks to a nonexistent local URL for fast failures.
   'extensions.update.url': 'http://localhost/extensions-dummy/updateURL',
@@ -54,11 +54,11 @@ const prefsCommon: FirefoxPreferences = {
     'http://localhost/extensions-dummy/blocklistURL',
 
   // Make sure opening about:addons won't hit the network.
-  'extensions.webservice.discoverURL' :
+  'extensions.webservice.discoverURL':
     'http://localhost/extensions-dummy/discoveryURL',
 
   // Allow unsigned add-ons.
-  'xpinstall.signatures.required' : false,
+  'xpinstall.signatures.required': false,
 };
 
 // Prefs specific to Firefox for Android.
@@ -69,22 +69,22 @@ const prefsFennec: FirefoxPreferences = {
 
 // Prefs specific to Firefox for desktop.
 const prefsFirefox: FirefoxPreferences = {
-  'browser.startup.homepage' : 'about:blank',
-  'startup.homepage_welcome_url' : 'about:blank',
-  'startup.homepage_welcome_url.additional' : '',
-  'devtools.errorconsole.enabled' : true,
-  'devtools.chrome.enabled' : true,
+  'browser.startup.homepage': 'about:blank',
+  'startup.homepage_welcome_url': 'about:blank',
+  'startup.homepage_welcome_url.additional': '',
+  'devtools.errorconsole.enabled': true,
+  'devtools.chrome.enabled': true,
 
   // From:
   // http://hg.mozilla.org/mozilla-central/file/1dd81c324ac7/build/automation.py.in//l388
   // Make url-classifier updates so rare that they won't affect tests.
-  'urlclassifier.updateinterval' : 172800,
+  'urlclassifier.updateinterval': 172800,
   // Point the url-classifier to a nonexistent local URL for fast failures.
-  'browser.safebrowsing.provider.0.gethashURL' :
+  'browser.safebrowsing.provider.0.gethashURL':
     'http://localhost/safebrowsing-dummy/gethash',
-  'browser.safebrowsing.provider.0.keyURL' :
+  'browser.safebrowsing.provider.0.keyURL':
     'http://localhost/safebrowsing-dummy/newkey',
-  'browser.safebrowsing.provider.0.updateURL' :
+  'browser.safebrowsing.provider.0.updateURL':
     'http://localhost/safebrowsing-dummy/update',
 
   // Disable self repair/SHIELD

--- a/src/program.js
+++ b/src/program.js
@@ -245,7 +245,7 @@ Example: $0 --help run.
           demand: false,
           type: 'string',
         },
-        'timeout' : {
+        'timeout': {
           describe: 'Number of milliseconds to wait before giving up',
           type: 'number',
         },

--- a/src/program.js
+++ b/src/program.js
@@ -82,8 +82,10 @@ export class Program {
 
   async execute(
     absolutePackageDir: string,
-    {systemProcess = process, logStream = defaultLogStream,
-     getVersion = defaultVersionGetter, shouldExitProgram = true}: Object = {}
+    {
+      systemProcess = process, logStream = defaultLogStream,
+      getVersion = defaultVersionGetter, shouldExitProgram = true,
+    }: Object = {}
   ): Promise<void> {
 
     this.shouldExitProgram = shouldExitProgram;
@@ -153,8 +155,10 @@ export function defaultVersionGetter(
 
 export function main(
   absolutePackageDir: string,
-  {getVersion = defaultVersionGetter, commands = defaultCommands, argv,
-   runOptions = {}}: Object = {}
+  {
+    getVersion = defaultVersionGetter, commands = defaultCommands, argv,
+    runOptions = {},
+  }: Object = {}
 ): Promise<any> {
   let program = new Program(argv, {absolutePackageDir});
   // yargs uses magic camel case expansion to expose options on the

--- a/src/program.js
+++ b/src/program.js
@@ -43,8 +43,10 @@ export class Program {
     this.commands = {};
   }
 
-  command(name: string, description: string, executor: Function,
-          commandOptions: Object = {}): Program {
+  command(
+    name: string, description: string, executor: Function,
+    commandOptions: Object = {}
+  ): Program {
     this.yargs.command(name, description, (yargs) => {
       if (!commandOptions) {
         return;
@@ -78,10 +80,11 @@ export class Program {
     return this;
   }
 
-  async execute(absolutePackageDir: string,
-      {systemProcess = process, logStream = defaultLogStream,
-       getVersion = defaultVersionGetter, shouldExitProgram = true}
-      : Object = {}): Promise<void> {
+  async execute(
+    absolutePackageDir: string,
+    {systemProcess = process, logStream = defaultLogStream,
+     getVersion = defaultVersionGetter, shouldExitProgram = true}: Object = {}
+  ): Promise<void> {
 
     this.shouldExitProgram = shouldExitProgram;
     this.yargs.exitProcess(this.shouldExitProgram);
@@ -150,9 +153,10 @@ export function defaultVersionGetter(
 
 
 export function main(
-    absolutePackageDir: string,
-    {getVersion = defaultVersionGetter, commands = defaultCommands, argv,
-     runOptions = {}}: Object = {}): Promise<any> {
+  absolutePackageDir: string,
+  {getVersion = defaultVersionGetter, commands = defaultCommands, argv,
+   runOptions = {}}: Object = {}
+): Promise<any> {
   let program = new Program(argv, {absolutePackageDir});
   // yargs uses magic camel case expansion to expose options on the
   // final argv object. For example, the 'artifacts-dir' option is alternatively

--- a/src/program.js
+++ b/src/program.js
@@ -111,8 +111,7 @@ export class Program {
       const prefix = cmd ? `${cmd}: ` : '';
       if (!(error instanceof UsageError) || argv.verbose) {
         log.error(`\n${prefix}${error.stack}\n`);
-      }
-      else {
+      } else {
         log.error(`\n${prefix}${error}\n`);
       }
       if (error.code) {

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -184,9 +184,10 @@ export function fake<T>(original: Object, methods: Object = {}): T {
  * Returns a fake Firefox client as would be returned by
  * connect() of 'node-firefox-connect'
  */
-export function fakeFirefoxClient(
-    {requestResult = {}, requestError = null,
-     makeRequestResult = {}, makeRequestError = null}: Object = {}) {
+export function fakeFirefoxClient({
+  requestResult = {}, requestError = null,
+  makeRequestResult = {}, makeRequestError = null,
+}: Object = {}) {
   return {
     disconnect: sinon.spy(() => {}),
     request: sinon.spy(

--- a/tests/unit/test-cmd/test.build.js
+++ b/tests/unit/test-cmd/test.build.js
@@ -28,37 +28,39 @@ describe('build', () => {
 
     return withTempDir(
       (tmpDir) =>
-        build({
-          sourceDir: fixturePath('minimal-web-ext'),
-          artifactsDir: tmpDir.path(),
-        })
-        .then((buildResult) => {
-          assert.match(buildResult.extensionPath,
-                       /minimal_extension-1\.0\.zip$/);
-          return buildResult.extensionPath;
-        })
-        .then((extensionPath) => zipFile.open(extensionPath))
-        .then(() => zipFile.extractFilenames())
-        .then((fileNames) => {
-          fileNames.sort();
-          assert.deepEqual(fileNames,
-                           ['background-script.js', 'manifest.json']);
-        })
+        build(
+          {
+            sourceDir: fixturePath('minimal-web-ext'),
+            artifactsDir: tmpDir.path(),
+          })
+          .then((buildResult) => {
+            assert.match(buildResult.extensionPath,
+                         /minimal_extension-1\.0\.zip$/);
+            return buildResult.extensionPath;
+          })
+          .then((extensionPath) => zipFile.open(extensionPath))
+          .then(() => zipFile.extractFilenames())
+          .then((fileNames) => {
+            fileNames.sort();
+            assert.deepEqual(fileNames,
+                             ['background-script.js', 'manifest.json']);
+          })
     );
   });
 
   it('gives the correct name to a localized extension', () => {
     return withTempDir(
       (tmpDir) =>
-        build({
-          sourceDir: fixturePath('minimal-localizable-web-ext'),
-          artifactsDir: tmpDir.path(),
-        })
-        .then((buildResult) => {
-          assert.match(buildResult.extensionPath,
-                       /name_of_the_extension-1\.0\.zip$/);
-          return buildResult.extensionPath;
-        })
+        build(
+          {
+            sourceDir: fixturePath('minimal-localizable-web-ext'),
+            artifactsDir: tmpDir.path(),
+          })
+          .then((buildResult) => {
+            assert.match(buildResult.extensionPath,
+                         /name_of_the_extension-1\.0\.zip$/);
+            return buildResult.extensionPath;
+          })
     );
   });
 
@@ -184,17 +186,18 @@ describe('build', () => {
 
   it('lets you specify a manifest', () => withTempDir(
     (tmpDir) =>
-      build({
-        sourceDir: fixturePath('minimal-web-ext'),
-        artifactsDir: tmpDir.path(),
-      }, {
-        manifestData: basicManifest,
-      })
-      .then((buildResult) => {
-        assert.match(buildResult.extensionPath,
-                     /the_extension-0\.0\.1\.zip$/);
-        return buildResult.extensionPath;
-      })
+      build(
+        {
+          sourceDir: fixturePath('minimal-web-ext'),
+          artifactsDir: tmpDir.path(),
+        }, {
+          manifestData: basicManifest,
+        })
+        .then((buildResult) => {
+          assert.match(buildResult.extensionPath,
+                       /the_extension-0\.0\.1\.zip$/);
+          return buildResult.extensionPath;
+        })
   ));
 
   it('asks FileFilter what files to include in the ZIP', () => {
@@ -205,15 +208,16 @@ describe('build', () => {
 
     return withTempDir(
       (tmpDir) =>
-        build({
-          sourceDir: fixturePath('minimal-web-ext'),
-          artifactsDir: tmpDir.path(),
-        }, {fileFilter})
-        .then((buildResult) => zipFile.open(buildResult.extensionPath))
-        .then(() => zipFile.extractFilenames())
-        .then((fileNames) => {
-          assert.notInclude(fileNames, 'background-script.js');
-        })
+        build(
+          {
+            sourceDir: fixturePath('minimal-web-ext'),
+            artifactsDir: tmpDir.path(),
+          }, {fileFilter})
+          .then((buildResult) => zipFile.open(buildResult.extensionPath))
+          .then(() => zipFile.extractFilenames())
+          .then((fileNames) => {
+            assert.notInclude(fileNames, 'background-script.js');
+          })
     );
   });
 

--- a/tests/unit/test-cmd/test.build.js
+++ b/tests/unit/test-cmd/test.build.js
@@ -28,11 +28,10 @@ describe('build', () => {
 
     return withTempDir(
       (tmpDir) =>
-        build(
-          {
-            sourceDir: fixturePath('minimal-web-ext'),
-            artifactsDir: tmpDir.path(),
-          })
+        build({
+          sourceDir: fixturePath('minimal-web-ext'),
+          artifactsDir: tmpDir.path(),
+        })
           .then((buildResult) => {
             assert.match(buildResult.extensionPath,
                          /minimal_extension-1\.0\.zip$/);
@@ -51,11 +50,10 @@ describe('build', () => {
   it('gives the correct name to a localized extension', () => {
     return withTempDir(
       (tmpDir) =>
-        build(
-          {
-            sourceDir: fixturePath('minimal-localizable-web-ext'),
-            artifactsDir: tmpDir.path(),
-          })
+        build({
+          sourceDir: fixturePath('minimal-localizable-web-ext'),
+          artifactsDir: tmpDir.path(),
+        })
           .then((buildResult) => {
             assert.match(buildResult.extensionPath,
                          /name_of_the_extension-1\.0\.zip$/);
@@ -172,11 +170,10 @@ describe('build', () => {
   it('prepares the artifacts dir', () => withTempDir(
     (tmpDir) => {
       const artifactsDir = path.join(tmpDir.path(), 'artifacts');
-      return build(
-        {
-          sourceDir: fixturePath('minimal-web-ext'),
-          artifactsDir,
-        })
+      return build({
+        sourceDir: fixturePath('minimal-web-ext'),
+        artifactsDir,
+      })
         .then(() => fs.stat(artifactsDir))
         .then((stats) => {
           assert.equal(stats.isDirectory(), true);
@@ -186,13 +183,12 @@ describe('build', () => {
 
   it('lets you specify a manifest', () => withTempDir(
     (tmpDir) =>
-      build(
-        {
-          sourceDir: fixturePath('minimal-web-ext'),
-          artifactsDir: tmpDir.path(),
-        }, {
-          manifestData: basicManifest,
-        })
+      build({
+        sourceDir: fixturePath('minimal-web-ext'),
+        artifactsDir: tmpDir.path(),
+      }, {
+        manifestData: basicManifest,
+      })
         .then((buildResult) => {
           assert.match(buildResult.extensionPath,
                        /the_extension-0\.0\.1\.zip$/);
@@ -208,11 +204,10 @@ describe('build', () => {
 
     return withTempDir(
       (tmpDir) =>
-        build(
-          {
-            sourceDir: fixturePath('minimal-web-ext'),
-            artifactsDir: tmpDir.path(),
-          }, {fileFilter})
+        build({
+          sourceDir: fixturePath('minimal-web-ext'),
+          artifactsDir: tmpDir.path(),
+        }, {fileFilter})
           .then((buildResult) => zipFile.open(buildResult.extensionPath))
           .then(() => zipFile.extractFilenames())
           .then((fileNames) => {
@@ -228,9 +223,11 @@ describe('build', () => {
       const onSourceChange = sinon.spy(() => {});
       const sourceDir = fixturePath('minimal-web-ext');
       const artifactsDir = tmpDir.path();
-      return build(
-        {sourceDir, artifactsDir, asNeeded: true},
-        {manifestData: basicManifest, onSourceChange, fileFilter})
+      return build({
+        sourceDir, artifactsDir, asNeeded: true,
+      }, {
+        manifestData: basicManifest, onSourceChange, fileFilter,
+      })
         .then((buildResult) => {
           // Make sure we still have a build result.
           assert.match(buildResult.extensionPath, /\.zip$/);
@@ -270,13 +267,13 @@ describe('build', () => {
       var packageResult = Promise.resolve({});
       const packageCreator = sinon.spy(() => packageResult);
       const onSourceChange = sinon.spy(() => {});
-      return build(
-        {
-          sourceDir: fixturePath('minimal-web-ext'),
-          artifactsDir: tmpDir.path(),
-          asNeeded: true,
-        },
-        {manifestData: basicManifest, onSourceChange, packageCreator})
+      return build({
+        sourceDir: fixturePath('minimal-web-ext'),
+        artifactsDir: tmpDir.path(),
+        asNeeded: true,
+      }, {
+        manifestData: basicManifest, onSourceChange, packageCreator
+      })
         .then(() => {
           assert.equal(onSourceChange.called, true);
           assert.equal(packageCreator.callCount, 1);

--- a/tests/unit/test-cmd/test.build.js
+++ b/tests/unit/test-cmd/test.build.js
@@ -272,7 +272,7 @@ describe('build', () => {
         artifactsDir: tmpDir.path(),
         asNeeded: true,
       }, {
-        manifestData: basicManifest, onSourceChange, packageCreator
+        manifestData: basicManifest, onSourceChange, packageCreator,
       })
         .then(() => {
           assert.equal(onSourceChange.called, true);

--- a/tests/unit/test-cmd/test.run.js
+++ b/tests/unit/test-cmd/test.run.js
@@ -52,7 +52,8 @@ describe('run', () => {
     };
 
     return {
-      argv, options,
+      argv,
+      options,
       run: (customArgv = {}, customOpt = {}) => run(
         {...argv, ...customArgv},
         {...options, ...customOpt}

--- a/tests/unit/test-cmd/test.sign.js
+++ b/tests/unit/test-cmd/test.sign.js
@@ -54,8 +54,9 @@ describe('sign', () => {
    * Run the sign command with stubs for all dependencies.
    */
   function sign(
-      tmpDir: Object, stubs: Object,
-      {extraArgs = {}, extraOptions = {}}: Object = {}): Promise<*> {
+    tmpDir: Object, stubs: Object,
+    {extraArgs = {}, extraOptions = {}}: Object = {}
+  ): Promise<*> {
     return completeSignCommand({
       verbose: false,
       artifactsDir: path.join(tmpDir.path(), 'artifacts-dir'),

--- a/tests/unit/test-firefox/test.firefox.js
+++ b/tests/unit/test-firefox/test.firefox.js
@@ -512,8 +512,7 @@ describe('firefox', () => {
         return new Promise((resolve, reject) => {
           if (callCount === 2) {
             reject(new TCPConnectError('port is free'));
-          }
-          else {
+          } else {
             resolve(client);
           }
         });

--- a/tests/unit/test-util/test.artifacts.js
+++ b/tests/unit/test-util/test.artifacts.js
@@ -26,10 +26,10 @@ describe('prepareArtifactsDir', () => {
   it('ignores existing artifacts dir', () => withTempDir(
     (tmpDir) =>
       prepareArtifactsDir(tmpDir.path())
-      .then(() => {
-        // Make sure everything is still cool with this path.
-        return fs.stat(tmpDir.path());
-      })
+        .then(() => {
+          // Make sure everything is still cool with this path.
+          return fs.stat(tmpDir.path());
+        })
   ));
 
   it('ensures the path is really a directory', () => withTempDir(

--- a/tests/unit/test-util/test.logger.js
+++ b/tests/unit/test-util/test.logger.js
@@ -34,7 +34,9 @@ describe('logger', () => {
     // NOTE: create a fake process that makes flow happy.
     function fakeProcess() {
       class FakeWritableStream extends WriteStream {
-        write(): boolean { return true; }
+        write(): boolean {
+          return true;
+        }
       }
 
       let fakeWritableStream = new FakeWritableStream();

--- a/tests/unit/test-util/test.manifest.js
+++ b/tests/unit/test-util/test.manifest.js
@@ -32,19 +32,19 @@ describe('util/manifest', () => {
     it('returns a valid manifest', () => withTempDir(
       (tmpDir) =>
         writeManifest(tmpDir.path(), basicManifest)
-        .then(() => getValidatedManifest(tmpDir.path()))
-        .then((manifestData) => {
-          assert.deepEqual(manifestData, basicManifest);
-        })
+          .then(() => getValidatedManifest(tmpDir.path()))
+          .then((manifestData) => {
+            assert.deepEqual(manifestData, basicManifest);
+          })
     ));
 
     it('allows manifests without an applications property', () => withTempDir(
       (tmpDir) =>
         writeManifest(tmpDir.path(), manifestWithoutApps)
-        .then(() => getValidatedManifest(tmpDir.path()))
-        .then((manifestData) => {
-          assert.deepEqual(manifestData, manifestWithoutApps);
-        })
+          .then(() => getValidatedManifest(tmpDir.path()))
+          .then((manifestData) => {
+            assert.deepEqual(manifestData, manifestWithoutApps);
+          })
     ));
 
     it('reports an error for a missing manifest file', () => {

--- a/tests/unit/test.watcher.js
+++ b/tests/unit/test.watcher.js
@@ -89,7 +89,8 @@ describe('watcher', () => {
       }
 
       const conf = {
-        ...defaults, shouldWatchFile,
+        ...defaults,
+        shouldWatchFile,
         onChange: sinon.spy(() => {}),
       };
 
@@ -103,7 +104,8 @@ describe('watcher', () => {
 
     it('filters out commonly unwanted files by default', () => {
       const conf = {
-        ...defaults, shouldWatchFile: undefined,
+        ...defaults,
+        shouldWatchFile: undefined,
         onChange: sinon.spy(() => {}),
       };
       proxyFileChanges({...conf, filePath: '/somewhere/.git'});


### PR DESCRIPTION
I added a few rules after I had to be an annoying reviewer on [this patch](https://github.com/mozilla/web-ext/pull/577) :) 

* Added [brace-style](http://eslint.org/docs/rules/brace-style) to catch some if/else consistency problems I've been seeing lately (I actually haven't been nagging about these in reviews)
* Added deeper [indent](http://eslint.org/docs/rules/indent) rules. These are nits that I've commented about on reviews.
* Added [object-property-newline](http://eslint.org/docs/rules/object-property-newline). This is an attempt to address inconsistent new lines in property lists but doesn't fully address it.