### PR TITLE
feat: Added package.json config to set option defaults

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -135,6 +135,24 @@ export function loadJSConfigFile(filePath: string): Object {
   return configObject;
 }
 
+export function loadJSONConfigFile(filePath: string): Object {
+  const resolvedFilePath = path.resolve(filePath);
+  log.debug(
+    `Loading JSON config file: "${filePath}" ` +
+    `(resolved to "${resolvedFilePath}")`);
+  let configObject;
+  try {
+    const topLevelConfig = requireUncached(resolvedFilePath);
+    configObject = topLevelConfig.webExt || {};
+  } catch (error) {
+    log.debug('Handling error:', error);
+    throw new UsageError(
+      `Cannot read config file: ${resolvedFilePath}\n` +
+      `Error: ${error.message}`);
+  }
+  return configObject;
+}
+
 type DiscoverConfigFilesParams = {|
   getHomeDir: () => string,
 |};
@@ -150,6 +168,8 @@ export async function discoverConfigFiles(
     path.join(getHomeDir(), `.${magicConfigName}`),
     // Look for a magic config in the current working directory.
     path.join(process.cwd(), magicConfigName),
+    // Look for webExt key in package.json file
+    path.join(process.cwd(), 'package.json'),
   ];
 
   const configs = await Promise.all(possibleConfigs.map(

--- a/src/program.js
+++ b/src/program.js
@@ -15,6 +15,7 @@ import {checkForUpdates as defaultUpdateChecker} from './util/updates';
 import {
   discoverConfigFiles as defaultConfigDiscovery,
   loadJSConfigFile as defaultLoadJSConfigFile,
+  loadJSONConfigFile as defaultLoadJSONConfigFile,
   applyConfigToArgv as defaultApplyConfigToArgv,
 } from './config';
 
@@ -38,6 +39,7 @@ type ExecuteOptions = {
   applyConfigToArgv?: typeof defaultApplyConfigToArgv,
   discoverConfigFiles?: typeof defaultConfigDiscovery,
   loadJSConfigFile?: typeof defaultLoadJSConfigFile,
+  loadJSONConfigFile?: typeof defaultLoadJSONConfigFile,
   shouldExitProgram?: boolean,
   globalEnv?: string,
 }
@@ -131,6 +133,7 @@ export class Program {
       applyConfigToArgv = defaultApplyConfigToArgv,
       discoverConfigFiles = defaultConfigDiscovery,
       loadJSConfigFile = defaultLoadJSConfigFile,
+      loadJSONConfigFile = defaultLoadJSONConfigFile,
       shouldExitProgram = true,
       globalEnv = WEBEXT_BUILD_ENV,
     }: ExecuteOptions = {}
@@ -191,7 +194,8 @@ export class Program {
       }
 
       configFiles.forEach((configFileName) => {
-        const configObject = loadJSConfigFile(configFileName);
+        const configObject = configFileName.endsWith('package.json') ?
+          loadJSONConfigFile(configFileName) : loadJSConfigFile(configFileName);
         adjustedArgv = applyConfigToArgv({
           argv: adjustedArgv,
           argvFromCLI: argv,


### PR DESCRIPTION
Fixes #1166

I stumbled upon this repository while trying to get myself involved in open-source development. Wish I could be of any help.

Basically what I did was adding `./package.json` as an option for config files and creating a new function `loadJSONConfigFile()`, which is just a modified version of `loadJSConfigFile()`, to load config options from `./package.json`

As a result, I was able to load configs from `./package.json` under the `webExt` key. However, `discoverConfigFiles` tests are now failing because `./package.json` was not expected as an option.

