### PR TITLE
fix(package): update addons-linter to version 0.26.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,16 @@ before_script:
 
 # Keep this in sync with appveyor.yml
 script:
+## run eslint, flow and the unit test suite.
 - COVERAGE=y NODE_ENV=production npm test
+
+## run functional test suite in a npm production environment
+## (See #1082 for rationale).
+- npm run copy-dist-files-to-artifacts-dir
+- cd artifacts/production && npm install --production && cd -
+- TEST_WEB_EXT_BIN=./artifacts/production/bin/web-ext npm run test:functional
+
+## lint the github PR title.
 - npm run travis-pr-title-lint
 
 after_script: npm run publish-coverage

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,13 +30,12 @@ module.exports = function(grunt) {
     'webpack:functional_tests',
   ]);
 
-  grunt.registerTask('test', 'run linting and test suites', function() {
+  grunt.registerTask('test', 'run linting and the unit test suite', function() {
     var tasks = [
       'lint',
       'flowbin:check',
       'build-tests',
       'mochaTest:unit',
-      'mochaTest:functional',
     ];
 
     // TODO: enable the flowbin:check task on AppVeyor (mozilla/web-ext#773)
@@ -46,6 +45,27 @@ module.exports = function(grunt) {
     }
 
     grunt.task.run(tasks);
+  });
+
+  grunt.registerTask('test:functional', 'run functional test suites', [
+    'build-tests',
+    'mochaTest:functional',
+  ]);
+
+  grunt.registerTask('copy-dist-files-to-artifacts-dir', function() {
+    const distFile = grunt.file.expand('./dist/**').filter((filename) => {
+      return filename.endsWith('web-ext.js');
+    });
+
+    if (distFile.length === 0) {
+      // By default grunt will exit here, unless the `--force` grunt option has been
+      // specified on the command line.
+      grunt.fail.warn(
+        'Required dist/ file missing. Run the build command first.'
+      );
+    }
+
+    grunt.task.run('copy:dist-files-to-artifacts-dir');
   });
 
   grunt.registerTask('develop', [

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,3 +21,13 @@ test_script:
   - set COVERAGE=y
   - set NODE_ENV=production
   - npm run test
+  ## install the eslint version needed by eslint and run functional test suite
+  ## (See #1082 for rationale).
+  ## run functional test suite in a npm production environment
+  ## (See #1082 for rationale).
+  - npm run copy-dist-files-to-artifacts-dir
+  - cd artifacts\production
+  - npm install --production
+  - cd ..\..
+  - set TEST_WEB_EXT_BIN=artifacts\production\bin\web-ext
+  - npm run test:functional

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "opera"
   ],
   "dependencies": {
-    "addons-linter": "0.25.1",
+    "addons-linter": "0.26.1",
     "babel-polyfill": "6.20.0",
     "babel-runtime": "6.25.0",
     "bunyan": "1.8.10",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "flow-check": "grunt flowbin:check",
     "lint": "grunt lint",
     "test": "grunt test",
+    "test:functional": "grunt test:functional:run",
+    "copy-dist-files-to-artifacts-dir": "grunt copy-dist-files-to-artifacts-dir",
     "publish-coverage": "grunt coveralls",
     "nsp-check": "nsp check -o summary",
     "changelog": "conventional-changelog -p angular -u",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "coveralls": "2.13.1",
     "deepcopy": "0.6.3",
     "doctoc": "1.3.0",
+    "eslint": "3.19.0",
     "eslint-plugin-async-await": "0.0.0",
     "eslint-plugin-flowtype": "2.35.0",
     "eslint-plugin-import": "2.3.0",

--- a/tasks/configs/copy.js
+++ b/tasks/configs/copy.js
@@ -1,0 +1,11 @@
+module.exports = {
+  'dist-files-to-artifacts-dir': {
+    files: [
+      {
+        expand: true,
+        src: ['package.json', 'dist/**', 'bin/**'],
+        dest: 'artifacts/production',
+      },
+    ],
+  },
+};

--- a/tests/functional/common.js
+++ b/tests/functional/common.js
@@ -13,7 +13,9 @@ export const withTempDir = tmpDirUtils.withTempDir;
 
 export const functionalTestsDir = path.resolve(__dirname);
 export const projectDir = path.join(functionalTestsDir, '..', '..');
-export const webExt = path.join(projectDir, 'bin', 'web-ext');
+export const webExt = process.env.TEST_WEB_EXT_BIN ?
+  path.resolve(process.env.TEST_WEB_EXT_BIN) :
+  path.join(projectDir, 'bin', 'web-ext');
 export const fixturesDir = path.join(functionalTestsDir, '..', 'fixtures');
 export const minimalAddonPath = path.join(fixturesDir, 'minimal-web-ext');
 export const fakeFirefoxPath = path.join(


### PR DESCRIPTION
Closes #1076

Here's an explanation of the problem. Eslint needs to load the `eslint-recommended` plugin. Before the latest `addons-linter` upgrade, it worked like this:

```
$ eslint --debug 'src/**/*.js'
...
  eslint:config-file Loading /Users/kumar/dev/web-ext/node_modules/eslint/conf/eslint-recommended.js +7ms
```

This works fine because there's only one `eslint` in the tree:

```
$ yarn list eslint
yarn list v1.1.0
└─ eslint@3.19.0
```

After upgrading `addons-linter`, we introduce a new `eslint` and it loads a different version of `eslint-recommended`:

```
$ eslint --debug 'src/**/*.js'
...
  eslint:config-file Loading /Users/kumar/dev/web-ext/node_modules/addons-linter/node_modules/eslint/conf/eslint-recommended.js +4ms
```

Here's where you can see the conflicting packages:

```
$ yarn list eslint
yarn list v1.1.0
├─ addons-linter@0.26.1
│  └─ eslint@4.7.1
└─ eslint@3.19.0
```

Why is `eslint` loading the wrong `eslint-recommended`? These bugs could be related but in our case it fails with `npm`, not just `yarn`:

* https://github.com/eslint/eslint/issues/8547
* https://github.com/eslint/eslint/issues/7338