### PR TITLE
fix: Ignore artifactsDir only if it is a sub directory of sourceDir

### DIFF
--- a/src/util/file-filter.js
+++ b/src/util/file-filter.js
@@ -96,7 +96,7 @@ export class FileFilter {
    * file in the folder that is being archived.
    */
   wantFile(filePath: string): boolean {
-    const resolvedPath = path.resolve(filePath);
+    const resolvedPath = this.resolve(filePath);
     for (const test of this.filesToIgnore) {
       if (minimatch(resolvedPath, test)) {
         log.debug(

--- a/src/util/file-filter.js
+++ b/src/util/file-filter.js
@@ -8,7 +8,7 @@ import {createLogger} from './logger';
 const log = createLogger(__filename);
 
 // check if target is a sub directory of src
-export const isSubDir = (src: string, target: string): boolean => {
+export const isSubPath = (src: string, target: string): boolean => {
   const relate = path.relative(src, target);
   // same dir
   if (!relate) {
@@ -58,7 +58,7 @@ export class FileFilter {
     if (ignoreFiles) {
       this.addToIgnoreList(ignoreFiles);
     }
-    if (artifactsDir && isSubDir(sourceDir, artifactsDir)) {
+    if (artifactsDir && isSubPath(sourceDir, artifactsDir)) {
       artifactsDir = path.resolve(artifactsDir);
       log.debug(
         `Ignoring artifacts directory "${artifactsDir}" ` +

--- a/src/util/file-filter.js
+++ b/src/util/file-filter.js
@@ -22,7 +22,7 @@ export const isSubDir = (src: string, target: string): boolean => {
 export type FileFilterOptions = {|
   baseIgnoredPatterns?: Array<string>,
   ignoreFiles?: Array<string>,
-  sourceDir?: string,
+  sourceDir: string,
   artifactsDir?: string,
 |};
 
@@ -43,7 +43,7 @@ export class FileFilter {
       '**/node_modules/**/*',
     ],
     ignoreFiles = [],
-    sourceDir = '.',
+    sourceDir,
     artifactsDir,
   }: FileFilterOptions = {}) {
     sourceDir = path.resolve(sourceDir);

--- a/src/util/file-filter.js
+++ b/src/util/file-filter.js
@@ -92,7 +92,7 @@ export class FileFilter {
    * file in the folder that is being archived.
    */
   wantFile(filePath: string): boolean {
-    const resolvedPath = this.resolve(filePath);
+    const resolvedPath = path.resolve(filePath);
     for (const test of this.filesToIgnore) {
       if (minimatch(resolvedPath, test)) {
         log.debug(

--- a/src/util/file-filter.js
+++ b/src/util/file-filter.js
@@ -69,11 +69,15 @@ export class FileFilter {
   }
 
   /**
-   *  Resolve relative path to absolute path if sourceDir is setted.
+   *  Resolve relative path to absolute path with sourceDir.
    */
   resolve(file: string): string {
-    log.debug(`Resolved path ${file} with sourceDir ${this.sourceDir}`);
-    return path.resolve(this.sourceDir, file);
+    const resolvedPath = path.resolve(this.sourceDir, file);
+    log.debug(
+      `Resolved path ${file} with sourceDir ${this.sourceDir} ` +
+      `to ${resolvedPath}`
+    );
+    return resolvedPath;
   }
 
   /**

--- a/src/util/file-filter.js
+++ b/src/util/file-filter.js
@@ -14,7 +14,10 @@ export const isSubDir = (src: string, target: string): boolean => {
   if (!relate) {
     return false;
   }
-  return relate[0] !== '.';
+  if (relate === '..') {
+    return false;
+  }
+  return !relate.startsWith(`..${path.sep}`);
 };
 
 // FileFilter types and implementation.

--- a/src/util/file-filter.js
+++ b/src/util/file-filter.js
@@ -69,19 +69,16 @@ export class FileFilter {
   }
 
   /**
-   *  Resolve relative path to absolute path if sourceDir is setted.
-   */
-  resolve(file: string): string {
-    log.debug(`Resolved path ${file} with sourceDir ${this.sourceDir}`);
-    return path.resolve(this.sourceDir, file);
-  }
-
-  /**
    *  Insert more files into filesToIgnore array.
    */
   addToIgnoreList(files: Array<string>) {
     for (const file of files) {
-      this.filesToIgnore.push(this.resolve(file));
+      const resolvedFile = path.resolve(this.sourceDir, file);
+      log.debug(
+        `Resolved path ${file} with sourceDir ${this.sourceDir} ` +
+        `to ${resolvedFile}`
+      );
+      this.filesToIgnore.push(resolvedFile);
     }
   }
 

--- a/src/util/file-filter.js
+++ b/src/util/file-filter.js
@@ -71,7 +71,7 @@ export class FileFilter {
   /**
    *  Resolve relative path to absolute path with sourceDir.
    */
-  resolve(file: string): string {
+  resolveWithSourceDir(file: string): string {
     const resolvedPath = path.resolve(this.sourceDir, file);
     log.debug(
       `Resolved path ${file} with sourceDir ${this.sourceDir} ` +
@@ -85,7 +85,7 @@ export class FileFilter {
    */
   addToIgnoreList(files: Array<string>) {
     for (const file of files) {
-      this.filesToIgnore.push(this.resolve(file));
+      this.filesToIgnore.push(this.resolveWithSourceDir(file));
     }
   }
 
@@ -100,7 +100,7 @@ export class FileFilter {
    * file in the folder that is being archived.
    */
   wantFile(filePath: string): boolean {
-    const resolvedPath = this.resolve(filePath);
+    const resolvedPath = this.resolveWithSourceDir(filePath);
     for (const test of this.filesToIgnore) {
       if (minimatch(resolvedPath, test)) {
         log.debug(

--- a/src/util/file-filter.js
+++ b/src/util/file-filter.js
@@ -57,6 +57,10 @@ export class FileFilter {
     }
     if (artifactsDir && isSubDir(sourceDir, artifactsDir)) {
       artifactsDir = path.resolve(artifactsDir);
+      log.debug(
+        `Ignoring artifacts directory "${artifactsDir}" ` +
+        'and all its subdirectories'
+      );
       this.addToIgnoreList([
         artifactsDir,
         path.join(artifactsDir, '**', '*'),

--- a/src/util/file-filter.js
+++ b/src/util/file-filter.js
@@ -69,16 +69,19 @@ export class FileFilter {
   }
 
   /**
+   *  Resolve relative path to absolute path if sourceDir is setted.
+   */
+  resolve(file: string): string {
+    log.debug(`Resolved path ${file} with sourceDir ${this.sourceDir}`);
+    return path.resolve(this.sourceDir, file);
+  }
+
+  /**
    *  Insert more files into filesToIgnore array.
    */
   addToIgnoreList(files: Array<string>) {
     for (const file of files) {
-      const resolvedFile = path.resolve(this.sourceDir, file);
-      log.debug(
-        `Resolved path ${file} with sourceDir ${this.sourceDir} ` +
-        `to ${resolvedFile}`
-      );
-      this.filesToIgnore.push(resolvedFile);
+      this.filesToIgnore.push(this.resolve(file));
     }
   }
 

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -18,7 +18,7 @@ export type OnSourceChangeParams = {|
   sourceDir: string,
   artifactsDir: string,
   onChange: OnChangeFn,
-  shouldWatchFile?: ShouldWatchFn,
+  shouldWatchFile: ShouldWatchFn,
 |};
 
 // NOTE: this fix an issue with flow and default exports (which currently
@@ -58,15 +58,12 @@ export type ProxyFileChangesParams = {|
   artifactsDir: string,
   onChange: OnChangeFn,
   filePath: string,
-  shouldWatchFile?: ShouldWatchFn,
+  shouldWatchFile: ShouldWatchFn,
 |};
 
 export function proxyFileChanges(
   {artifactsDir, onChange, filePath, shouldWatchFile}: ProxyFileChangesParams
 ): void {
-  if (!shouldWatchFile) {
-    shouldWatchFile = () => true;
-  }
   if (filePath.indexOf(artifactsDir) === 0 || !shouldWatchFile(filePath)) {
     log.debug(`Ignoring change to: ${filePath}`);
   } else {

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -3,7 +3,6 @@ import Watchpack from 'watchpack';
 import debounce from 'debounce';
 
 import {createLogger} from './util/logger';
-import {FileFilter} from './util/file-filter';
 
 
 const log = createLogger(__filename);
@@ -66,8 +65,7 @@ export function proxyFileChanges(
   {artifactsDir, onChange, filePath, shouldWatchFile}: ProxyFileChangesParams
 ): void {
   if (!shouldWatchFile) {
-    const fileFilter = new FileFilter();
-    shouldWatchFile = (...args) => fileFilter.wantFile(...args);
+    shouldWatchFile = () => true;
   }
   if (filePath.indexOf(artifactsDir) === 0 || !shouldWatchFile(filePath)) {
     log.debug(`Ignoring change to: ${filePath}`);

--- a/tests/unit/test-cmd/test.build.js
+++ b/tests/unit/test-cmd/test.build.js
@@ -224,6 +224,7 @@ describe('build', () => {
   it('asks FileFilter what files to include in the ZIP', () => {
     const zipFile = new ZipFile();
     const fileFilter = new FileFilter({
+      sourceDir: '.',
       baseIgnoredPatterns: ['**/background-script.js'],
     });
 
@@ -244,11 +245,11 @@ describe('build', () => {
 
   it('lets you rebuild when files change', () => withTempDir(
     (tmpDir) => {
-      const fileFilter = new FileFilter();
-      sinon.spy(fileFilter, 'wantFile');
-      const onSourceChange = sinon.spy(() => {});
       const sourceDir = fixturePath('minimal-web-ext');
       const artifactsDir = tmpDir.path();
+      const fileFilter = new FileFilter({sourceDir, artifactsDir});
+      sinon.spy(fileFilter, 'wantFile');
+      const onSourceChange = sinon.spy(() => {});
       return build({
         sourceDir, artifactsDir, asNeeded: true,
       }, {

--- a/tests/unit/test-util/test.file-filter.js
+++ b/tests/unit/test-util/test.file-filter.js
@@ -2,7 +2,7 @@
 import {describe, it} from 'mocha';
 import {assert} from 'chai';
 
-import {FileFilter} from '../../../src/util/file-filter';
+import {FileFilter, isSubDir} from '../../../src/util/file-filter';
 
 describe('util/file-filter', () => {
 
@@ -108,6 +108,17 @@ describe('util/file-filter', () => {
       assert.equal(filter.wantFile('/some.js'), true);
     });
 
+  });
+
+  describe('isSubDir', () => {
+    it('test if target is a sub directory of src', () => {
+      assert.equal(isSubDir('dist', '.'), false);
+      assert.equal(isSubDir('.', 'artifacts'), true);
+      assert.equal(isSubDir('.', '.'), false);
+      assert.equal(isSubDir('/src/dist', '/src'), false);
+      assert.equal(isSubDir('/src', '/src/artifacts'), true);
+      assert.equal(isSubDir('/src', '/src'), false);
+    });
   });
 
 });

--- a/tests/unit/test-util/test.file-filter.js
+++ b/tests/unit/test-util/test.file-filter.js
@@ -125,6 +125,7 @@ describe('util/file-filter', () => {
       assert.equal(isSubDir('/src/dist', '/src'), false);
       assert.equal(isSubDir('/src', '/src/artifacts'), true);
       assert.equal(isSubDir('/src', '/src'), false);
+      assert.equal(isSubDir('/firstroot', '/secondroot'), false);
     });
   });
 

--- a/tests/unit/test-util/test.file-filter.js
+++ b/tests/unit/test-util/test.file-filter.js
@@ -2,7 +2,7 @@
 import {describe, it} from 'mocha';
 import {assert} from 'chai';
 
-import {FileFilter, isSubDir} from '../../../src/util/file-filter';
+import {FileFilter, isSubPath} from '../../../src/util/file-filter';
 
 describe('util/file-filter', () => {
 
@@ -117,17 +117,17 @@ describe('util/file-filter', () => {
 
   });
 
-  describe('isSubDir', () => {
+  describe('isSubPath', () => {
     it('test if target is a sub directory of src', () => {
-      assert.equal(isSubDir('dist', '.'), false);
-      assert.equal(isSubDir('.', 'artifacts'), true);
-      assert.equal(isSubDir('.', '.'), false);
-      assert.equal(isSubDir('/src/dist', '/src'), false);
-      assert.equal(isSubDir('/src', '/src/artifacts'), true);
-      assert.equal(isSubDir('/src', '/src'), false);
-      assert.equal(isSubDir('/firstroot', '/secondroot'), false);
-      assert.equal(isSubDir('/src', '/src/.dir'), true);
-      assert.equal(isSubDir('/src', '/src/..dir'), true);
+      assert.equal(isSubPath('dist', '.'), false);
+      assert.equal(isSubPath('.', 'artifacts'), true);
+      assert.equal(isSubPath('.', '.'), false);
+      assert.equal(isSubPath('/src/dist', '/src'), false);
+      assert.equal(isSubPath('/src', '/src/artifacts'), true);
+      assert.equal(isSubPath('/src', '/src'), false);
+      assert.equal(isSubPath('/firstroot', '/secondroot'), false);
+      assert.equal(isSubPath('/src', '/src/.dir'), true);
+      assert.equal(isSubPath('/src', '/src/..dir'), true);
     });
   });
 

--- a/tests/unit/test-util/test.file-filter.js
+++ b/tests/unit/test-util/test.file-filter.js
@@ -1,10 +1,8 @@
 /* @flow */
-import path from 'path';
-
 import {describe, it} from 'mocha';
 import {assert} from 'chai';
 
-import {FileFilter, normalizeResolve} from '../../../src/util/file-filter';
+import {FileFilter} from '../../../src/util/file-filter';
 
 describe('util/file-filter', () => {
 
@@ -80,6 +78,15 @@ describe('util/file-filter', () => {
       assert.equal(filter.wantFile('artifacts/some.js'), false);
     });
 
+    it('no ignore if artifactsDir is outside the sourceDir', () => {
+      const filter = new FileFilter({
+        artifactsDir: '.',
+        sourceDir: 'dist',
+      });
+      assert.equal(filter.wantFile('file'), true);
+      assert.equal(filter.wantFile('dist/file'), true);
+    });
+
     it('resolve relative path', () => {
       const filter = new FileFilter({
         sourceDir: '/src',
@@ -88,7 +95,7 @@ describe('util/file-filter', () => {
           'ignore-dir/', 'some.js', '**/some.log', 'ignore/dir/content/**/*',
         ],
       });
-      assert.equal(filter.wantFile('/src/artifacts'), false);
+      assert.equal(filter.wantFile('/src/artifacts'), true);
       assert.equal(filter.wantFile('/src/ignore-dir'), false);
       assert.equal(filter.wantFile('/src/ignore-dir/some.css'), true);
       assert.equal(filter.wantFile('/src/some.js'), false);
@@ -101,25 +108,6 @@ describe('util/file-filter', () => {
       assert.equal(filter.wantFile('/some.js'), true);
     });
 
-  });
-
-  describe('normalizeResolve', () => {
-    const paths = [
-      'file', 'dir/',
-      'path/to/file', 'path/to/dir/', 'path/to/../file', 'path/to/../dir/',
-      'path/to/dir/.', 'path/to/dir/..',
-    ];
-
-    it('mimic path.resolve', () => {
-      const src = '/src/';
-
-      paths.forEach((file) => {
-        assert.equal(
-          path.resolve(src, file),
-          path.join(path.resolve(src), normalizeResolve(file))
-        );
-      });
-    });
   });
 
 });

--- a/tests/unit/test-util/test.file-filter.js
+++ b/tests/unit/test-util/test.file-filter.js
@@ -7,7 +7,7 @@ import {FileFilter, isSubDir} from '../../../src/util/file-filter';
 describe('util/file-filter', () => {
 
   describe('default', () => {
-    const defaultFilter = new FileFilter();
+    const defaultFilter = new FileFilter({sourceDir: '.'});
 
     it('ignores long XPI paths', () => {
       assert.equal(defaultFilter.wantFile('path/to/some.xpi'), false);
@@ -56,6 +56,7 @@ describe('util/file-filter', () => {
 
     it('override the defaults with baseIgnoredPatterns', () => {
       const filter = new FileFilter({
+        sourceDir: '.',
         baseIgnoredPatterns: ['manifest.json'],
       });
       assert.equal(filter.wantFile('some.xpi'), true);
@@ -64,6 +65,7 @@ describe('util/file-filter', () => {
 
     it('add more files to ignore with ignoreFiles', () => {
       const filter = new FileFilter({
+        sourceDir: '.',
         ignoreFiles: ['*.log'],
       });
       assert.equal(filter.wantFile('some.xpi'), false);
@@ -72,6 +74,7 @@ describe('util/file-filter', () => {
 
     it('ignore artifactsDir and its content', () => {
       const filter = new FileFilter({
+        sourceDir: '.',
         artifactsDir: 'artifacts',
       });
       assert.equal(filter.wantFile('artifacts'), false);

--- a/tests/unit/test-util/test.file-filter.js
+++ b/tests/unit/test-util/test.file-filter.js
@@ -126,6 +126,8 @@ describe('util/file-filter', () => {
       assert.equal(isSubDir('/src', '/src/artifacts'), true);
       assert.equal(isSubDir('/src', '/src'), false);
       assert.equal(isSubDir('/firstroot', '/secondroot'), false);
+      assert.equal(isSubDir('/src', '/src/.dir'), true);
+      assert.equal(isSubDir('/src', '/src/..dir'), true);
     });
   });
 

--- a/tests/unit/test-util/test.file-filter.js
+++ b/tests/unit/test-util/test.file-filter.js
@@ -81,7 +81,7 @@ describe('util/file-filter', () => {
       assert.equal(filter.wantFile('artifacts/some.js'), false);
     });
 
-    it('no ignore if artifactsDir is outside the sourceDir', () => {
+    it('does not ignore an artifactsDir outside of sourceDir', () => {
       const filter = new FileFilter({
         artifactsDir: '.',
         sourceDir: 'dist',

--- a/tests/unit/test-util/test.file-filter.js
+++ b/tests/unit/test-util/test.file-filter.js
@@ -6,8 +6,15 @@ import {FileFilter, isSubDir} from '../../../src/util/file-filter';
 
 describe('util/file-filter', () => {
 
+  const newFileFilter = (params = {}) => {
+    return new FileFilter({
+      sourceDir: '.',
+      ...params,
+    });
+  };
+
   describe('default', () => {
-    const defaultFilter = new FileFilter({sourceDir: '.'});
+    const defaultFilter = newFileFilter();
 
     it('ignores long XPI paths', () => {
       assert.equal(defaultFilter.wantFile('path/to/some.xpi'), false);
@@ -55,8 +62,7 @@ describe('util/file-filter', () => {
   describe('options', () => {
 
     it('override the defaults with baseIgnoredPatterns', () => {
-      const filter = new FileFilter({
-        sourceDir: '.',
+      const filter = newFileFilter({
         baseIgnoredPatterns: ['manifest.json'],
       });
       assert.equal(filter.wantFile('some.xpi'), true);
@@ -64,8 +70,7 @@ describe('util/file-filter', () => {
     });
 
     it('add more files to ignore with ignoreFiles', () => {
-      const filter = new FileFilter({
-        sourceDir: '.',
+      const filter = newFileFilter({
         ignoreFiles: ['*.log'],
       });
       assert.equal(filter.wantFile('some.xpi'), false);
@@ -73,8 +78,7 @@ describe('util/file-filter', () => {
     });
 
     it('ignore artifactsDir and its content', () => {
-      const filter = new FileFilter({
-        sourceDir: '.',
+      const filter = newFileFilter({
         artifactsDir: 'artifacts',
       });
       assert.equal(filter.wantFile('artifacts'), false);
@@ -82,7 +86,7 @@ describe('util/file-filter', () => {
     });
 
     it('does not ignore an artifactsDir outside of sourceDir', () => {
-      const filter = new FileFilter({
+      const filter = newFileFilter({
         artifactsDir: '.',
         sourceDir: 'dist',
       });
@@ -91,7 +95,7 @@ describe('util/file-filter', () => {
     });
 
     it('resolve relative path', () => {
-      const filter = new FileFilter({
+      const filter = newFileFilter({
         sourceDir: '/src',
         artifactsDir: 'artifacts',
         ignoreFiles: [

--- a/tests/unit/test.watcher.js
+++ b/tests/unit/test.watcher.js
@@ -103,16 +103,6 @@ describe('watcher', () => {
 
     });
 
-    it('filters out commonly unwanted files by default', () => {
-      const conf = {
-        ...defaults,
-        shouldWatchFile: undefined,
-        onChange: sinon.spy(() => {}),
-      };
-      proxyFileChanges({...conf, filePath: '/somewhere/.git'});
-      assert.equal(conf.onChange.called, false);
-    });
-
   });
 
 });

--- a/tests/unit/test.watcher.js
+++ b/tests/unit/test.watcher.js
@@ -31,6 +31,7 @@ describe('watcher', () => {
             sourceDir: tmpDir.path(),
             artifactsDir,
             onChange,
+            shouldWatchFile: () => true,
           });
         })
         .then((watcher) => {
@@ -56,6 +57,7 @@ describe('watcher', () => {
     const defaults = {
       artifactsDir: '/some/artifacts/dir/',
       onChange: () => {},
+      shouldWatchFile: () => true,
     };
 
     it('proxies file changes', () => {


### PR DESCRIPTION
Fixes #789

I tried to drop "relative mode" to make FileFilter simpler:

1. `sourceDir` defaults to `.`
2. `FileFilter` would only match files inside `sourceDir`. (prefix all patterns with `sourceDir`)
3. `sourceDir` and `artifactsDir` are resolved with `cwd`.
4. `wantFile(path)` is resolved with `cwd`.

The change in (2) makes `proxyFileChanges` unable to filter out `baseIgnoredPatterns` since it doesn't know `sourceDir`, and I just removed that test.
