### PR TITLE
feat: Added web-ext run --experiments to install additional webextensions experiments/addons

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "babel-preset-es2015": "6.18.0",
     "babel-preset-stage-2": "6.18.0",
     "chai": "3.5.0",
+    "chai-as-promised": "6.0.0",
     "conventional-changelog-cli": "1.2.0",
     "conventional-changelog-lint": "1.1.0",
     "copy-dir": "0.3.0",

--- a/src/program.js
+++ b/src/program.js
@@ -388,6 +388,13 @@ Example: $0 --help run.
         demand: false,
         type: 'boolean',
       },
+      'experiments': {
+        describe: 'Install one or more WebExtensions Experiments ' +
+                  'alongside the WebExtension Addon.',
+        demand: false,
+        requiresArg: true,
+        type: 'array',
+      },
     })
     .command('lint', 'Validate the web extension source', commands.lint, {
       'output': {


### PR DESCRIPTION
This PR goal is to make working with experiments easier and faster (which should fix #741) by providing an additional command line option for "web-ext run" (that is "--experiments" in the current version of this patch) which:

- install the experiments (one or more than one) before installing the extension (which is needed because the extension will depends on the experiments and a "your extension is not compatible with the application version" error is going to be raised if we try to install the extension before the experiments it depends on)

- watch the experiments sources and reload the experiment addon when they change (which also already has the very nice side-effect of reloading the addon that depends from the reloaded experiment)

- raise an error if we try to use it with --pre-install (mainly because with --pre-install the experiment cannot be reloaded, well... it can be disabled and re-enabled to achieve the same effect, but I'm not sure there is a lot of value on supporting the experiments with this mode)

- raise an error if the experiment addon id is missing during the experiments installation

Example command line:
```
web-ext run -s ./extension --experiments ./experiment ../../another-experiment -f /path/to/nightly-or-devedition/bin/firefox
```

Note: the "-- experiments" option take an array of paths to the experiments, but they do not need to really be webextension experiment addons, they can also be just regular addons, the only requirement is that they should be able to install as temporarily installed addons.