### PR TITLE
feat: run command handles bootstap addons

### DIFF
--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -67,7 +67,17 @@ export default async function run(
     noReload = true;
   }
 
-  const manifestData = await getValidatedManifest(sourceDir);
+  let manifestData;
+
+  try {
+    manifestData = await getValidatedManifest(sourceDir);
+  } catch (e) {
+    // in case it is not a webExtension
+    manifestData = {
+      name: '',
+      version: '',
+    };
+  }
 
   const firefoxDesktopRunnerParams = {
     // Common options.


### PR DESCRIPTION
on top of: https://github.com/mozilla/web-ext/pull/1018
and this PR, web-ext can be use to `run` boostrapped/system addons.