### PR TITLE
fix: Change Android cleanup message on exit

### DIFF
--- a/src/extension-runners/firefox-android.js
+++ b/src/extension-runners/firefox-android.js
@@ -239,7 +239,7 @@ export class FirefoxAndroidExtensionRunner {
     await this.adbForceStopSelectedPackage();
 
     if (selectedArtifactsDir) {
-      log.info('Cleanup artifacts dir created on the Android device...');
+      log.debug('Cleaning up artifacts directory on the Android device...');
       await adbUtils.clearArtifactsDir(selectedAdbDevice);
     }
 


### PR DESCRIPTION
I think this can be a hidden debug message. What do you think?