### PR TITLE
fix: Allowed --ignore-files option within sign command

### DIFF
--- a/src/cmd/sign.js
+++ b/src/cmd/sign.js
@@ -24,6 +24,7 @@ export type SignParams = {|
   verbose?: boolean,
   sourceDir: string,
   artifactsDir: string,
+  ignoreFiles?: Array<string>,
   apiKey: string,
   apiSecret: string,
   apiUrlPrefix: string,
@@ -45,8 +46,8 @@ export type SignResult = {|
 
 export default function sign(
   {
-    verbose, sourceDir, artifactsDir, apiKey, apiSecret,
-    apiUrlPrefix, apiProxy, id, timeout,
+    verbose, sourceDir, artifactsDir, ignoreFiles = [],
+    apiKey, apiSecret, apiUrlPrefix, apiProxy, id, timeout,
   }: SignParams,
   {
     build = defaultBuilder, signAddon = defaultAddonSigner,
@@ -66,7 +67,7 @@ export default function sign(
       }
 
       const [buildResult, idFromSourceDir] = await Promise.all([
-        build({sourceDir, artifactsDir: tmpDir.path()},
+        build({sourceDir, ignoreFiles, artifactsDir: tmpDir.path()},
               {manifestData, showReadyMessage: false}),
         getIdFromSourceDir(sourceDir),
       ]);

--- a/tests/unit/test-cmd/test.sign.js
+++ b/tests/unit/test-cmd/test.sign.js
@@ -303,6 +303,18 @@ describe('sign', () => {
     }
   ));
 
+  it('passes the ignoreFiles flag to the builder', () => withTempDir(
+    (tmpDir) => {
+      const stubs = getStubs();
+      const ignoreFiles = ['*'];
+      return sign(tmpDir, stubs, {extraArgs: {ignoreFiles}})
+        .then(() => {
+          assert.equal(stubs.signAddon.called, true);
+          assert.equal(stubs.build.firstCall.args[0].ignoreFiles, ignoreFiles);
+        });
+    }
+  ));
+
   it('passes through a signing exception', () => withTempDir(
     (tmpDir) => {
       const stubs = getStubs();


### PR DESCRIPTION
This is meant to fix #843.

Also worth noting, some unrelated tests failed on my computer, due to i18n : 

```
1) program.Program throws an error about unknown options:
     AssertionError: expected 'Argument inconnu: nope' to match /Unknown argument: nope/
      at Function.assert.match (node_modules/chai/lib/chai/interface/assert.js:883:32)
      at dist/webpack:/tests/unit/test.program.js:226:16
      at runMicrotasksCallback (internal/process/next_tick.js:58:5)
      at _combinedTickCallback (internal/process/next_tick.js:67:7)
      at process._tickDomainCallback (internal/process/next_tick.js:122:9)

  2) program.Program throws an error about unknown sub-command options:
     AssertionError: expected 'Argument inconnu: nope' to match /Unknown argument: nope/
      at Function.assert.match (node_modules/chai/lib/chai/interface/assert.js:883:32)
      at dist/webpack:/tests/unit/test.program.js:237:16
      at runMicrotasksCallback (internal/process/next_tick.js:58:5)
      at _combinedTickCallback (internal/process/next_tick.js:67:7)
      at process._tickDomainCallback (internal/process/next_tick.js:122:9)
```

This is because an exception is thrown in french : `Argument inconnu: nope` instead of `Unknown argument: nope`.