### PR TITLE
fix: initiate remote debugger with firefox runner's port

### DIFF
--- a/src/firefox/index.js
+++ b/src/firefox/index.js
@@ -109,6 +109,11 @@ export type FirefoxRunnerFn =
   (params: FirefoxRunnerParams) => Promise<FirefoxRunnerResults>;
 
 
+export type FirefoxInfo = {|
+  firefox: FirefoxProcess,
+  debuggerPort: number,
+|}
+
 // Run command types and implementaion.
 
 export type FirefoxRunOptions = {|
@@ -129,7 +134,7 @@ export async function run(
     findRemotePort = defaultRemotePortFinder,
     firefoxBinary, binaryArgs,
   }: FirefoxRunOptions = {}
-): Promise<FirefoxProcess> {
+): Promise<FirefoxInfo> {
 
   log.debug(`Running Firefox with profile at ${profile.path()}`);
 
@@ -180,7 +185,7 @@ export async function run(
     log.debug('Firefox closed');
   });
 
-  return firefox;
+  return { firefox, debuggerPort: remotePort };
 }
 
 

--- a/src/firefox/remote.js
+++ b/src/firefox/remote.js
@@ -204,6 +204,6 @@ export default async function connect(
 ): Promise<RemoteFirefox> {
   log.debug(`Connecting to Firefox on port ${port}`);
   const client = await connectToFirefox(port);
-  log.debug('Connected to the remote Firefox debugger');
+  log.debug(`Connected to the remote Firefox debugger on port ${port}`);
   return new RemoteFirefox(client);
 }


### PR DESCRIPTION
Fixes #821 