### PR TITLE
Added optional channel parameter for signing add-ons

### DIFF
--- a/src/cmd/sign.js
+++ b/src/cmd/sign.js
@@ -30,6 +30,7 @@ export type SignParams = {|
   sourceDir: string,
   timeout: number,
   verbose?: boolean,
+  channel?: string,
 |};
 
 export type SignOptions = {
@@ -57,6 +58,7 @@ export default function sign(
     sourceDir,
     timeout,
     verbose,
+    channel,
   }: SignParams,
   {
     build = defaultBuilder,
@@ -118,6 +120,7 @@ export default function sign(
         xpiPath: buildResult.extensionPath,
         version: manifestData.version,
         downloadDir: artifactsDir,
+        channel,
       });
 
       if (signingResult.id) {

--- a/src/program.js
+++ b/src/program.js
@@ -412,6 +412,11 @@ Example: $0 --help run.
           describe: 'Number of milliseconds to wait before giving up',
           type: 'number',
         },
+        'channel': {
+          describe: 'The channel for which to sign the addon. Either ' +
+          '\'listed\' or \'unlisted\'',
+          type: 'string',
+        },
       })
     .command('run', 'Run the extension', commands.run, {
       'target': {


### PR DESCRIPTION
Added optional `channel` parameter for signing add-ons.

This requires `sign-addon` module updated with [PR#250](https://github.com/mozilla/sign-addon/pull/250).