### PR TITLE
chore(package): update addons-linter to version 0.31.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "opera"
   ],
   "dependencies": {
-    "addons-linter": "0.30.0",
+    "addons-linter": "0.31.0",
     "babel-polyfill": "6.20.0",
     "babel-runtime": "6.25.0",
     "bunyan": "1.8.12",


### PR DESCRIPTION
This PR update the addons-linter dependency to the 0.31.0, which include the upstream fix for #1164 