### PR TITLE
docs: Add summary to docs and fix command descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,16 @@ cross-platform way. Initially, it will provide a streamlined experience for deve
 * [Getting started with web-ext](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Getting_started_with_web-ext)
 * [Command reference](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/web-ext_command_reference)
 
-Here are the commands you can run. Click on each one for detailed documentation or use `--help` on the command line, such as `web-ext --help build`.
+Here are the commands you can run. Click on each one for detailed documentation or use `--help` on the command line, such as `web-ext build --help`.
 
-* [`build`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/web-ext_command_reference#web-ext_build)
-  * Create an extension package from source
-* [`sign`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/web-ext_command_reference#web-ext_sign)
-  * Sign the extension so it can be installed in Firefox
 * [`run`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/web-ext_command_reference#web-ext_run)
   * Run the extension
 * [`lint`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/web-ext_command_reference#web-ext_lint)
   * Validate the extension source
+* [`sign`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/web-ext_command_reference#web-ext_sign)
+  * Sign the extension so it can be installed in Firefox
+* [`build`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/web-ext_command_reference#web-ext_build)
+  * Create an extension package from source
 * [`docs`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/web-ext_command_reference#web-ext_docs)
   * Open the `web-ext` documentation in a browser
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@ cross-platform way. Initially, it will provide a streamlined experience for deve
 * [Getting started with web-ext](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Getting_started_with_web-ext)
 * [Command reference](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/web-ext_command_reference)
 
+Here are the commands you can run. Click on each one for detailed documentation or use `--help` on the command line, such as `web-ext --help build`.
+
+* [`build`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/web-ext_command_reference#web-ext_build)
+  * Create an extension package from source
+* [`sign`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/web-ext_command_reference#web-ext_sign)
+  * Sign the extension so it can be installed in Firefox
+* [`run`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/web-ext_command_reference#web-ext_run)
+  * Run the extension
+* [`lint`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/web-ext_command_reference#web-ext_lint)
+  * Validate the extension source
+* [`docs`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/web-ext_command_reference#web-ext_docs)
+  * Open the `web-ext` documentation in a browser
+
 ## Installation from npm
 
 First, make sure you are running the current

--- a/src/program.js
+++ b/src/program.js
@@ -270,7 +270,7 @@ Example: $0 --help run.
   program
     .command(
       'build',
-      'Create a web extension package from source',
+      'Create an extension package from source',
       commands.build, {
         'as-needed': {
           describe: 'Watch for file changes and re-build as needed',
@@ -284,7 +284,7 @@ Example: $0 --help run.
       })
     .command(
       'sign',
-      'Sign the web extension so it can be installed in Firefox',
+      'Sign the extension so it can be installed in Firefox',
       commands.sign, {
         'api-key': {
           describe: 'API key (JWT issuer) from addons.mozilla.org',
@@ -321,7 +321,7 @@ Example: $0 --help run.
           type: 'number',
         },
       })
-    .command('run', 'Run the web extension', commands.run, {
+    .command('run', 'Run the extension', commands.run, {
       'firefox': {
         alias: ['f', 'firefox-binary'],
         describe: 'Path or alias to a Firefox executable such as firefox-bin ' +
@@ -383,7 +383,7 @@ Example: $0 --help run.
         type: 'boolean',
       },
     })
-    .command('lint', 'Validate the web extension source', commands.lint, {
+    .command('lint', 'Validate the extension source', commands.lint, {
       'output': {
         alias: 'o',
         describe: 'The type of output to generate',


### PR DESCRIPTION
The command descriptions now follow the new extension terminology: https://wiki.mozilla.org/Add-ons/Terminology