### PR TITLE
feat: Added release channel as optional sign parameter

### DIFF
--- a/src/cmd/sign.js
+++ b/src/cmd/sign.js
@@ -30,6 +30,7 @@ export type SignParams = {|
   sourceDir: string,
   timeout: number,
   verbose?: boolean,
+  channel?: string,
 |};
 
 export type SignOptions = {
@@ -57,6 +58,7 @@ export default function sign(
     sourceDir,
     timeout,
     verbose,
+    channel,
   }: SignParams,
   {
     build = defaultBuilder,
@@ -118,6 +120,7 @@ export default function sign(
         xpiPath: buildResult.extensionPath,
         version: manifestData.version,
         downloadDir: artifactsDir,
+        channel,
       });
 
       if (signingResult.id) {

--- a/src/program.js
+++ b/src/program.js
@@ -412,6 +412,11 @@ Example: $0 --help run.
           describe: 'Number of milliseconds to wait before giving up',
           type: 'number',
         },
+        'channel': {
+          describe: 'The channel for which to sign the addon. Either ' +
+          '\'listed\' or \'unlisted\'',
+          type: 'string',
+        },
       })
     .command('run', 'Run the extension', commands.run, {
       'target': {

--- a/tests/unit/test-cmd/test.sign.js
+++ b/tests/unit/test-cmd/test.sign.js
@@ -288,6 +288,34 @@ describe('sign', () => {
     }
   ));
 
+  it('passes the channel parameter to the signer', () => withTempDir(
+    (tmpDir) => {
+      const stubs = getStubs();
+      const artifactsDir = path.join(tmpDir.path(), 'some-artifacts-dir');
+      const applications: ExtensionManifestApplications =
+        stubs.preValidatedManifest.applications || {gecko: {}};
+      return sign(tmpDir, stubs, {extraArgs: {
+        artifactsDir,
+        channel: 'unlisted',
+      }})
+        .then(() => {
+          sinon.assert.called(stubs.signAddon);
+          sinon.assert.calledWithMatch(stubs.signAddon, {
+            apiKey: stubs.signingConfig.apiKey,
+            apiProxy: stubs.signingConfig.apiProxy,
+            apiSecret: stubs.signingConfig.apiSecret,
+            apiUrlPrefix: stubs.signingConfig.apiUrlPrefix,
+            downloadDir: artifactsDir,
+            id: applications.gecko.id,
+            timeout: stubs.signingConfig.timeout,
+            version: stubs.preValidatedManifest.version,
+            xpiPath: stubs.buildResult.extensionPath,
+            channel: 'unlisted',
+          });
+        });
+    }
+  ));
+
   it('passes the verbose flag to the signer', () => withTempDir(
     (tmpDir) => {
       const stubs = getStubs();


### PR DESCRIPTION
Fixes https://github.com/mozilla/web-ext/issues/877

Added release channel as optional sign parameter.

To be effective, this requires a version of the [sign-addon](https://github.com/mozilla/sign-addon) module patched with PR [#249](https://github.com/mozilla/sign-addon/pull/249) or [#250](https://github.com/mozilla/sign-addon/pull/250).
