### PR TITLE
feat: You can now use web-ext programatically, e.g. `webExt.cmd.run()`

### DIFF
--- a/bin/web-ext
+++ b/bin/web-ext
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+var webExt = require('../dist/web-ext').default;
 var path = require('path');
 var absolutePackageDir = path.join(path.resolve(__dirname), '..');
-require('../dist/web-ext').main(absolutePackageDir);
+
+webExt.main(absolutePackageDir);

--- a/src/cmd/build.js
+++ b/src/cmd/build.js
@@ -175,6 +175,7 @@ export type BuildCmdParams = {|
   sourceDir: string,
   artifactsDir: string,
   asNeeded?: boolean,
+  noInput?: boolean,
   overwriteDest?: boolean,
   ignoreFiles?: Array<string>,
 |};
@@ -196,6 +197,7 @@ export default async function build(
     asNeeded = false,
     overwriteDest = false,
     ignoreFiles = [],
+    noInput = false,
   }: BuildCmdParams,
   {
     manifestData,

--- a/src/cmd/docs.js
+++ b/src/cmd/docs.js
@@ -5,16 +5,20 @@ import {createLogger} from '../util/logger';
 
 const log = createLogger(__filename);
 
+type DocsParams = {
+  noInput?: boolean,
+  shouldExitProgram?: boolean,
+}
+
 type DocsOptions = {
   openUrl?: typeof defaultUrlOpener,
-  shouldExitProgram?: boolean,
 }
 
 export const url = 'https://developer.mozilla.org/en-US/Add-ons' +
   '/WebExtensions/Getting_started_with_web-ext';
 
 export default function docs(
-  params: Object, {openUrl = defaultUrlOpener}: DocsOptions = {}
+  params: DocsParams, {openUrl = defaultUrlOpener}: DocsOptions = {}
 ) {
   return new Promise((resolve, reject) => {
     openUrl(url, (error) => {

--- a/src/cmd/index.js
+++ b/src/cmd/index.js
@@ -6,4 +6,3 @@ import sign from './sign';
 import docs from './docs';
 
 export default {build, lint, run, sign, docs};
-

--- a/src/cmd/lint.js
+++ b/src/cmd/lint.js
@@ -41,16 +41,17 @@ export type LinterCreatorFn = (params: LinterCreatorParams) => Linter;
 // Lint command types and implementation.
 
 export type LintCmdParams = {|
+  artifactsDir?: string,
+  boring?: boolean,
+  ignoreFiles?: Array<string>,
+  metadata?: boolean,
+  noInput?: boolean,
+  output?: LinterOutputType,
+  pretty?: boolean,
+  selfHosted?: boolean,
   sourceDir: string,
   verbose?: boolean,
-  selfHosted?: boolean,
-  boring?: boolean,
-  output?: LinterOutputType,
-  metadata?: boolean,
-  pretty?: boolean,
   warningsAsErrors?: boolean,
-  ignoreFiles?: Array<string>,
-  artifactsDir?: string,
 |};
 
 export type LintCmdOptions = {|
@@ -61,8 +62,17 @@ export type LintCmdOptions = {|
 
 export default function lint(
   {
-    verbose, sourceDir, selfHosted, boring, output,
-    metadata, pretty, warningsAsErrors, ignoreFiles, artifactsDir,
+    artifactsDir,
+    boring,
+    ignoreFiles,
+    metadata,
+    noInput = false,
+    output,
+    pretty,
+    sourceDir,
+    selfHosted,
+    verbose,
+    warningsAsErrors,
   }: LintCmdParams,
   {
     createLinter = defaultLinterCreator,

--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -22,17 +22,18 @@ const log = createLogger(__filename);
 // Run command types and implementation.
 
 export type CmdRunParams = {|
-  sourceDir: string,
   artifactsDir: string,
-  firefox: string,
-  firefoxProfile?: string,
-  keepProfileChanges: boolean,
-  preInstall: boolean,
-  noReload: boolean,
   browserConsole: boolean,
   customPrefs?: FirefoxPreferences,
-  startUrl?: string | Array<string>,
+  firefox: string,
+  firefoxProfile?: string,
   ignoreFiles?: Array<string>,
+  keepProfileChanges: boolean,
+  noInput?: boolean,
+  noReload: boolean,
+  preInstall: boolean,
+  sourceDir: string,
+  startUrl?: string | Array<string>,
 |};
 
 export type CmdRunOptions = {|
@@ -48,9 +49,18 @@ export type CmdRunOptions = {|
 
 export default async function run(
   {
-    sourceDir, artifactsDir, firefox, firefoxProfile,
-    keepProfileChanges = false, preInstall = false, noReload = false,
-    browserConsole = false, customPrefs, startUrl, ignoreFiles,
+    artifactsDir,
+    browserConsole = false,
+    customPrefs,
+    firefox,
+    firefoxProfile,
+    keepProfileChanges = false,
+    ignoreFiles,
+    noInput = false,
+    noReload = false,
+    preInstall = false,
+    sourceDir,
+    startUrl,
   }: CmdRunParams,
   {
     desktopNotifications = defaultDesktopNotifications,
@@ -111,6 +121,7 @@ export default async function run(
       sourceDir,
       artifactsDir,
       ignoreFiles,
+      noInput,
     });
   }
 

--- a/src/cmd/sign.js
+++ b/src/cmd/sign.js
@@ -20,16 +20,17 @@ export const extensionIdFile = '.web-extension-id';
 // Sign command types and implementation.
 
 export type SignParams = {|
-  id?: string,
-  verbose?: boolean,
-  sourceDir: string,
-  artifactsDir: string,
-  ignoreFiles?: Array<string>,
   apiKey: string,
+  apiProxy: string,
   apiSecret: string,
   apiUrlPrefix: string,
-  apiProxy: string,
+  artifactsDir: string,
+  id?: string,
+  ignoreFiles?: Array<string>,
+  noInput?: boolean,
+  sourceDir: string,
   timeout: number,
+  verbose?: boolean,
 |};
 
 export type SignOptions = {
@@ -47,12 +48,22 @@ export type SignResult = {|
 
 export default function sign(
   {
-    verbose, sourceDir, artifactsDir, ignoreFiles = [],
-    apiKey, apiSecret, apiUrlPrefix, apiProxy, id, timeout,
+    apiKey,
+    apiProxy,
+    apiSecret,
+    apiUrlPrefix,
+    artifactsDir,
+    id,
+    ignoreFiles = [],
+    noInput = false,
+    sourceDir,
+    timeout,
+    verbose,
   }: SignParams,
   {
-    build = defaultBuilder, signAddon = defaultAddonSigner,
+    build = defaultBuilder,
     preValidatedManifest,
+    signAddon = defaultAddonSigner,
   }: SignOptions = {}
 ): Promise<SignResult> {
   return withTempDir(

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,10 @@
 /* @flow */
 import {main} from './program';
 import cmd from './cmd';
+import * as logger from './util/logger';
 
-export default {main, cmd};
+// This only exposes util/logger so far.
+// Do we need anything else?
+const util = {logger};
+
+export default {main, cmd, util};

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 /* @flow */
 import {main} from './program';
+import cmd from './cmd';
 
-export {main};
+export default {main, cmd};

--- a/tests/unit/test-cmd/test.run.js
+++ b/tests/unit/test-cmd/test.run.js
@@ -136,6 +136,14 @@ describe('run', () => {
     assert.equal(args.artifactsDir, artifactsDir);
   });
 
+  it('can disable input in the reload strategy', async () => {
+    const cmd = prepareRun();
+    const {reloadStrategy} = cmd.options;
+
+    await cmd.run({noInput: true, noReload: false});
+    sinon.assert.calledWithMatch(reloadStrategy, {noInput: true});
+  });
+
   it('will not reload when using --pre-install', async () => {
     const cmd = prepareRun();
     const {reloadStrategy} = cmd.options;

--- a/tests/unit/test-extension-runners/test.extension-runners.js
+++ b/tests/unit/test-extension-runners/test.extension-runners.js
@@ -500,6 +500,27 @@ describe('util/extension-runners', () => {
       }
     });
 
+    it('allows you to disable input', async () => {
+      const {extensionRunner, reloadStrategy} = prepare();
+      sinon.spy(extensionRunner, 'registerCleanup');
+
+      const fakeStdin = new tty.ReadStream();
+      sinon.spy(fakeStdin, 'pause');
+      sinon.spy(fakeStdin, 'setRawMode');
+
+      try {
+        await reloadStrategy({noInput: true}, {stdin: fakeStdin});
+        // This is meant to test that all input is ignored.
+        sinon.assert.notCalled(fakeStdin.setRawMode);
+      } finally {
+        exitKeypressLoop(fakeStdin);
+      }
+
+      const cleanupCb = extensionRunner.registerCleanup.firstCall.args[0];
+      cleanupCb();
+      sinon.assert.notCalled(fakeStdin.pause);
+    });
+
     it('can still reload when user presses R after a reload error',
       async () => {
         const {extensionRunner, reloadStrategy} = prepare({

--- a/tests/unit/test.web-ext.js
+++ b/tests/unit/test.web-ext.js
@@ -6,6 +6,7 @@ import webExt from '../../src/main';
 import build from '../../src/cmd/build';
 import run from '../../src/cmd/run';
 import {main} from '../../src/program';
+import {consoleStream} from '../../src/util/logger';
 
 
 describe('webExt', () => {
@@ -17,5 +18,9 @@ describe('webExt', () => {
     // This just checks a sample of commands.
     assert.equal(webExt.cmd.run, run);
     assert.equal(webExt.cmd.build, build);
+  });
+
+  it('gives you access to the log stream', () => {
+    assert.equal(webExt.util.logger.consoleStream, consoleStream);
   });
 });

--- a/tests/unit/test.web-ext.js
+++ b/tests/unit/test.web-ext.js
@@ -1,0 +1,21 @@
+/* @flow */
+import {describe, it} from 'mocha';
+import {assert} from 'chai';
+
+import webExt from '../../src/main';
+import build from '../../src/cmd/build';
+import run from '../../src/cmd/run';
+import {main} from '../../src/program';
+
+
+describe('webExt', () => {
+  it('exposes main', () => {
+    assert.equal(webExt.main, main);
+  });
+
+  it('exposes commands', () => {
+    // This just checks a sample of commands.
+    assert.equal(webExt.cmd.run, run);
+    assert.equal(webExt.cmd.build, build);
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/mozilla/web-ext/issues/683

This only supports minimal programmatic use. You can just execute raw functions without any argument validation, like:

```js
import webExt from 'web-ext';

webExt.cmd.run({shouldExitProgram: false, firefox: '...', sourceDir: '...'})
  .then((extensionRunner) => {
    console.log(extensionRunner);
  });
```

One would have to set up verbose logging manually:

```js
webExt.util.logger.consoleStream.makeVerbose();
webExt.cmd.run({shouldExitProgram: false, firefox: '...', sourceDir: '...'});
```

You can also disable the use of standard input:

```js
webExt.cmd.run({shouldExitProgram: false, noInput: true});
```