### PR TITLE
fix: Config file array files should be recognized as options of array type

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -66,7 +66,11 @@ export function applyConfigToArgv({
     const expectedType = options[decamelizedOptName].type ===
       'count' ? 'number' : options[decamelizedOptName].type;
 
-    const optionType = typeof configObject[option];
+    const optionType = (
+      Array.isArray(configObject[option]) ?
+        'array' : typeof configObject[option]
+    );
+
     if (optionType !== expectedType) {
       throw new UsageError(`The config file at ${configFileName} specified ` +
         `the type of "${option}" incorrectly as "${optionType}"` +

--- a/tests/unit/test.config.js
+++ b/tests/unit/test.config.js
@@ -277,6 +277,25 @@ describe('config', () => {
       assert.strictEqual(argv.filePath, secondConfigObject.filePath);
     });
 
+    it('recognizes array config values as array types', () => {
+      const params = makeArgv({
+        userCmd: ['fakecommand'],
+        globalOpt: {
+          'ignore-files': {
+            demand: false,
+            type: 'array',
+          },
+        },
+      });
+
+      const configObject = {
+        ignoreFiles: ['file1', 'file2'],
+      };
+
+      const argv = applyConf({...params, configObject});
+      assert.strictEqual(argv.ignoreFiles, configObject.ignoreFiles);
+    });
+
     it('uses CLI option over undefined configured option and default', () => {
       const cmdLineSrcDir = '/user/specified/source/dir/';
       const params = makeArgv({


### PR DESCRIPTION
This PR contains the changes (and additional test case) to fix #1198