### PR TITLE
Support warnings-as-errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "opera"
   ],
   "dependencies": {
-    "addons-linter": "0.15.6",
+    "addons-linter": "0.15.10",
     "babel-polyfill": "6.16.0",
     "babel-runtime": "6.11.6",
     "bunyan": "1.8.4",

--- a/src/cmd/lint.js
+++ b/src/cmd/lint.js
@@ -16,6 +16,7 @@ export type LinterCreatorParams = {
     logLevel: 'debug' | 'fatal',
     stack: boolean,
     pretty?: boolean,
+    warningsAsErrors?: boolean,
     metadata?: boolean,
     output?: LinterOutputType,
     boring?: boolean,
@@ -42,6 +43,7 @@ export type LintCmdParams = {
   output?: LinterOutputType,
   metadata?: boolean,
   pretty?: boolean,
+  warningsAsErrors?: boolean,
 };
 
 export type LintCmdOptions = {
@@ -52,7 +54,7 @@ export type LintCmdOptions = {
 export default function lint(
   {
     verbose, sourceDir, selfHosted, boring, output,
-    metadata, pretty,
+    metadata, pretty, warningsAsErrors,
   }: LintCmdParams,
   {
     createLinter = defaultLinterCreator,
@@ -65,6 +67,7 @@ export default function lint(
       logLevel: verbose ? 'debug' : 'fatal',
       stack: Boolean(verbose),
       pretty,
+      warningsAsErrors,
       metadata,
       output,
       boring,

--- a/src/program.js
+++ b/src/program.js
@@ -300,6 +300,12 @@ Example: $0 --help run.
         type: 'boolean',
         default: false,
       },
+      'warnings-as-errors': {
+        describe: 'Treat warnings as errors',
+        alias: 'w',
+        type: 'boolean',
+        default: false,
+      },
       'pretty': {
         describe: 'Prettify JSON output',
         type: 'boolean',

--- a/tests/unit/test-cmd/test.lint.js
+++ b/tests/unit/test-cmd/test.lint.js
@@ -65,6 +65,22 @@ describe('lint', () => {
     });
   });
 
+  it('passes warningsAsErrors to the linter', () => {
+    const {lint, createLinter} = setUp();
+    return lint({warningsAsErrors: true}).then(() => {
+      const config = createLinter.firstCall.args[0].config;
+      assert.equal(config.warningsAsErrors, true);
+    });
+  });
+
+  it('passes warningsAsErrors undefined to the linter', () => {
+    const {lint, createLinter} = setUp();
+    return lint({}).then(() => {
+      const config = createLinter.firstCall.args[0].config;
+      assert.equal(config.warningsAsErrors, undefined);
+    });
+  });
+
   it('configures the linter when verbose', () => {
     const {lint, createLinter} = setUp();
     return lint({verbose: true}).then(() => {


### PR DESCRIPTION
This patch adds support for using `--warnings-as-errors` as a parameter for the lint command.

This enables the functionality provided in the PR https://github.com/mozilla/addons-linter/pull/1016 and partially resolves the issue https://github.com/mozilla/addons-linter/issues/1014.

Once `addons-linter` has PR accepted and merged, [packages.json](https://github.com/mozilla/web-ext/blob/master/package.json#L47) will also need to have the package-version bumped to fully resolve and close the issue.
