### PR TITLE
fix: Fixed `Error: Cannot find module 'regenerator-runtime'`

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "minimatch": "3.0.3",
     "mz": "2.4.0",
     "node-firefox-connect": "1.2.0",
+    "regenerator-runtime": "0.9.5",
     "sign-addon": "0.2.0",
     "source-map-support": "0.4.5",
     "stream-to-promise": "2.2.0",


### PR DESCRIPTION
Fixes https://github.com/mozilla/web-ext/issues/575