### PR TITLE
chore: fix mysterious lint error

### DIFF
--- a/tests/unit/test-firefox/test.remote.js
+++ b/tests/unit/test-firefox/test.remote.js
@@ -270,8 +270,10 @@ describe('firefox.remote', () => {
             addonsActor: 'addons1.actor.conn',
           },
           // installTemporaryAddon response:
-          makeRequestError: {error: 'install error',
-                             message: 'error message'},
+          makeRequestError: {
+            error: 'install error',
+            message: 'error message',
+          },
         });
         const conn = makeInstance(client);
         return conn.installTemporaryAddon('/path/to/addon')


### PR DESCRIPTION
Some PR builds on Node 4 were getting:
````
/home/travis/build/mozilla/web-ext/tests/unit/test-firefox/test.remote.js

274:30  error  Expected indentation of 12 spaces but found 29  indent
````