### PR TITLE
fix(package): update addons-linter to version 0.30.0 and ensure that CI tests fail on production npm binary components in dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,24 @@ script:
 ## run eslint, flow and the unit test suite.
 - COVERAGE=y NODE_ENV=production npm test
 
+## NOTE: by setting the configured python to /bin/false we are forcing the production mode tests
+## to fail if any of the dependencies is a binary dependency that is build using node-gyp.
+- npm config set python /bin/false
+
 ## run functional test suite in a npm production environment
 ## (See #1082 for rationale).
 - npm run copy-dist-files-to-artifacts-dir
-- cd artifacts/production && npm install --production && cd -
-- TEST_WEB_EXT_BIN=./artifacts/production/bin/web-ext npm run test:functional
+- cd artifacts/production
+- npm install --production; export NPM_INSTALL_EXIT_CODE=$?
+- cd -
+- test $NPM_INSTALL_EXIT_CODE -eq 0 &&
+  TEST_WEB_EXT_BIN=./artifacts/production/bin/web-ext npm run test:functional
+
+## NOTE: remove the custom python path from the npm config, and also
+## remove production package.json (which seems to convince npm run travlis-pr-title-lint
+## to look for grunt in the production node_modules/ dir).
+- npm config delete python
+- rm artifacts/production/package.json
 
 ## lint the github PR title.
 - npm run travis-pr-title-lint

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,8 @@
+## Force 64bit platform and nodejs, the addons-linter has dependencies which
+## do not provide a pre-compiled 32bit version of their nodejs binary module.
+platform: x64
 install:
-  - ps: Install-Product node $env:nodejs_version
+  - ps: Install-Product node $env:nodejs_version x64
   - set CI=true
   - set PATH=%APPDATA%\npm;%PATH%
   - npm install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,13 @@ test_script:
   ## (See #1082 for rationale).
   - npm run copy-dist-files-to-artifacts-dir
   - cd artifacts\production
+  ## NOTE: by setting the configured python to a batch file that exits with an error,
+  ## we are forcing the production mode tests to fail if any of the dependencies is
+  ## a binary dependency that is built using node-gyp.
+  - echo "exit /b 1" > C:\Python-forbidden-in-production-install.cmd
+  - npm config set python C:\Python-forbidden-in-production-install.cmd
   - npm install --production
   - cd ..\..
+  - npm config delete python
   - set TEST_WEB_EXT_BIN=artifacts\production\bin\web-ext
   - npm run test:functional

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "opera"
   ],
   "dependencies": {
-    "addons-linter": "0.27.0",
+    "addons-linter": "0.30.0",
     "babel-polyfill": "6.20.0",
     "babel-runtime": "6.25.0",
     "bunyan": "1.8.10",


### PR DESCRIPTION
Closes #1112