### PR TITLE
chore(package): update addons-linter to version 0.32.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   ],
   "dependencies": {
     "adbkit": "2.11.0",
-    "addons-linter": "0.31.0",
+    "addons-linter": "0.32.0",
     "babel-polyfill": "6.26.0",
     "babel-runtime": "6.26.0",
     "bunyan": "1.8.12",


### PR DESCRIPTION
This PR updates the addons-linter dependency to the version 0.32.0 (which fixes #1134)