### PR TITLE
feat: WiP - Allow connecting to an existing Firefox instance

### DIFF
--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -27,6 +27,7 @@ export type CmdRunParams = {|
   pref?: FirefoxPreferences,
   firefox: string,
   firefoxProfile?: string,
+  firefoxPort?: number,
   ignoreFiles?: Array<string>,
   keepProfileChanges: boolean,
   noInput?: boolean,
@@ -54,6 +55,7 @@ export default async function run(
     pref,
     firefox,
     firefoxProfile,
+    firefoxPort,
     keepProfileChanges = false,
     ignoreFiles,
     noInput = false,
@@ -93,6 +95,7 @@ export default async function run(
 
     // Firefox specific CLI options.
     firefoxBinary: firefox,
+    firefoxPort: firefoxPort,
     profilePath: firefoxProfile,
     customPrefs,
     browserConsole,

--- a/src/program.js
+++ b/src/program.js
@@ -341,6 +341,15 @@ Example: $0 --help run.
         demand: false,
         type: 'string',
       },
+      'firefox-port': {
+        alias: 'P',
+        describe: 'Attach to a running Firefox on this developer tools ' +
+                  'port. To do so, open the developer toolbar and enter ' +
+                  'e.g. `listen 6060`. This flag usually does not need to ' +
+                  'be set and is only for advanced use.',
+        demand: false,
+        type: 'number'
+      },
       'keep-profile-changes': {
         describe: 'Run Firefox directly in custom profile. Any changes to ' +
                   'the profile will be saved.',


### PR DESCRIPTION
Hey @kumar303, this is my WiP for #1100. It is mostly unpolished because I do have a few design questions open:

* `FirefoxInfo` has a `FirefoxProcess` member that is checked against `null` in some of the code. When connecting to a remote port without a process, there is nothing sensible to set `FirefoxProcess` to. Right now what I am doing is creating a mock `runningInfo` that just has the debuggerPort and the process' `kill` function which is used for cleanup. I can imagine better ways to fix this, but I'd appreciate your input on what you prefer. There could be some refactoring involved in this.
* Code right now assumes the only reason a process will interrupt is if the process is closed. I think it would be good to change/adapt this to react when the connection to the devtools server is interrupted. I'm not yet sure the event for this is exposed, but I would investigate. This way if you close the Firefox you've connected to it will properly disconnect. Does this sound reasonable?
* A feature I should add is that if e.g. Ctrl+C is pressed, the last action before the connection to the devtools server is interrupted is to uninstall the temporary add-on. The code for this would have to live in the mock `kill` function and would be asynchronous instead. I'd likely have to adapt the `FirefoxDesktopExtensionRunner::exit` function to take care of the asynchronous shutdown. Does this sound right?
* There are a few options not compatible with the `--firefox-port` option, e.g. `--firefox-profile`, `--firefox-binary`, `--keep-profile-changes`, and `--pre-install`. I could reasonably make `--pref`, `--browser-console`, and `--start-url` work, but I think that would be bonus. Is there an existing way to flag incompatible options, and if not anything I should consider while implementing? 
* I've added some text explaining this is an advanced feature to the option description. Do you consider this enough?