### PR TITLE
fix: Do not treat an array of config values as a sub-command config section

### DIFF
--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -40,8 +40,8 @@ export type CmdRunParams = {|
   noReload: boolean,
   preInstall: boolean,
   sourceDir: string,
-  startUrl?: string | Array<string>,
-  target?: string | Array<string>,
+  startUrl?: Array<string>,
+  target?: Array<string>,
 
   // Android CLI options.
   adbBin?: string,

--- a/src/config.js
+++ b/src/config.js
@@ -32,14 +32,17 @@ export function applyConfigToArgv({
 }: ApplyConfigToArgvParams): Object {
   let newArgv = {...argv};
 
-  for (const option in configObject) {
+  for (const option of Object.keys(configObject)) {
     if (camelCase(option) !== option) {
       throw new UsageError(
         `The config option "${option}" must be ` +
         `specified in camel case: "${camelCase(option)}"`);
     }
 
-    if (typeof options[option] === 'object' &&
+    // A config option cannot be a sub-command config
+    // object if it is an array.
+    if (!Array.isArray(configObject[option]) &&
+      typeof options[option] === 'object' &&
       typeof configObject[option] === 'object') {
       // Descend into the nested configuration for a sub-command.
       newArgv = applyConfigToArgv({

--- a/src/firefox/preferences.js
+++ b/src/firefox/preferences.js
@@ -117,14 +117,9 @@ export function getPrefs(
 }
 
 export function coerceCLICustomPreference(
-  cliPrefs: string | Array<string>
+  cliPrefs: Array<string>
 ): FirefoxPreferences {
   const customPrefs = {};
-
-  if (!Array.isArray(cliPrefs)) {
-    cliPrefs = [cliPrefs];
-  }
-
 
   for (const pref of cliPrefs) {
     const prefsAry = pref.split('=');

--- a/src/program.js
+++ b/src/program.js
@@ -401,7 +401,7 @@ Example: $0 --help run.
                   'run against multiple targets.',
         default: 'firefox-desktop',
         demand: false,
-        type: 'string',
+        type: 'array',
       },
       'firefox': {
         alias: ['f', 'firefox-binary'],
@@ -447,7 +447,7 @@ Example: $0 --help run.
                   'preference.',
         demand: false,
         requiresArg: true,
-        type: 'string',
+        type: 'array',
         coerce: coerceCLICustomPreference,
       },
       'start-url': {
@@ -455,7 +455,7 @@ Example: $0 --help run.
         describe: 'Launch firefox at specified page',
         demand: false,
         requiresArg: true,
-        type: 'string',
+        type: 'array',
       },
       'browser-console': {
         alias: ['bc'],

--- a/src/program.js
+++ b/src/program.js
@@ -144,10 +144,15 @@ export class Program {
 
     const runCommand = this.commands[cmd];
 
+    let versionLogged = false;
+
     if (argv.verbose) {
       logStream.makeVerbose();
       log.info('Version:', getVersion(absolutePackageDir));
+      versionLogged = true;
     }
+
+    let adjustedArgv = {...argv};
 
     try {
       if (cmd === undefined) {
@@ -162,7 +167,6 @@ export class Program {
         });
       }
 
-      let adjustedArgv = {...argv};
       const configFiles = [];
 
       if (argv.configDiscovery) {
@@ -201,10 +205,18 @@ export class Program {
         });
       });
 
+      if (adjustedArgv.verbose) {
+        logStream.makeVerbose();
+
+        if (!versionLogged) {
+          log.info('Version:', getVersion(absolutePackageDir));
+        }
+      }
+
       await runCommand(adjustedArgv, {shouldExitProgram});
 
     } catch (error) {
-      if (!(error instanceof UsageError) || argv.verbose) {
+      if (!(error instanceof UsageError) || adjustedArgv.verbose) {
         log.error(`\n${error.stack}\n`);
       } else {
         log.error(`\n${error}\n`);

--- a/tests/unit/test-cmd/test.run.js
+++ b/tests/unit/test-cmd/test.run.js
@@ -73,7 +73,7 @@ describe('run', () => {
 
   it('passes startUrl parameter to Firefox when specified', async () => {
     const cmd = prepareRun();
-    const expectedStartUrls = 'www.example.com';
+    const expectedStartUrls = ['www.example.com'];
     const FirefoxDesktopExtensionRunner = sinon.spy(FakeExtensionRunner);
 
     await cmd.run({startUrl: expectedStartUrls},

--- a/tests/unit/test-firefox/test.preferences.js
+++ b/tests/unit/test-firefox/test.preferences.js
@@ -39,7 +39,7 @@ describe('firefox/preferences', () => {
   describe('coerceCLICustomPreference', () => {
 
     it('converts a single --pref cli option from string to object', () => {
-      const prefs = coerceCLICustomPreference('valid.preference=true');
+      const prefs = coerceCLICustomPreference(['valid.preference=true']);
       assert.isObject(prefs);
       assert.equal(prefs['valid.preference'], true);
     });
@@ -54,23 +54,23 @@ describe('firefox/preferences', () => {
     });
 
     it('converts boolean values', () => {
-      const prefs = coerceCLICustomPreference('valid.preference=true');
+      const prefs = coerceCLICustomPreference(['valid.preference=true']);
       assert.equal(prefs['valid.preference'], true);
     });
 
     it('converts number values', () => {
-      const prefs = coerceCLICustomPreference('valid.preference=455');
+      const prefs = coerceCLICustomPreference(['valid.preference=455']);
       assert.equal(prefs['valid.preference'], 455);
     });
 
     it('converts float values', () => {
-      const prefs = coerceCLICustomPreference('valid.preference=4.55');
+      const prefs = coerceCLICustomPreference(['valid.preference=4.55']);
       assert.equal(prefs['valid.preference'], '4.55');
     });
 
     it('supports string values with "=" chars', () => {
       const prefs = coerceCLICustomPreference(
-        'valid.preference=value=withequals=chars'
+        ['valid.preference=value=withequals=chars']
       );
       assert.equal(prefs['valid.preference'], 'value=withequals=chars');
     });
@@ -87,13 +87,13 @@ describe('firefox/preferences', () => {
 
     it('throws an error for invalid or incomplete preferences', () => {
       assert.throws(
-        () => coerceCLICustomPreference('test.invalid.prop'),
+        () => coerceCLICustomPreference(['test.invalid.prop']),
         UsageError,
         'UsageError: Incomplete custom preference: "test.invalid.prop". ' +
         'Syntax expected: "prefname=prefvalue".'
       );
 
-      assert.throws(() => coerceCLICustomPreference('*&%£=true'),
+      assert.throws(() => coerceCLICustomPreference(['*&%£=true']),
                     UsageError,
                     'UsageError: Invalid custom preference name: *&%£');
     });

--- a/tests/unit/test.config.js
+++ b/tests/unit/test.config.js
@@ -303,7 +303,7 @@ describe('config', () => {
            globalOpt: {
              pref: {
                demand: false,
-               type: 'string',
+               type: 'array',
              },
            },
          });
@@ -312,12 +312,8 @@ describe('config', () => {
            pref: ['pref1=true', 'pref2=false'],
          };
 
-         // TODO: expect a raised exception array is not a string
-         assert.throws(
-           () => applyConf({...params, configObject}),
-           UsageError,
-           'type of "pref" incorrectly as "array" (expected type "string")'
-         );
+         const resultArgv = applyConf({...params, configObject});
+         assert.strictEqual(resultArgv.pref, configObject.pref);
        });
 
     it('uses CLI option over undefined configured option and default', () => {

--- a/tests/unit/test.config.js
+++ b/tests/unit/test.config.js
@@ -296,6 +296,30 @@ describe('config', () => {
       assert.strictEqual(argv.ignoreFiles, configObject.ignoreFiles);
     });
 
+    it('does not mistake an array config values for a sub-command',
+       () => {
+         const params = makeArgv({
+           userCmd: ['fakecommand'],
+           globalOpt: {
+             pref: {
+               demand: false,
+               type: 'string',
+             },
+           },
+         });
+
+         const configObject = {
+           pref: ['pref1=true', 'pref2=false'],
+         };
+
+         // TODO: expect a raised exception array is not a string
+         assert.throws(
+           () => applyConf({...params, configObject}),
+           UsageError,
+           'type of "pref" incorrectly as "array" (expected type "string")'
+         );
+       });
+
     it('uses CLI option over undefined configured option and default', () => {
       const cmdLineSrcDir = '/user/specified/source/dir/';
       const params = makeArgv({

--- a/tests/unit/test.program.js
+++ b/tests/unit/test.program.js
@@ -449,7 +449,7 @@ describe('program.main', () => {
       .then(() => {
         sinon.assert.calledWithMatch(
           fakeCommands.run,
-          {startUrl: 'www.example.com'}
+          {startUrl: ['www.example.com']}
         );
       });
   });

--- a/tests/unit/test.program.js
+++ b/tests/unit/test.program.js
@@ -683,11 +683,9 @@ describe('program.main', () => {
 
     const customConfig = path.resolve('custom/web-ext-config.js');
 
-    const finalSourceDir = path.resolve('final/source-dir');
     const loadJSConfigFile = makeConfigLoader({
       configObjects: {
         [customConfig]: {
-          sourceDir: finalSourceDir,
           verbose: true,
         },
       },

--- a/tests/unit/test.program.js
+++ b/tests/unit/test.program.js
@@ -674,6 +674,39 @@ describe('program.main', () => {
     // This should equal the final configured value.
     assert.equal(options.sourceDir, finalSourceDir);
   });
+
+  it('enables verbose more from config file', async () => {
+    const logStream = fake(new ConsoleStream());
+    const fakeCommands = fake(commands, {
+      lint: () => Promise.resolve(),
+    });
+
+    const customConfig = path.resolve('custom/web-ext-config.js');
+
+    const finalSourceDir = path.resolve('final/source-dir');
+    const loadJSConfigFile = makeConfigLoader({
+      configObjects: {
+        [customConfig]: {
+          sourceDir: finalSourceDir,
+          verbose: true,
+        },
+      },
+    });
+
+    await execProgram(
+      ['lint', '--config', customConfig],
+      {
+        commands: fakeCommands,
+        runOptions: {
+          discoverConfigFiles: async () => [],
+          loadJSConfigFile,
+          logStream,
+        },
+      }
+    );
+
+    sinon.assert.called(logStream.makeVerbose);
+  });
 });
 
 describe('program.defaultVersionGetter', () => {


### PR DESCRIPTION
This PR contains a set of proposed changes to fix #1213, #1214 and #1215 

#1213 is fixed by prevent `applyConfigToArgv` to recurse on an array of config values (by consider it as a sub-command config section by mistake)

#1214 is fixed by checking if `adjustedArgv.verbose` is `true` after we loaded and applied the config file and then calling `logStream.makeVerbose` accordingly.

#1215 proposed fix is (as describe in [this comment](https://github.com/mozilla/web-ext/issues/1215#issuecomment-359062606)) to mark explicitly as array the options that may makes sense as an array of values in the config file