### PR TITLE
fix: Granted android permissions are only needed for android >= 23

### DIFF
--- a/src/extension-runners/firefox-android.js
+++ b/src/extension-runners/firefox-android.js
@@ -400,7 +400,13 @@ export class FirefoxAndroidExtensionRunner {
       selectedAdbDevice
     );
 
-    if (androidVersion < 21) {
+    if (typeof androidVersion !== 'number' || isNaN(androidVersion)) {
+      throw new WebExtError(`Invalid Android version: ${androidVersion}`);
+    }
+
+    log.debug(`Detected Android version ${androidVersion}`);
+
+    if (androidVersion < 23) {
       return;
     }
 

--- a/src/extension-runners/firefox-android.js
+++ b/src/extension-runners/firefox-android.js
@@ -400,7 +400,7 @@ export class FirefoxAndroidExtensionRunner {
       selectedAdbDevice
     );
 
-    if (typeof androidVersion !== 'number' || isNaN(androidVersion)) {
+    if (typeof androidVersion !== 'number' || Number.isNaN(androidVersion)) {
       throw new WebExtError(`Invalid Android version: ${androidVersion}`);
     }
 
@@ -414,7 +414,8 @@ export class FirefoxAndroidExtensionRunner {
               `on ${selectedFirefoxApk}...`);
 
     // Runtime permission needed to be able to run Firefox on a temporarily created profile
-    // on android versions >= 21.
+    // on android versions >= 23 (Android Marshmallow, which is the first version where
+    // these permissions are optional and have to be granted explicitly).
     await adbUtils.ensureRequiredAPKRuntimePermissions(
       selectedAdbDevice, selectedFirefoxApk, [
         'android.permission.READ_EXTERNAL_STORAGE',

--- a/tests/unit/test-extension-runners/test.firefox-android.js
+++ b/tests/unit/test-extension-runners/test.firefox-android.js
@@ -704,37 +704,99 @@ describe('util/extension-runners/firefox-android', () => {
          sinon.assert.calledOnce(anotherCallback);
        });
 
-    it('checks the granted android permissions on Android >= 21',
+    it('raised an error when unable to find an android version number',
        async () => {
-         const {
-           params, fakeADBUtils,
-         } = prepareSelectedDeviceAndAPKParams();
+         async function expectInvalidVersionError(version: any) {
+           const {
+             params, fakeADBUtils,
+           } = prepareSelectedDeviceAndAPKParams();
 
-         fakeADBUtils.getAndroidVersionNumber = sinon.spy(() => {
-           Promise.resolve(21);
-         });
+           fakeADBUtils.getAndroidVersionNumber = sinon.spy(() => {
+             return version;
+           });
 
-         const runnerInstance = new FirefoxAndroidExtensionRunner(params);
+           const runnerInstance = new FirefoxAndroidExtensionRunner(params);
+           const promise = runnerInstance.run();
 
-         await runnerInstance.run();
+           assert.isRejected(promise, WebExtError);
+           assert.isRejected(promise, `Invalid Android version: ${version}`);
+         }
 
-         sinon.assert.calledWithMatch(
-           fakeADBUtils.getAndroidVersionNumber,
-           'emulator-1'
-         );
+         await expectInvalidVersionError(undefined);
+         await expectInvalidVersionError(NaN);
+       });
 
-         sinon.assert.calledWithMatch(
-           fakeADBUtils.ensureRequiredAPKRuntimePermissions,
-           'emulator-1', 'org.mozilla.firefox', [
-             'android.permission.READ_EXTERNAL_STORAGE',
-             'android.permission.WRITE_EXTERNAL_STORAGE',
-           ]
-         );
+    it('does not check granted android permissions on Android <= 21',
+       async () => {
+         async function expectNoGrantedPermissionDiscovery(version) {
+           const {
+             params, fakeADBUtils,
+           } = prepareSelectedDeviceAndAPKParams();
 
-         sinon.assert.callOrder(
-           fakeADBUtils.getAndroidVersionNumber,
-           fakeADBUtils.ensureRequiredAPKRuntimePermissions
-         );
+           fakeADBUtils.getAndroidVersionNumber = sinon.spy(() => {
+             return Promise.resolve(version);
+           });
+
+           const runnerInstance = new FirefoxAndroidExtensionRunner(params);
+
+           await runnerInstance.run();
+
+           sinon.assert.calledWithMatch(
+             fakeADBUtils.getAndroidVersionNumber,
+             'emulator-1'
+           );
+
+           sinon.assert.notCalled(
+             fakeADBUtils.ensureRequiredAPKRuntimePermissions
+           );
+         }
+
+         // KitKat (Android 4.4).
+         await expectNoGrantedPermissionDiscovery(19);
+         await expectNoGrantedPermissionDiscovery(21);
+         // Lollipop versions (Android 5.0 and 5.1).
+         await expectNoGrantedPermissionDiscovery(22);
+       });
+
+    it('checks the granted android permissions on Android >= 23',
+       async () => {
+         async function testGrantedPermissionDiscovery(version) {
+           const {
+             params, fakeADBUtils,
+           } = prepareSelectedDeviceAndAPKParams();
+
+           fakeADBUtils.getAndroidVersionNumber = sinon.spy(() => {
+             return Promise.resolve(version);
+           });
+
+           const runnerInstance = new FirefoxAndroidExtensionRunner(params);
+
+           await runnerInstance.run();
+
+           sinon.assert.calledWithMatch(
+             fakeADBUtils.getAndroidVersionNumber,
+             'emulator-1'
+           );
+
+           sinon.assert.calledWithMatch(
+             fakeADBUtils.ensureRequiredAPKRuntimePermissions,
+             'emulator-1', 'org.mozilla.firefox', [
+               'android.permission.READ_EXTERNAL_STORAGE',
+               'android.permission.WRITE_EXTERNAL_STORAGE',
+             ]
+           );
+
+           sinon.assert.callOrder(
+             fakeADBUtils.getAndroidVersionNumber,
+             fakeADBUtils.ensureRequiredAPKRuntimePermissions
+           );
+         }
+
+         // Marshmallow (Android 6.0)
+         await testGrantedPermissionDiscovery(23);
+         // Nougat versions (Android 7.0 and 7.1.1)
+         await testGrantedPermissionDiscovery(24);
+         await testGrantedPermissionDiscovery(25);
        });
 
     it('logs warnings on the unsupported CLI options', async () => {

--- a/tests/unit/test-extension-runners/test.firefox-android.js
+++ b/tests/unit/test-extension-runners/test.firefox-android.js
@@ -704,7 +704,7 @@ describe('util/extension-runners/firefox-android', () => {
          sinon.assert.calledOnce(anotherCallback);
        });
 
-    it('raised an error when unable to find an android version number',
+    it('raises an error when unable to find an android version number',
        async () => {
          async function expectInvalidVersionError(version: any) {
            const {
@@ -718,8 +718,9 @@ describe('util/extension-runners/firefox-android', () => {
            const runnerInstance = new FirefoxAndroidExtensionRunner(params);
            const promise = runnerInstance.run();
 
-           assert.isRejected(promise, WebExtError);
-           assert.isRejected(promise, `Invalid Android version: ${version}`);
+           const expectedMsg = `Invalid Android version: ${version}`;
+           await assert.isRejected(promise, WebExtError);
+           await assert.isRejected(promise, expectedMsg);
          }
 
          await expectInvalidVersionError(undefined);


### PR DESCRIPTION
This pull request contains the changes needed to fix #1211 

The android "external storage permissions" are optional only starting from Marshmallow (android-23), and so they cannot be "granted" on the previous android versions.

This patch also fixes a bug in the test suite (and in the code), the previous version of the test was wrongly returning undefined from the `getAndroidVersionNumber` spy and so the test wasn't really testing the behavior on the expected android version number (and the implementation wasn't raising an error for an unexpected "not number" android version).  