### PR TITLE
docs: Added more docs related to the flow errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,15 +88,15 @@ classes are used correctly. Run all Flow checks with `npm run flow-check`.
 The first steps to learn how to fix flow errors are:
 
 - learn how to read the flow annotations
-- learn how to write new or change the existent type definitions
+- learn how to write new type definitions or change the existing definitions
 - learn to read the flow errors and know some of the more common errors
 
 To learn more about the syntax used to add the flow annotations and how to
 write/change the type definitions, you should take a look at the official
 [Flow docs](https://flowtype.org/docs/getting-started.html)
 
-Follows some additional information related to common flow errors and how
-to read them.
+The following sections contain additional informations related to common
+flow errors and how to read and fix them.
 
 ### Missing annotation
 
@@ -119,7 +119,7 @@ src/util/manifest.js:32
        ^^^^^^^^^ parameter `sourceDir`. Missing annotation
 ```
 
-which is fixed by annotate the function correctly, e.g.:
+which is fixed by annotating the function correctly, e.g.:
 
 ```js
 export default async function getValidatedManifest(
@@ -131,7 +131,7 @@ export default async function getValidatedManifest(
 
 ### How to read Flow errors related to type inconsistencies
 
-Some of the flow errors are going to contains references to the two sides
+Some of the flow errors are going to contain references to the two sides
 of the flowtype errors:
 
 ```
@@ -144,29 +144,34 @@ tests/unit/test-cmd/test.build.js:193
 ```
 
 - The first part points to the offending code (where the type violation has been found)
-- The second part points to the offended type annotation (where the type has been defined)
+- The second part points to the violated type annotation (where the type has been defined)
 
-When flow raises this kind of errors (e.g. it is pretty common during a refactoring),
+When flow raises this kind of error (e.g. it is pretty common during a refactoring),
 we have to evaluate which one of the two sides is wrong.
 
-As an example, by reading the above error is not immediately clear which part should be fixed,
+As an example, by reading the above error it is not immediately clear which part should be fixed.
+
 To be sure about which is the proper fix, we have to look at the code near to both the lines
-and evaluate the actual reason (that can be different from time to time), e.g.:
+and evaluate the actual reason, e.g.:
 
-- it is possible that we wrote some of property names wrong (in the code or in the type definitions)
-- or the defined type is supposed to contains a new property and it is not yet in the related type definitions
+- it is possible that we wrote some of the property names wrong (in the code or in the type definitions)
+- or the defined type is supposed to contain a new property and it is not yet in the related type definitions
 
-### Flow type definitions conventions
+### Flow type conventions
 
-In the `web-ext` sources we are currently using the following conventions, that should be preserved
-when we change or add flow types definitions:
+In the `web-ext` sources we are currently using the following conventions (and they should be preserved
+when we change or add flow types definitions):
 
 - the type names should be CamelCased (e.g. `ExtensionManifest`)
-- the types used to annotate functions or methods exported from the module should be exported
-  (`export type ExtensionManifest = ...`)
+- the types used to annotate functions or methods defined in a module should be exported only when
+  they are supposed to be used by other modules (`export type ExtensionManifest = ...`)
+- any type imported from the other modules should be in the module preamble (near to the regular ES6 imports)
 - object types should be exact object types (e.g. `{| ... |}`), because flow will be able to raise
   errors when we try to set or get a property not explicitly defined in the flow type (which is
-  particularly helpful during refactorings).
+  particularly helpful during refactorings)
+- all the flow type definitions should be as close as possible to the function they annotate
+- we prefer to do not use external files (e.g. .flow.js files or declaration files configured in the
+  .flowconfig file) for the web-ext flow types.
 
 ## Code Coverage
 


### PR DESCRIPTION
This PR adds some "flowtype" docs to the CONTRIBUTING.md file (as part of #739).

Add more info in the intro to flow:

- [x] small introduction to how to learn more about Flow
- [x] link to the official Flow docs

include some helpful example: 

- [x] missing annotation (the simplest one, used to introduce "how to fix a flow error" on the simplest scenario)
- [x] "How to read Flow errors related to type inconsistencies" (used to explain how to read and evaluate the kind of flow error message that is usually harder to read)
- [x] Common "Flow types definitions" conventions