### PR TITLE
feat: Removed temporary profile path from `web-ext run` logging

### DIFF
--- a/src/firefox/index.js
+++ b/src/firefox/index.js
@@ -130,7 +130,7 @@ export async function run(
   }: FirefoxRunOptions = {}
 ): Promise<FirefoxProcess> {
 
-  log.info(`Running Firefox with profile at ${profile.path()}`);
+  log.debug(`Running Firefox with profile at ${profile.path()}`);
 
   const remotePort = await findRemotePort();
 


### PR DESCRIPTION
Fixes #820

I think the only fix for this was to convert this [line of code](https://github.com/mozilla/web-ext/blob/master/src/firefox/index.js#L133) from `log.info(...)` to `log.debug(...)`. You don't see the temporary path when you type `web-ext run`, but you do when you run `web-ext --verbose run`.

