### PR TITLE
feat: allow to specify multiple source directories

### DIFF
--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -82,11 +82,14 @@ export default async function run(
   // Create an alias for --pref since it has been transformed into an
   // object containing one or more preferences.
   const customPrefs = pref;
-  const manifestData = await getValidatedManifest(sourceDir);
+  const extensions = await Promise.all(sourceDir.split(',').map(async (sourceDir) => {
+    let manifestData = await getValidatedManifest(sourceDir);
+    return { sourceDir, manifestData };
+  }));
 
   const firefoxDesktopRunnerParams = {
     // Common options.
-    extensions: [{sourceDir, manifestData}],
+    extensions: extensions,
     keepProfileChanges,
     startUrl,
     desktopNotifications,


### PR DESCRIPTION
This change allows `web-ext` to receive multiple source directories as a comma-separated list. (Sorry I cannot find out how to receive multiple `--source-dir=...` options like `--pref=...`.) This fixes #1107.