### PR TITLE
fix: Support custom prefs values that contains '=' chars

### DIFF
--- a/src/firefox/preferences.js
+++ b/src/firefox/preferences.js
@@ -136,8 +136,16 @@ export function coerceCLICustomPreference(
 
   for (const pref of cliPrefs) {
     const prefsAry = pref.split('=');
+
+    if (prefsAry.length < 2) {
+      throw new UsageError(
+        `Incomplete custom preference: "${pref}". ` +
+        'Syntax expected: "prefname=prefvalue".'
+      );
+    }
+
     const key = prefsAry[0];
-    let value = prefsAry[1];
+    let value = prefsAry.slice(1).join('=');
 
     if (/[^\w{@}.-]/.test(key)) {
       throw new UsageError(`Invalid custom preference name: ${key}`);

--- a/tests/unit/test-firefox/test.preferences.js
+++ b/tests/unit/test-firefox/test.preferences.js
@@ -68,6 +68,13 @@ describe('firefox/preferences', () => {
       assert.equal(prefs['valid.preference'], '4.55');
     });
 
+    it('supports string values with "=" chars', () => {
+      const prefs = coerceCLICustomPreference(
+        'valid.preference=value=withequals=chars'
+      );
+      assert.equal(prefs['valid.preference'], 'value=withequals=chars');
+    });
+
     it('does not allow certain default preferences to be customized', () => {
       const nonChangeablePrefs = nonOverridablePreferences.map((prop) => {
         return prop += '=true';
@@ -78,7 +85,14 @@ describe('firefox/preferences', () => {
       }
     });
 
-    it('throws an error for invalid preferences', () => {
+    it('throws an error for invalid or incomplete preferences', () => {
+      assert.throws(
+        () => coerceCLICustomPreference('test.invalid.prop'),
+        UsageError,
+        'UsageError: Incomplete custom preference: "test.invalid.prop". ' +
+        'Syntax expected: "prefname=prefvalue".'
+      );
+
       assert.throws(() => coerceCLICustomPreference('*&%£=true'),
                     UsageError,
                     'UsageError: Invalid custom preference name: *&%£');


### PR DESCRIPTION
This PR contains two small fixes which cover the following corner cases:

- custom prefs values which contains '=' chars
- custom prefs which do not specify a value