### PR TITLE
Exposing run command from node package

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 /* @flow */
 import {main} from './program';
+import cmd from './cmd';
 
-export {main};
+export {main, cmd};


### PR DESCRIPTION
Relates to https://github.com/mozilla/web-ext/issues/683

web-ext can be useful not only as a cli but also being integrated to other build tools.
This simple PR exposes `run` command from node module entry point, so other project can use it:
```js
const path = require('path');
const run = require('web-ext').run;

run({
  noReload: true,
  sourceDir: path.resolve('.'),
  artifactsDir: path.resolve('.', 'web-ext-artifacts'),
});
```