### PR TITLE
fix: Format JSON parse errors so that they provide file context

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "node-firefox-connect": "1.2.0",
     "regenerator-runtime": "0.10.0",
     "parse-json": "2.2.0",
-    "regenerator-runtime": "0.9.5",
     "sign-addon": "0.2.0",
     "source-map-support": "0.4.6",
     "stream-to-promise": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -56,8 +56,10 @@
     "git-rev-sync": "1.8.0",
     "minimatch": "3.0.3",
     "mz": "2.6.0",
-    "node-firefox-connect": "1.2.0",
+    "node-firefox-connect": "1.2.0",< HEAD
     "regenerator-runtime": "0.10.0",
+    "parse-json": "2.2.0",
+    "regenerator-runtime": "0.9.5",ded parse-json package to package.json
     "sign-addon": "0.2.0",
     "source-map-support": "0.4.6",
     "stream-to-promise": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -56,10 +56,10 @@
     "git-rev-sync": "1.8.0",
     "minimatch": "3.0.3",
     "mz": "2.6.0",
-    "node-firefox-connect": "1.2.0",< HEAD
+    "node-firefox-connect": "1.2.0",
     "regenerator-runtime": "0.10.0",
     "parse-json": "2.2.0",
-    "regenerator-runtime": "0.9.5",ded parse-json package to package.json
+    "regenerator-runtime": "0.9.5",
     "sign-addon": "0.2.0",
     "source-map-support": "0.4.6",
     "stream-to-promise": "2.2.0",

--- a/src/cmd/build.js
+++ b/src/cmd/build.js
@@ -60,7 +60,7 @@ export async function getDefaultLocalizedName(
 ): Promise<string> {
 
   let messageData: LocalizedMessageData;
-  let messageContents: string|Buffer;
+  let messageContents: string | Buffer;
   let extensionName: string = manifestData.name;
 
   try {

--- a/src/cmd/build.js
+++ b/src/cmd/build.js
@@ -4,6 +4,7 @@ import minimatch from 'minimatch';
 import {createWriteStream} from 'fs';
 import streamToPromise from 'stream-to-promise';
 import {fs} from 'mz';
+import parseJson from 'parse-json';
 
 import defaultSourceWatcher from '../watcher';
 import {zipDir} from '../util/zip-dir';
@@ -62,10 +63,11 @@ export async function getDefaultLocalizedName(
   let extensionName: string = manifestData.name;
 
   try {
-    messageData = JSON.parse(await fs.readFile(messageFile));
-  } catch (error) {
-    throw new UsageError(
-      `Error reading or parsing file ${messageFile}: ${error}`);
+    messageData = parseJson(await fs.readFile(messageFile));
+  }
+  catch (error) {
+    error.fileName = messageFile;
+    throw new UsageError(error);
   }
   extensionName = manifestData.name.replace(/__MSG_([A-Za-z0-9@_]+?)__/g,
     (match, messageName) => {

--- a/src/cmd/build.js
+++ b/src/cmd/build.js
@@ -64,8 +64,7 @@ export async function getDefaultLocalizedName(
 
   try {
     messageData = parseJson(await fs.readFile(messageFile));
-  }
-  catch (error) {
+  } catch (error) {
     error.fileName = messageFile;
     throw new UsageError(error);
   }

--- a/src/cmd/build.js
+++ b/src/cmd/build.js
@@ -67,14 +67,14 @@ export async function getDefaultLocalizedName(
     messageContents = await fs.readFile(messageFile);
   } catch (error) {
     throw new UsageError(
-      `Could not read messages.json file at ${messageFile}: ${error}`);
+      `Error reading messages.json file at ${messageFile}: ${error}`);
   }
 
   try {
     messageData = parseJSON(messageContents, messageFile);
   } catch (error) {
     throw new UsageError(
-      `Error parsing manifest.json at ${messageFile}: ${error}`);
+      `Error parsing messages.json ${error}`);
   }
 
   extensionName = manifestData.name.replace(/__MSG_([A-Za-z0-9@_]+?)__/g,

--- a/src/util/manifest.js
+++ b/src/util/manifest.js
@@ -4,7 +4,7 @@ import path from 'path';
 import {fs} from 'mz';
 import {InvalidManifest} from '../errors';
 import {createLogger} from './logger';
-import parseJson from 'parse-json';
+import parseJSON from 'parse-json';
 
 
 const log = createLogger(__filename);
@@ -46,7 +46,7 @@ export default async function getValidatedManifest(
   let manifestData;
 
   try {
-    manifestData = parseJson(manifestContents);
+    manifestData = parseJSON(manifestContents, manifestFile);
   } catch (error) {
     error.fileName = manifestFile;
     throw new InvalidManifest(

--- a/src/util/manifest.js
+++ b/src/util/manifest.js
@@ -48,7 +48,6 @@ export default async function getValidatedManifest(
   try {
     manifestData = parseJSON(manifestContents, manifestFile);
   } catch (error) {
-    error.fileName = manifestFile;
     throw new InvalidManifest(
       `Error parsing manifest.json at ${manifestFile}: ${error}`);
   }

--- a/src/util/manifest.js
+++ b/src/util/manifest.js
@@ -4,6 +4,7 @@ import path from 'path';
 import {fs} from 'mz';
 import {InvalidManifest} from '../errors';
 import {createLogger} from './logger';
+import parseJson from 'parse-json';
 
 
 const log = createLogger(__filename);
@@ -45,8 +46,9 @@ export default async function getValidatedManifest(
   let manifestData;
 
   try {
-    manifestData = JSON.parse(manifestContents);
+    manifestData = parseJson(manifestContents);
   } catch (error) {
+    error.fileName = manifestFile;
     throw new InvalidManifest(
       `Error parsing manifest.json at ${manifestFile}: ${error}`);
   }

--- a/tests/unit/test-cmd/test.build.js
+++ b/tests/unit/test-cmd/test.build.js
@@ -103,6 +103,7 @@ describe('build', () => {
           .catch((error) => {
             assert.instanceOf(error, UsageError);
             assert.match(error.message, /Unexpected token '"' at 1:15/);
+            assert.match(error.message, /^Error parsing messages.json/);
             assert.include(error.message, messageFileName);
           });
       }
@@ -150,6 +151,9 @@ describe('build', () => {
         assert.match(
           error.message,
           /Error: ENOENT: no such file or directory, open .*messages.json/);
+        assert.match(error.message, /^Error reading messages.json/);
+        assert.include(error.message,
+          '/path/to/non-existent-dir/messages.json');
       });
   });
 

--- a/tests/unit/test-cmd/test.build.js
+++ b/tests/unit/test-cmd/test.build.js
@@ -102,9 +102,8 @@ describe('build', () => {
           .then(makeSureItFails())
           .catch((error) => {
             assert.instanceOf(error, UsageError);
-            assert.match(
-              error.message,
-              /Unexpected token '"' .* in .*messages.json/);
+            assert.match(error.message, /Unexpected token '"' at 1:15/);
+            assert.include(error.message, messageFileName);
           });
       }
     );

--- a/tests/unit/test-cmd/test.build.js
+++ b/tests/unit/test-cmd/test.build.js
@@ -104,7 +104,7 @@ describe('build', () => {
             assert.instanceOf(error, UsageError);
             assert.match(
               error.message,
-              /Error .* file .*messages\.json: SyntaxError: Unexpected string/);
+              /Unexpected token '"' .* in .*messages.json/);
           });
       }
     );
@@ -150,7 +150,7 @@ describe('build', () => {
         assert.instanceOf(error, UsageError);
         assert.match(
           error.message,
-          /Error .* file .*messages\.json: .*: no such file or directory/);
+          /Error: ENOENT: no such file or directory, open .*messages.json/);
       });
   });
 

--- a/tests/unit/test-util/test.manifest.js
+++ b/tests/unit/test-util/test.manifest.js
@@ -70,7 +70,8 @@ describe('util/manifest', () => {
           .then(() => getValidatedManifest(tmpDir.path()))
           .then(makeSureItFails())
           .catch(onlyInstancesOf(InvalidManifest, (error) => {
-            assert.match(error.message, /Error parsing manifest\.json/);
+            assert.match(error.message, /Error parsing manifest\.json at /);
+            assert.include(error.message, 'Unexpected token \' \' at 2:49');
             assert.include(error.message, manifestFile);
           }));
       }


### PR DESCRIPTION
Fixes #491 
Used the [json-parse](https://github.com/sindresorhus/parse-json) to display line column number for providing context for syntax errors in JSON files.
