### PR TITLE
test: run a minimal set of 'production mode' smoke tests on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ before_script:
 script:
 - COVERAGE=y NODE_ENV=production npm test
 - npm run changelog-lint
+# Run a minimal set of smoke tests in production mode (npm install --production)
+- ./tests/smoke-test-production.sh
 
 after_script: npm run publish-coverage
 

--- a/tests/smoke-test-production.sh
+++ b/tests/smoke-test-production.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+set -e
+
+CWD=`pwd`
+
+onExit() {
+  cd $CWD
+}
+
+trap onExit EXIT
+
+if [ -z "$TRAVIS" ]; then
+  echo "This smoke test will remove your 'node_modules/' dir and it is supposed to run only on Travis CI."
+  exit 1
+fi
+
+echo "Removing the exitent node_modules/ dir content..."
+rm -rf node_modules/
+
+echo "Reinstall the node_modules/ dependencies in production mode..."
+npm install --production
+
+echo "Run: 'web-ext --version' ..."
+$CWD/bin/web-ext --version
+
+echo "Copy a minimal webextension into /tmp/minimal-web-ext ..."
+cp -rf tests/fixtures/minimal-web-ext /tmp/minimal-web-ext
+
+echo "Run: 'web-ext build' ..."
+cd /tmp/minimal-web-ext
+$CWD/bin/web-ext build


### PR DESCRIPTION
This PR contains a small shell script that run an additional minimal set of smoke tests on travis
(and only on travis, because it is going to destroy the `node_modules` dir to recereate it using `npm install --production`).

This additional smoke test should be able to catch issues related to missing dependencies when `web-ext` is installed in production mode (`npm install --production`), as in #575.
