### PR TITLE
feat: Added conditional check to launch browser in multiple tabs with environment var

### DIFF
--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -365,10 +365,16 @@ export class ExtensionRunner {
       binaryArgs.push('-jsconsole');
     }
     if (startUrl) {
-      const urls = Array.isArray(startUrl) ? startUrl : [startUrl];
+      let urls;
+      if (typeof startUrl === 'string' && startUrl.indexOf(' ') !== -1) {
+        urls = startUrl.split(' ');
+      } else {
+        urls = Array.isArray(startUrl) ? startUrl : [startUrl];
+      }
       for (const url of urls) {
         binaryArgs.push('--url', url);
       }
+      log.debug('binaryArgs is: ', binaryArgs);
     }
     return firefoxApp.run(profile, {
       firefoxBinary: firefox, binaryArgs,

--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -374,7 +374,6 @@ export class ExtensionRunner {
       for (const url of urls) {
         binaryArgs.push('--url', url);
       }
-      log.debug('binaryArgs is: ', binaryArgs);
     }
     return firefoxApp.run(profile, {
       firefoxBinary: firefox, binaryArgs,


### PR DESCRIPTION
The environment variable `WEB_EXT_START_URL` returns multiple urls as a single string. For example:

`WEB_EXT_START_URL="mozilla.org addons.mozilla.org" web-ext run` returns: 

`'mozilla.org addons.mozilla.org'`, which doesn't yield the desired behavior of opening multiple tabs in Firefox. 

Whereas its counterpart command `web-ext run --start-url mozilla.org --start-url addons.mozilla.org` returns an `array`: 

`[ 'mozilla.org', 'addons.mozilla.org' ]`, which does yield the desired behavior.

If you change the [--start-url type](https://github.com/mozilla/web-ext/blob/d37cb13039e2667aa3bf01c86b357a6c6d80993f/src/program.js#L366) from `string` to `array`, that doesn't solve the problem because with that change, `WEB_EXT_START_URL="mozilla.org addons.mozilla.org" web-ext run` returns a single item `array` like so: `[ 'mozilla.org addons.mozilla.org' ]`.

Thus, the solution I propose in this PR is to leave [--start-url type](https://github.com/mozilla/web-ext/blob/d37cb13039e2667aa3bf01c86b357a6c6d80993f/src/program.js#L366) as type `string`, and to add a [conditional check](https://github.com/mozilla/web-ext/blob/master/src/cmd/run.js#L377) that will catch a string with multiple urls and convert it to an array to get each URL sent as a separate arg to Firefox. 

As to why the environment var returns multiple urls as a single `string` and the standard command returns an `array`, I figure it must have something to do with yargs, but I haven't been able to isolate why yet. Perhaps you can shed some light? 

Fixes #797