### PR TITLE
chore: after upgrading yargs, fix deprecated use of demand()

### DIFF
--- a/src/program.js
+++ b/src/program.js
@@ -59,7 +59,11 @@ export class Program {
         return;
       }
       return yargs
-        .demand(0, 0, 'This command does not take any arguments')
+        // Make sure the user does not add any extra commands. For example,
+        // this would be a mistake because lint does not accept arguments:
+        // web-ext lint ./src/path/to/file.js
+        .demandCommand(0, 0, undefined,
+                       'This command does not take any arguments')
         .strict()
         .exitProcess(this.shouldExitProgram)
         // Calling env() will be unnecessary after
@@ -198,7 +202,7 @@ Example: $0 --help run.
     .alias('h', 'help')
     .env(envPrefix)
     .version(() => getVersion(absolutePackageDir))
-    .demand(1)
+    .demandCommand(1, 'You must specify a command')
     .strict();
 
   program.setGlobalOptions({

--- a/tests/unit/test.program.js
+++ b/tests/unit/test.program.js
@@ -79,7 +79,9 @@ describe('program.Program', () => {
     return execProgram(program)
       .then(makeSureItFails())
       .catch((error) => {
-        assert.match(error.message, /This command does not take any arguments/);
+        assert.match(
+          error.message,
+          /Too many non-option arguments: got 1, maximum of 0/);
       });
   });
 

--- a/tests/unit/test.program.js
+++ b/tests/unit/test.program.js
@@ -79,9 +79,7 @@ describe('program.Program', () => {
     return execProgram(program)
       .then(makeSureItFails())
       .catch((error) => {
-        assert.match(
-          error.message,
-          /Too many non-option arguments: got 1, maximum of 0/);
+        assert.match(error.message, /This command does not take any arguments/);
       });
   });
 

--- a/tests/unit/test.program.js
+++ b/tests/unit/test.program.js
@@ -306,6 +306,15 @@ describe('program.main', () => {
       });
   });
 
+  it('throws an error if no command is given', () => {
+    const fakeCommands = fake(commands, {});
+    return execProgram([], {commands: fakeCommands})
+      .then(makeSureItFails())
+      .catch((error) => {
+        assert.match(error.message, /You must specify a command/);
+      });
+  });
+
   it('can get the program version', () => {
     const fakeVersionGetter = sinon.spy(() => '<version>');
     const fakeCommands = fake(commands, {


### PR DESCRIPTION
`demand()` changed after yargs 6.6.0 https://github.com/yargs/yargs/pull/740

Test bustage was in https://travis-ci.org/mozilla/web-ext/builds/189002823 (but this mysteriously didn't fail in the PR that actually upgraded yargs, hmm)