### PR TITLE
fix: Prevent --keep-profile-changes on default Firefox profiles

### DIFF
--- a/src/firefox/index.js
+++ b/src/firefox/index.js
@@ -336,9 +336,10 @@ export async function useProfile(
   const isForbiddenProfile = await isFirefoxDefaultProfile(profilePath);
   if (isForbiddenProfile) {
     throw new UsageError(
-      'Using --keep-profile-changes' +
-      ` on the Firefox default profile "${profilePath}" is forbidden.` +
-      '\n(See https://github.com/mozilla/web-ext/issues/1005)'
+      'Cannot use --keep-profile-changes on a default profile' +
+      ` ("${profilePath}")` +
+      ' because web-ext will make it insecure and unsuitable for daily use.' +
+      '\nSee https://github.com/mozilla/web-ext/issues/1005'
     );
   }
   const profile = new FirefoxProfile({destinationDirectory: profilePath});

--- a/src/firefox/index.js
+++ b/src/firefox/index.js
@@ -211,7 +211,7 @@ export async function isDefaultProfile(
   profilePathOrName: string,
   ProfileFinder?: typeof FirefoxProfile.Finder = FirefoxProfile.Finder
 ): Promise<boolean> {
-  if (DEFAULT_PROFILES_NAMES.indexOf(profilePathOrName) >= 0) {
+  if (DEFAULT_PROFILES_NAMES.includes(profilePathOrName)) {
     return true;
   }
 
@@ -243,7 +243,7 @@ export async function isDefaultProfile(
   for (const profile of finder.profiles) {
     // Check if the profile dir path or name is one of the default profiles
     // defined in the profiles.ini file.
-    if (DEFAULT_PROFILES_NAMES.indexOf(profile.Name) >= 0 ||
+    if (DEFAULT_PROFILES_NAMES.includes(profile.Name) ||
         profile.Default === '1') {
       let profileFullPath;
 

--- a/tests/unit/test-firefox/test.firefox.js
+++ b/tests/unit/test-firefox/test.firefox.js
@@ -422,6 +422,31 @@ describe('firefox', () => {
          });
        });
 
+    it('rejects on any unexpected error while looking for profiles.ini',
+       async () => {
+         return withTempDir(async (tmpDir) => {
+           const profilesDirPath = tmpDir.path();
+           const FakeProfileFinder = createFakeProfileFinder(profilesDirPath);
+           const fakeFsStat = sinon.spy(() => {
+             return Promise.reject(new Error('Fake fs stat error'));
+           });
+
+           let exception;
+           try {
+             await firefox.isDefaultProfile(
+               '/tmp/my-custom-profile-dir',
+               FakeProfileFinder,
+               fakeFsStat
+             );
+           } catch (error) {
+             exception = error;
+           }
+
+           assert.match(exception && exception.message, /Fake fs stat error/);
+         });
+       }
+      );
+
   });
 
   describe('createProfile', () => {

--- a/tests/unit/test-firefox/test.firefox.js
+++ b/tests/unit/test-firefox/test.firefox.js
@@ -51,13 +51,14 @@ function createFakeProfileFinder(profilesDirPath) {
   return FakeProfileFinder;
 }
 
-async function createFakeProfilesIni(dirPath, profilesDefs) { // eslint-disable-line
+async function createFakeProfilesIni(
+  dirPath: string, profilesDefs: Array<Object>
+): Promise<void> {
   let content = '';
 
   for (const [idx, profile] of profilesDefs.entries()) {
     content += `[Profile${idx}]\n`;
     for (const k of Object.keys(profile)) {
-      // $FLOW_FIXME: test123
       content += `${k}=${profile[k]}\n`;
     }
     content += '\n';

--- a/tests/unit/test-firefox/test.firefox.js
+++ b/tests/unit/test-firefox/test.firefox.js
@@ -486,7 +486,7 @@ describe('firefox', () => {
 
         assert.match(
           exception && exception.message,
-            /Using --keep-profile-changes .* forbidden/
+            /Cannot use --keep-profile-changes on a default profile/
         );
       });
 

--- a/tests/unit/test-firefox/test.firefox.js
+++ b/tests/unit/test-firefox/test.firefox.js
@@ -326,12 +326,18 @@ describe('firefox', () => {
           const isDefault = await firefox.isDefaultProfile(
             'manually-set-default', FakeProfileFinder
           );
+          assert.equal(
+            isDefault, true,
+            'Manually configured default profile'
+          );
+
           const isNotDefault = await firefox.isDefaultProfile(
             'unkown-profile-name', FakeProfileFinder
           );
-
-          assert.equal(isDefault, true);
-          assert.equal(isNotDefault, false);
+          assert.equal(
+            isNotDefault, false,
+            'Unknown profile name'
+          );
         });
       });
 
@@ -367,19 +373,37 @@ describe('firefox', () => {
              path.join(profilesDirPath, 'fake-default-profile'),
              FakeProfileFinder
            );
-           assert.equal(isFirefoxDefaultPath, true);
+           assert.equal(
+             isFirefoxDefaultPath, true,
+             'Firefox default profile'
+           );
 
            const isDevEditionDefaultPath = await firefox.isDefaultProfile(
              path.join(profilesDirPath, 'fake-devedition-default-profile'),
              FakeProfileFinder
            );
-           assert.equal(isDevEditionDefaultPath, true);
+           assert.equal(
+             isDevEditionDefaultPath, true,
+             'Firefox DevEdition default profile'
+           );
 
            const isManuallyDefault = await firefox.isDefaultProfile(
              absProfilePath,
              FakeProfileFinder
            );
-           assert.equal(isManuallyDefault, true);
+           assert.equal(
+             isManuallyDefault, true,
+             'Manually configured default profile'
+           );
+
+           const isNotDefault = await firefox.isDefaultProfile(
+             path.join(profilesDirPath, 'unkown-profile-dir'),
+             FakeProfileFinder
+           );
+           assert.equal(
+             isNotDefault, false,
+             'Unknown profile path'
+           );
          });
        });
 

--- a/tests/unit/test-firefox/test.firefox.js
+++ b/tests/unit/test-firefox/test.firefox.js
@@ -380,12 +380,6 @@ describe('firefox', () => {
              FakeProfileFinder
            );
            assert.equal(isManuallyDefault, true);
-
-           const isNotDefault = await firefox.isDefaultProfile(
-             path.join(profilesDirPath, 'unkown-profile-dir'),
-             FakeProfileFinder
-           );
-           assert.equal(isNotDefault, false);
          });
        });
 

--- a/tests/unit/test-firefox/test.firefox.js
+++ b/tests/unit/test-firefox/test.firefox.js
@@ -308,7 +308,7 @@ describe('firefox', () => {
          assert.equal(isDevEditionDefault, true);
        });
 
-    it('allows profile name if is not listed as default in profiles.ini',
+    it('allows profile name if it is not listed as default in profiles.ini',
       async () => {
         return withTempDir(async (tmpDir) => {
           const profilesDirPath = tmpDir.path();
@@ -335,7 +335,7 @@ describe('firefox', () => {
         });
       });
 
-    it('allows profile path if is not listed as default in profiles.ini',
+    it('allows profile path if it is not listed as default in profiles.ini',
        async () => {
          return withTempDir(async (tmpDir) => {
            const profilesDirPath = tmpDir.path();

--- a/tests/unit/test-firefox/test.firefox.js
+++ b/tests/unit/test-firefox/test.firefox.js
@@ -340,6 +340,10 @@ describe('firefox', () => {
          return withTempDir(async (tmpDir) => {
            const profilesDirPath = tmpDir.path();
            const FakeProfileFinder = createFakeProfileFinder(profilesDirPath);
+           const absProfilePath = path.join(
+             profilesDirPath,
+             'fake-manually-default-profile'
+           );
 
            await createFakeProfilesIni(profilesDirPath, [
              {
@@ -354,7 +358,7 @@ describe('firefox', () => {
              },
              {
                Name: 'manually-set-default',
-               Path: '/tmp/fake-manually-default-profile',
+               Path: absProfilePath,
                Default: 1,
              },
            ]);
@@ -372,7 +376,7 @@ describe('firefox', () => {
            assert.equal(isDevEditionDefaultPath, true);
 
            const isManuallyDefault = await firefox.isDefaultProfile(
-             '/tmp/fake-manually-default-profile',
+             absProfilePath,
              FakeProfileFinder
            );
            assert.equal(isManuallyDefault, true);


### PR DESCRIPTION
This PR extracts (and expands) the "checks for the Firefox default profile" pieces that we are working on in #968 to fix #1005 

- [x] additional checks needed to prevent the usage on the --keep-profile-changes option on a default Firefox profile (when specified using the name, a full path or a relative path)
- [x] additional unit tests