### PR TITLE
fix: issue 510 new error type

### DIFF
--- a/src/util/artifacts.js
+++ b/src/util/artifacts.js
@@ -18,8 +18,14 @@ export async function prepareArtifactsDir(
     }
   } catch (error) {
     if (isErrorWithCode('ENOENT', error)) {
-      log.debug(`Creating artifacts directory: ${artifactsDir}`);
-      await fs.mkdir(artifactsDir);
+      await fs.mkdir(artifactsDir, (error) => {
+        if (error) {
+          throw new UsageError(
+            `--artifacts-dir=${artifactsDir} (lack permissions)`);
+        } else {
+          log.debug(`Creating artifacts directory: ${artifactsDir}`);
+        }
+      });
     } else {
       throw error;
     }


### PR DESCRIPTION
Fixes #510 
This is not exactly what issue is describing, but I think this is understandable for a user. 
`--artifacts-dir /non-existant-directory is not a directory` is only thrown when path leads to a file and not a directory. If access is missing `--artifacts-dir /non-existant-directory lack permissions` is thrown (i am open to better phrasing suggestions). This way `mkdir` is attempted as expected, but user receives clear `UsageError` if it fails