### PR TITLE
test: Windows compatibilities

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.js]
+indent_style = space
+indent_size = 2

--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "object.entries": "1.0.4",
     "object.values": "1.0.4",
     "prettyjson": "1.2.1",
-    "semver": "5.3.0",
     "sinon": "1.17.7",
     "webpack": "1.14.0",
     "webpack-dev-server": "1.16.2",

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "object.entries": "1.0.4",
     "object.values": "1.0.4",
     "prettyjson": "1.2.1",
+    "semver": "5.3.0",
     "sinon": "1.17.7",
     "webpack": "1.14.0",
     "webpack-dev-server": "1.16.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "regenerator-runtime": "0.10.1",
     "sign-addon": "0.2.0",
     "source-map-support": "0.4.8",
-    "stream-to-promise": "2.2.0",
     "tmp": "0.0.30",
     "update-notifier": "1.0.3",
     "watchpack": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "debounce": "1.0.0",
     "es6-error": "4.0.1",
     "es6-promisify": "5.0.0",
+    "event-to-promise": "0.7.0",
     "firefox-profile": "0.4.7",
     "fx-runner": "1.0.6",
     "git-rev-sync": "1.8.0",

--- a/src/cmd/build.js
+++ b/src/cmd/build.js
@@ -4,9 +4,9 @@ import {createWriteStream} from 'fs';
 
 import minimatch from 'minimatch';
 import {fs} from 'mz';
-import streamToPromise from 'stream-to-promise';
 import parseJSON from 'parse-json';
 
+import {streamToPromise} from '../util/stream-to-promise';
 import defaultSourceWatcher from '../watcher';
 import {zipDir} from '../util/zip-dir';
 import getValidatedManifest, {getManifestId} from '../util/manifest';
@@ -121,10 +121,11 @@ async function defaultPackageCreator({
     `${extensionName}-${manifestData.version}.zip`);
   const extensionPath = path.join(artifactsDir, packageName);
   const stream = createWriteStream(extensionPath);
+  const pendingStream = streamToPromise(stream);
 
   stream.write(buffer, () => stream.end());
 
-  await streamToPromise(stream);
+  await pendingStream;
 
   if (showReadyMessage) {
     log.info(`Your web extension is ready: ${extensionPath}`);

--- a/src/cmd/build.js
+++ b/src/cmd/build.js
@@ -5,8 +5,8 @@ import {createWriteStream} from 'fs';
 import minimatch from 'minimatch';
 import {fs} from 'mz';
 import parseJSON from 'parse-json';
+import eventToPromise from 'event-to-promise';
 
-import {streamToPromise} from '../util/stream-to-promise';
 import defaultSourceWatcher from '../watcher';
 import {zipDir} from '../util/zip-dir';
 import getValidatedManifest, {getManifestId} from '../util/manifest';
@@ -121,11 +121,10 @@ async function defaultPackageCreator({
     `${extensionName}-${manifestData.version}.zip`);
   const extensionPath = path.join(artifactsDir, packageName);
   const stream = createWriteStream(extensionPath);
-  const pendingStream = streamToPromise(stream);
 
   stream.write(buffer, () => stream.end());
 
-  await pendingStream;
+  await eventToPromise(stream, 'close');
 
   if (showReadyMessage) {
     log.info(`Your web extension is ready: ${extensionPath}`);

--- a/src/firefox/index.js
+++ b/src/firefox/index.js
@@ -5,10 +5,10 @@ import path from 'path';
 import {default as defaultFxRunner} from 'fx-runner';
 import FirefoxProfile, {copyFromUserProfile as defaultUserProfileCopier}
   from 'firefox-profile';
-import streamToPromise from 'stream-to-promise';
 import {fs} from 'mz';
 import promisify from 'es6-promisify';
 
+import {streamToPromise} from '../util/stream-to-promise';
 import isDirectory from '../util/is-directory';
 import {isErrorWithCode, UsageError, WebExtError} from '../errors';
 import {getPrefs as defaultPrefGetter} from './preferences';
@@ -377,9 +377,10 @@ export async function installExtension(
     // https://developer.mozilla.org/en-US/Add-ons/Setting_up_extension_development_environment#Firefox_extension_proxy_file
     const destPath = path.join(profile.extensionsDir, `${id}`);
     const writeStream = nodeFs.createWriteStream(destPath);
+    const pendingStream = streamToPromise(writeStream);
     writeStream.write(extensionPath);
     writeStream.end();
-    await streamToPromise(writeStream);
+    return await pendingStream;
   } else {
     // Write the XPI file to the profile.
     const readStream = nodeFs.createReadStream(extensionPath);

--- a/src/util/stream-to-promise.js
+++ b/src/util/stream-to-promise.js
@@ -1,9 +1,0 @@
-/* @flow */
-
-export async function streamToPromise(
-  stream: stream$Readable | stream$Writable
-) {
-  return new Promise((resolve) => {
-    stream.on('close', resolve);
-  });
-}

--- a/src/util/stream-to-promise.js
+++ b/src/util/stream-to-promise.js
@@ -1,0 +1,9 @@
+/* @flow */
+
+export async function streamToPromise(
+  stream: stream$Readable | stream$Writable
+) {
+  return new Promise((resolve) => {
+    stream.on('close', resolve);
+  });
+}

--- a/tests/functional/common.js
+++ b/tests/functional/common.js
@@ -91,7 +91,8 @@ export function execWebExt(
 ): RunningWebExt {
 
   const spawnedProcess = spawn(
-      process.execPath, [webExt, ...argv], spawnOptions);
+    process.execPath, [webExt, ...argv], spawnOptions
+  );
 
   const waitForExit = new Promise((resolve) => {
     let errorData = '';

--- a/tests/functional/common.js
+++ b/tests/functional/common.js
@@ -90,6 +90,12 @@ export type RunningCommand = {|
 export function execCommand(
   execPath: string, argv: Array<string>, spawnOptions: child_process$spawnOpts,
 ): RunningCommand {
+  // bin/web-ext can't be directly spawned on Windows
+  if (execPath === webExt && process.platform === 'win32') {
+    argv.unshift(execPath);
+    execPath = process.execPath;
+  }
+
   const spawnedProcess = spawn(execPath, argv, spawnOptions);
   const waitForExit = new Promise((resolve) => {
     let errorData = '';

--- a/tests/functional/common.js
+++ b/tests/functional/common.js
@@ -72,31 +72,27 @@ export function reportCommandErrors(obj: Object, msg: ?string) {
   throw error;
 }
 
-// execCommand helper
+// execWebExt helper
 
-export type RunCommandResult = {|
+export type RunWebExtResult = {|
   exitCode: number,
   stderr: string,
   stdout: string,
 |};
 
-export type RunningCommand = {|
-  execPath: string,
+export type RunningWebExt = {|
   argv: Array<string>,
-  waitForExit: Promise<RunCommandResult>,
+  waitForExit: Promise<RunWebExtResult>,
   spawnedProcess: ChildProcess,
 |};
 
-export function execCommand(
-  execPath: string, argv: Array<string>, spawnOptions: child_process$spawnOpts,
-): RunningCommand {
-  // bin/web-ext can't be directly spawned on Windows
-  if (execPath === webExt && process.platform === 'win32') {
-    argv.unshift(execPath);
-    execPath = process.execPath;
-  }
+export function execWebExt(
+  argv: Array<string>, spawnOptions: child_process$spawnOpts,
+): RunningWebExt {
 
-  const spawnedProcess = spawn(execPath, argv, spawnOptions);
+  const spawnedProcess = spawn(
+      process.execPath, [webExt, ...argv], spawnOptions);
+
   const waitForExit = new Promise((resolve) => {
     let errorData = '';
     let outputData = '';
@@ -113,5 +109,5 @@ export function execCommand(
     });
   });
 
-  return {execPath, argv, waitForExit, spawnedProcess};
+  return {argv, waitForExit, spawnedProcess};
 }

--- a/tests/functional/common.js
+++ b/tests/functional/common.js
@@ -74,7 +74,7 @@ export function reportCommandErrors(obj: Object, msg: ?string) {
 
 // execWebExt helper
 
-export type RunWebExtResult = {|
+export type WebExtResult = {|
   exitCode: number,
   stderr: string,
   stdout: string,
@@ -82,7 +82,7 @@ export type RunWebExtResult = {|
 
 export type RunningWebExt = {|
   argv: Array<string>,
-  waitForExit: Promise<RunWebExtResult>,
+  waitForExit: Promise<WebExtResult>,
   spawnedProcess: ChildProcess,
 |};
 

--- a/tests/functional/common.js
+++ b/tests/functional/common.js
@@ -17,7 +17,9 @@ export const webExt = path.join(projectDir, 'bin', 'web-ext');
 export const fixturesDir = path.join(functionalTestsDir, '..', 'fixtures');
 export const addonPath = path.join(fixturesDir, 'minimal-web-ext');
 export const fakeFirefoxPath = path.join(
-  functionalTestsDir, 'fake-firefox-binary.js'
+  functionalTestsDir,
+  process.platform === 'win32' ?
+    'fake-firefox-binary.bat' : 'fake-firefox-binary.js'
 );
 export const fakeServerPath = path.join(
   functionalTestsDir, 'fake-amo-server.js'

--- a/tests/functional/fake-amo-server.js
+++ b/tests/functional/fake-amo-server.js
@@ -35,4 +35,7 @@ http.createServer(function(req, res) {
   } else {
     process.exit(1);
   }
-}).listen(8989);
+}).listen(8989, () => {
+  process.stdout.write('listening');
+  process.stdout.uncork();
+});

--- a/tests/functional/fake-firefox-binary.bat
+++ b/tests/functional/fake-firefox-binary.bat
@@ -1,0 +1,3 @@
+@ECHO OFF
+REM Spawn this file as an Firefox executable on Windows.
+node "%~dp0fake-firefox-binary.js" %*

--- a/tests/functional/test.cli.build.js
+++ b/tests/functional/test.cli.build.js
@@ -2,15 +2,15 @@
 import {describe, it} from 'mocha';
 
 import {
-  webExt, addonPath,
-  withTempAddonDir, execCommand, reportCommandErrors,
+  addonPath,
+  withTempAddonDir, execWebExt, reportCommandErrors,
 } from './common';
 
 describe('web-ext build', () => {
   it('should accept: --source-dir SRCDIR',
      () => withTempAddonDir({addonPath}, (srcDir, tmpDir) => {
        const argv = ['build', '--source-dir', srcDir, '--verbose'];
-       const cmd = execCommand(webExt, argv, {cwd: tmpDir});
+       const cmd = execWebExt(argv, {cwd: tmpDir});
 
        return cmd.waitForExit.then(({exitCode, stdout, stderr}) => {
          if (exitCode !== 0) {

--- a/tests/functional/test.cli.lint.js
+++ b/tests/functional/test.cli.lint.js
@@ -2,15 +2,15 @@
 import {describe, it} from 'mocha';
 
 import {
-  webExt, addonPath,
-  withTempAddonDir, execCommand, reportCommandErrors,
+  addonPath,
+  withTempAddonDir, execWebExt, reportCommandErrors,
 } from './common';
 
 describe('web-ext lint', () => {
   it('should accept: --source-dir SRCDIR',
      () => withTempAddonDir({addonPath}, (srcDir, tmpDir) => {
        const argv = ['lint', '--source-dir', srcDir, '--verbose'];
-       const cmd = execCommand(webExt, argv, {cwd: tmpDir});
+       const cmd = execWebExt(argv, {cwd: tmpDir});
 
        return cmd.waitForExit.then(({exitCode, stdout, stderr}) => {
          if (exitCode !== 0) {

--- a/tests/functional/test.cli.nocommand.js
+++ b/tests/functional/test.cli.nocommand.js
@@ -2,14 +2,13 @@
 import {describe, it} from 'mocha';
 
 import {
-  webExt,
-  withTempDir, execCommand, reportCommandErrors,
+  withTempDir, execWebExt, reportCommandErrors,
 } from './common';
 
 describe('web-ext', () => {
   it('should accept: --help', () => withTempDir((tmpDir) => {
     const argv = ['--help'];
-    const cmd = execCommand(webExt, argv, {cwd: tmpDir});
+    const cmd = execWebExt(argv, {cwd: tmpDir});
 
     return cmd.waitForExit.then(({exitCode, stdout, stderr}) => {
       if (exitCode !== 0) {

--- a/tests/functional/test.cli.run.js
+++ b/tests/functional/test.cli.run.js
@@ -1,5 +1,5 @@
 /* @flow */
-import {describe, it} from 'mocha';
+import {describe, it, before} from 'mocha';
 
 import {
   addonPath, fakeFirefoxPath,
@@ -9,6 +9,13 @@ import {
 const EXPECTED_MESSAGE = 'Fake Firefox binary executed correctly.';
 
 describe('web-ext run', () => {
+  before(function() {
+    // you can't spawn .js file as an executable on Windows
+    if (process.platform === 'win32') {
+      return this.skip();
+    }
+  });
+
   it('should accept: --no-reload --source-dir SRCDIR --firefox FXPATH',
      () => withTempAddonDir(
        {addonPath},

--- a/tests/functional/test.cli.run.js
+++ b/tests/functional/test.cli.run.js
@@ -1,5 +1,5 @@
 /* @flow */
-import {describe, it, before} from 'mocha';
+import {describe, it} from 'mocha';
 
 import {
   addonPath, fakeFirefoxPath,
@@ -9,12 +9,6 @@ import {
 const EXPECTED_MESSAGE = 'Fake Firefox binary executed correctly.';
 
 describe('web-ext run', () => {
-  before(function() {
-    // you can't spawn .js file as an executable on Windows
-    if (process.platform === 'win32') {
-      return this.skip();
-    }
-  });
 
   it('should accept: --no-reload --source-dir SRCDIR --firefox FXPATH',
      () => withTempAddonDir(

--- a/tests/functional/test.cli.run.js
+++ b/tests/functional/test.cli.run.js
@@ -2,8 +2,8 @@
 import {describe, it} from 'mocha';
 
 import {
-  webExt, addonPath, fakeFirefoxPath,
-  withTempAddonDir, execCommand, reportCommandErrors,
+  addonPath, fakeFirefoxPath,
+  withTempAddonDir, execWebExt, reportCommandErrors,
 } from './common';
 
 const EXPECTED_MESSAGE = 'Fake Firefox binary executed correctly.';
@@ -26,7 +26,7 @@ describe('web-ext run', () => {
            },
          };
 
-         const cmd = execCommand(webExt, argv, spawnOptions);
+         const cmd = execWebExt(argv, spawnOptions);
 
          return cmd.waitForExit.then(({exitCode, stdout, stderr}) => {
            if (stdout.indexOf(EXPECTED_MESSAGE) < 0) {

--- a/tests/functional/test.cli.sign.js
+++ b/tests/functional/test.cli.sign.js
@@ -4,8 +4,8 @@ import {spawn} from 'child_process';
 import {describe, it, beforeEach, afterEach} from 'mocha';
 
 import {
-  webExt, addonPath, fakeServerPath,
-  withTempAddonDir, execCommand, reportCommandErrors,
+  addonPath, fakeServerPath,
+  withTempAddonDir, execWebExt, reportCommandErrors,
 } from './common';
 
 describe('web-ext sign', () => {
@@ -34,7 +34,7 @@ describe('web-ext sign', () => {
          '--api-key', 'FAKEAPIKEY', '--api-secret', 'FAKEAPISECRET',
          '--source-dir', srcDir,
        ];
-       const cmd = execCommand(webExt, argv, {cwd: tmpDir});
+       const cmd = execWebExt(argv, {cwd: tmpDir});
 
        return cmd.waitForExit.then(({exitCode, stdout, stderr}) => {
          if (exitCode !== 0) {

--- a/tests/functional/test.cli.sign.js
+++ b/tests/functional/test.cli.sign.js
@@ -13,7 +13,7 @@ describe('web-ext sign', () => {
 
   beforeEach(() => {
     return new Promise((resolve, reject) => {
-      fakeServerProcess = spawn(fakeServerPath);
+      fakeServerProcess = spawn(process.execPath, [fakeServerPath]);
       fakeServerProcess.stdout.on('data', resolve);
       fakeServerProcess.stderr.on('data', reject);
     });

--- a/tests/functional/test.cli.sign.js
+++ b/tests/functional/test.cli.sign.js
@@ -12,7 +12,11 @@ describe('web-ext sign', () => {
   let fakeServerProcess;
 
   beforeEach(() => {
-    fakeServerProcess = spawn(fakeServerPath);
+    return new Promise((resolve, reject) => {
+      fakeServerProcess = spawn(fakeServerPath);
+      fakeServerProcess.stdout.on('data', resolve);
+      fakeServerProcess.stderr.on('data', reject);
+    });
   });
 
   afterEach(() => {

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -16,9 +16,11 @@ const log = createLogger(__filename);
  */
 export class ZipFile {
   _zip: any;
+  _close: Promise<void> | null;
 
   constructor() {
     this._zip = null;
+    this._close = null;
   }
 
   /*
@@ -29,7 +31,18 @@ export class ZipFile {
     return promisify(yauzl.open)(...args)
       .then((zip) => {
         this._zip = zip;
+        this._close = new Promise((resolve) => {
+          zip.once('close', resolve);
+        });
       });
+  }
+
+  /**
+   * Close the zip file and wait fd to release.
+   */
+  close() {
+    this._zip.close();
+    return this._close;
   }
 
   /*

--- a/tests/unit/test-cmd/test.build.js
+++ b/tests/unit/test-cmd/test.build.js
@@ -5,6 +5,7 @@ import {fs} from 'mz';
 import {it, describe} from 'mocha';
 import {assert} from 'chai';
 import sinon from 'sinon';
+import semver from 'semver';
 
 import build, {
   safeFileName,
@@ -90,7 +91,12 @@ describe('build', () => {
     );
   });
 
-  it('checks locale file for malformed json', () => {
+  // FIXME: Failed on Node 7.
+  // https://github.com/sindresorhus/parse-json/issues/6
+  it('checks locale file for malformed json', function() {
+    if (semver.gte(process.versions.node, '7.0.0')) {
+      return this.skip();
+    }
     return withTempDir(
       (tmpDir) => {
         const messageFileName = path.join(tmpDir.path(), 'messages.json');

--- a/tests/unit/test-cmd/test.build.js
+++ b/tests/unit/test-cmd/test.build.js
@@ -5,7 +5,6 @@ import {fs} from 'mz';
 import {it, describe} from 'mocha';
 import {assert} from 'chai';
 import sinon from 'sinon';
-import semver from 'semver';
 
 import build, {
   safeFileName,
@@ -92,12 +91,7 @@ describe('build', () => {
     );
   });
 
-  // FIXME: Failed on Node 7.
-  // https://github.com/sindresorhus/parse-json/issues/6
-  it('checks locale file for malformed json', function() {
-    if (semver.gte(process.versions.node, '7.0.0')) {
-      return this.skip();
-    }
+  it('checks locale file for malformed json', () => {
     return withTempDir(
       (tmpDir) => {
         const messageFileName = path.join(tmpDir.path(), 'messages.json');

--- a/tests/unit/test-cmd/test.build.js
+++ b/tests/unit/test-cmd/test.build.js
@@ -45,6 +45,7 @@ describe('build', () => {
             fileNames.sort();
             assert.deepEqual(fileNames,
                              ['background-script.js', 'manifest.json']);
+            return zipFile.close();
           })
     );
   });
@@ -221,6 +222,7 @@ describe('build', () => {
           .then(() => zipFile.extractFilenames())
           .then((fileNames) => {
             assert.notInclude(fileNames, 'background-script.js');
+            return zipFile.close();
           })
     );
   });

--- a/tests/unit/test-util/test.manifest.js
+++ b/tests/unit/test-util/test.manifest.js
@@ -5,6 +5,7 @@ import {describe, it} from 'mocha';
 import {assert} from 'chai';
 import deepcopy from 'deepcopy';
 import {fs} from 'mz';
+import semver from 'semver';
 
 import {onlyInstancesOf, InvalidManifest} from '../../../src/errors';
 import getValidatedManifest, {getManifestId} from '../../../src/util/manifest';
@@ -60,23 +61,30 @@ describe('util/manifest', () => {
         }));
     });
 
-    it('reports an error for invalid manifest JSON', () => withTempDir(
-      (tmpDir) => {
-        const badManifest = `{
-          "name": "I'm an invalid JSON Manifest
-          "version": "0.0.0"
-        }`;
-        const manifestFile = path.join(tmpDir.path(), 'manifest.json');
-        return fs.writeFile(manifestFile, badManifest)
-          .then(() => getValidatedManifest(tmpDir.path()))
-          .then(makeSureItFails())
-          .catch(onlyInstancesOf(InvalidManifest, (error) => {
-            assert.match(error.message, /Error parsing manifest\.json at /);
-            assert.include(error.message, 'Unexpected token \' \' at 2:49');
-            assert.include(error.message, manifestFile);
-          }));
+    // FIXME: Failed on Node 7.
+    // https://github.com/sindresorhus/parse-json/issues/6
+    it('reports an error for invalid manifest JSON', function() {
+      if (semver.gte(process.versions.node, '7.0.0')) {
+        return this.skip();
       }
-    ));
+      return withTempDir(
+        (tmpDir) => {
+          const badManifest = `{
+            "name": "I'm an invalid JSON Manifest
+            "version": "0.0.0"
+          }`;
+          const manifestFile = path.join(tmpDir.path(), 'manifest.json');
+          return fs.writeFile(manifestFile, badManifest)
+            .then(() => getValidatedManifest(tmpDir.path()))
+            .then(makeSureItFails())
+            .catch(onlyInstancesOf(InvalidManifest, (error) => {
+              assert.match(error.message, /Error parsing manifest\.json at /);
+              assert.include(error.message, 'Unexpected token \' \' at 2:49');
+              assert.include(error.message, manifestFile);
+            }));
+        }
+      );
+    });
 
     it('reports an error when missing a name', () => withTempDir(
       (tmpDir) => {

--- a/tests/unit/test-util/test.manifest.js
+++ b/tests/unit/test-util/test.manifest.js
@@ -50,7 +50,7 @@ describe('util/manifest', () => {
     ));
 
     it('reports an error for a missing manifest file', () => {
-      const nonExistentDir = '/dev/null/nowhere/';
+      const nonExistentDir = path.join('dev', 'null', 'nowhere');
       return getValidatedManifest(nonExistentDir)
         .then(makeSureItFails())
         .catch(onlyInstancesOf(InvalidManifest, (error) => {

--- a/tests/unit/test.watcher.js
+++ b/tests/unit/test.watcher.js
@@ -34,7 +34,7 @@ describe('watcher', () => {
           });
         })
         .then((watcher) => {
-          return fs.utimes(someFile, Date.now(), Date.now())
+          return fs.utimes(someFile, Date.now() / 1000, Date.now() / 1000)
             .then(() => watcher);
         })
         .then((watcher) => {


### PR DESCRIPTION
This PR makes `npm test` be able to pass under Windows 7, Node 7.0.0. However `functional/test.cli.run.js` still failed since web-ext uses `fx-runner` to spawn the browser, which is a fake .js file. Any idea how to fix this?

The original `stream-to-promise` doesn't ensure that the file descriptor is closed. This sometimes makes `fs.rmdir` throws during cleaning the tempdir when testing.

A small test script:
```javascript
var streamToPromise = require("stream-to-promise"),
	fs = require("fs");

function streamToPromise2(stream) {
	return new Promise(resolve => {
		stream.on("close", resolve);
	});
}
	
function test(toPromise, fn) {
	return new Promise(resolve => {
		var i = 0;
		(function loop() {
			var stream = fs.createWriteStream(fn),
				pending = toPromise(stream);
				
			stream.end("test");
			
			pending.then(() => {
				fs.unlinkSync(fn);
				var files = fs.readdirSync(".");
				if (files.includes(fn)) {
					console.log("fd is still opened");
					resolve();
					return;
				}
				if (i < 1000) {
					i++;
					loop();
				} else {
					console.log("all tests are passed");
					resolve();
				}
			}).catch(err => {
				console.log(err);
				resolve();
			});
		})();
	});
}

test(streamToPromise, "test.txt")
	.then(() => test(streamToPromise2, "test2.txt"));
```
