### PR TITLE
chore: clean up aliasing of --pref

### DIFF
--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -24,7 +24,7 @@ const log = createLogger(__filename);
 export type CmdRunParams = {|
   artifactsDir: string,
   browserConsole: boolean,
-  customPrefs?: FirefoxPreferences,
+  pref?: FirefoxPreferences,
   firefox: string,
   firefoxProfile?: string,
   ignoreFiles?: Array<string>,
@@ -51,7 +51,7 @@ export default async function run(
   {
     artifactsDir,
     browserConsole = false,
-    customPrefs,
+    pref,
     firefox,
     firefoxProfile,
     keepProfileChanges = false,
@@ -79,6 +79,9 @@ export default async function run(
     noReload = true;
   }
 
+  // Create an alias for --pref since it has been transformed into an
+  // object containing one or more preferences.
+  const customPrefs = pref;
   const manifestData = await getValidatedManifest(sourceDir);
 
   const firefoxDesktopRunnerParams = {

--- a/src/program.js
+++ b/src/program.js
@@ -124,9 +124,6 @@ export class Program {
     const argv = this.yargs.argv;
     const cmd = argv._[0];
 
-    // Command line option (pref) renamed for internal use (customPref).
-    argv.customPrefs = argv.pref;
-
     const runCommand = this.commands[cmd];
 
     if (argv.verbose) {

--- a/tests/unit/test-cmd/test.run.js
+++ b/tests/unit/test-cmd/test.run.js
@@ -89,7 +89,7 @@ describe('run', () => {
       keepProfileChanges: true,
       browserConsole: true,
       firefox: '/path/to/custom/bin/firefox',
-      customPrefs: {'my.custom.pref': 'value'},
+      pref: {'my.custom.pref': 'value'},
       firefoxProfile: '/path/to/custom/profile',
     };
 
@@ -99,14 +99,23 @@ describe('run', () => {
 
     assert.ok(FirefoxDesktopExtensionRunner.called);
     const runnerParams = FirefoxDesktopExtensionRunner.firstCall.args[0];
+
+    // The runner should receive the same parameters as the options sent
+    // to run() with just a few minor adjustments.
+    const expectedRunnerParams = { ...runOptions };
+    expectedRunnerParams.firefoxBinary = runOptions.firefox;
+    delete expectedRunnerParams.firefox;
+    expectedRunnerParams.customPrefs = runOptions.pref;
+    delete expectedRunnerParams.pref;
+
     assert.deepEqual({
       preInstall: runnerParams.preInstall,
       keepProfileChanges: runnerParams.keepProfileChanges,
       browserConsole: runnerParams.browserConsole,
-      firefox: runnerParams.firefoxBinary,
+      firefoxBinary: runnerParams.firefoxBinary,
       customPrefs: runnerParams.customPrefs,
       firefoxProfile: runnerParams.profilePath,
-    }, runOptions);
+    }, expectedRunnerParams);
     assert.equal(runnerParams.extensions.length, 1);
     assert.equal(runnerParams.extensions[0].sourceDir, cmd.argv.sourceDir);
   });

--- a/tests/unit/test.program.js
+++ b/tests/unit/test.program.js
@@ -411,10 +411,10 @@ describe('program.main', () => {
       ['run', '--pref', 'prop=true', '--pref', 'prop2=value2'],
       {commands: fakeCommands})
       .then(() => {
-        const {customPrefs} = fakeCommands.run.firstCall.args[0];
-        assert.isObject(customPrefs);
-        assert.equal(customPrefs.prop, true);
-        assert.equal(customPrefs.prop2, 'value2');
+        const {pref} = fakeCommands.run.firstCall.args[0];
+        assert.isObject(pref);
+        assert.equal(pref.prop, true);
+        assert.equal(pref.prop2, 'value2');
       });
   });
 


### PR DESCRIPTION
I was trying to track down the `--pref` option and I became confused until I realized it was getting aliased in `program.js`. I don't think this is the right place to alias it because it's not an obvious place to look. Also, it introduces an inconsistency since no other option is aliased like that. Most importantly, I'd like to keep the mapping of option names to top-level callback arguments one-to-one, whenever possible, for sanity.