### PR TITLE
fix: Fix typo in --firefox-apk error message

### DIFF
--- a/src/extension-runners/firefox-android.js
+++ b/src/extension-runners/firefox-android.js
@@ -342,7 +342,7 @@ export class FirefoxAndroidExtensionRunner {
 
     if (packages.length === 0) {
       throw new UsageError(
-        'No Firefox packages found of the selected Android device');
+        'No Firefox packages were found on the selected Android device');
     }
 
     const pkgsListMsg = (pkgs) => {

--- a/tests/unit/test-extension-runners/test.firefox-android.js
+++ b/tests/unit/test-extension-runners/test.firefox-android.js
@@ -234,7 +234,7 @@ describe('util/extension-runners/firefox-android', () => {
         assert.instanceOf(actualException, UsageError);
         assert.match(
           actualException && actualException.message,
-          /No Firefox packages found of the selected Android device/
+          /No Firefox packages were found on the selected Android device/
         );
       });
     });


### PR DESCRIPTION
Fixes a minor typo in the `--firefox-apk` error message