### PR TITLE
fix: Prevent the privacy policy info page to be opened on every run

### DIFF
--- a/src/firefox/preferences.js
+++ b/src/firefox/preferences.js
@@ -89,6 +89,11 @@ const prefsFirefox: FirefoxPreferences = {
   'browser.selfsupport.url': 'https://localhost/selfrepair',
   // Disable Reader Mode UI tour
   'browser.reader.detectedFirstArticle': true,
+
+  // Set the policy firstURL to an empty string to prevent
+  // the privacy info page to be opened on every "web-ext run".
+  // (See #1114 for rationale)
+  'datareporting.policy.firstRunURL': '',
 };
 
 const prefs = {

--- a/tests/unit/test-firefox/test.preferences.js
+++ b/tests/unit/test-firefox/test.preferences.js
@@ -18,6 +18,9 @@ describe('firefox/preferences', () => {
       assert.equal(prefs['devtools.debugger.remote-enabled'], true);
       // This is a Firefox only pref.
       assert.equal(prefs['devtools.chrome.enabled'], true);
+      // This is a Firefox only pref that we set to prevent Firefox
+      // to open the privacy policy info page on every "web-ext run".
+      assert.equal(prefs['datareporting.policy.firstRunURL'], '');
     });
 
     it('gets Fennec prefs with some defaults', () => {


### PR DESCRIPTION
This PR contains a very small change, needed to fix #1114