### PR TITLE
style: Fix typo: “occured” → “occurred”

### DIFF
--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -70,7 +70,7 @@ export function defaultWatcherCreator(
           log.error('\n');
           log.error(error.stack);
           desktopNotifications({
-            title: 'web-ext run: error occured',
+            title: 'web-ext run: error occurred',
             message: error.message,
           });
           throw error;


### PR DESCRIPTION
Saw the typo prominently featured in the first screenshot of this blog post: https://blog.mozilla.org/addons/2017/02/09/web-ext-1-8-released/