### PR TITLE
fix: Fixed loading changelog lint config

### DIFF
--- a/tasks/travis-pr-title-lint.js
+++ b/tasks/travis-pr-title-lint.js
@@ -154,7 +154,7 @@ module.exports = function(grunt) {
 
       Promise.all([
         getPreset('angular'),
-        getConfiguration('.conventional-changelog-lintrc'),
+        getConfiguration(),
       ]).then(function(results) {
         var preset = results[0];
         var configuration = results[1];

--- a/tasks/travis-pr-title-lint.js
+++ b/tasks/travis-pr-title-lint.js
@@ -1,9 +1,11 @@
 /* eslint prefer-template: 0, no-console: 0 */
 
 var exec = require('child_process').exec;
+var path = require('path');
 var https = require('https');
 
 var changelogLintPkg = require('conventional-changelog-lint');
+var fs = require('mz').fs;
 var objectValues = require('object.values');
 var objectEntries = require('object.entries');
 
@@ -152,12 +154,30 @@ module.exports = function(grunt) {
         return;
       }
 
+      var config = path.join(__dirname, '..', '.conventional-changelog-lintrc');
+      var checkLintConfig = Promise.all([
+        fs.stat(config), fs.access(config, fs.R_OK),
+      ])
+        .then(function(results) {
+          const configStat = results[0];
+
+          if (!configStat.isFile()) {
+            throw new Error(
+              `Config file "${config}" found, but it should be a regular file`
+            );
+          }
+        })
+        .catch(function(err) {
+          throw new Error(`Unable to load changelog lint config: ${err.stack}`);
+        });
+
       Promise.all([
+        checkLintConfig,
         getPreset('angular'),
         getConfiguration(),
       ]).then(function(results) {
-        var preset = results[0];
-        var configuration = results[1];
+        var preset = results[1];
+        var configuration = results[2];
 
         grunt.log.writeln('\nChangelog lint input: "' + message + '"');
 


### PR DESCRIPTION
Fixes #767

This PR introduces a small change in the `travis-pr-title-lint` grunt task that fixes the `conventional-changelog-lint` config loading.

Based on the failure from this Travis build https://travis-ci.org/mozilla/web-ext/jobs/193576176, we noticed that the configuration file `'.conventional-changelog-lintrc'` was not loading correctly, by looking at the `conventional-changelog-lint`, sources it looks like the reason was related to the usage of `getConfiguration` with the wrong parameters (which unfortunately doesn't generate any complains or promise rejection, it just return a default configuration based on the selected preset).