### PR TITLE
fix: Changed web-ext build to suggest submitting the generated zip file to AMO (Fixes #847)

### DIFF
--- a/src/cmd/build.js
+++ b/src/cmd/build.js
@@ -131,7 +131,8 @@ async function defaultPackageCreator({
   await eventToPromise(stream, 'close');
 
   if (showReadyMessage) {
-    log.info(`Your web extension is ready: ${extensionPath}`);
+    log.info('Your web extension is ready for being submitted on ' +
+             `addons.mozilla.org: ${extensionPath}`);
   }
   return {extensionPath};
 }


### PR DESCRIPTION
this fixes https://github.com/mozilla/web-ext/issues/847

Now `web-ext build` prints the following message:

```
Building web extension from /tmp/test
Your web extension is ready for being submitted on addons.mozilla.org: /tmp/test/web-ext-artifacts/test-1.0.zip
```
