### PR TITLE
chore(package): update conventional-changelog-cli to version 1.3.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "babel-preset-stage-2": "6.24.1",
     "chai": "3.5.0",
     "chai-as-promised": "7.1.1",
-    "conventional-changelog-cli": "1.3.9",
+    "conventional-changelog-cli": "1.3.13",
     "conventional-changelog-lint": "2.1.1",
     "copy-dir": "0.3.0",
     "coveralls": "2.13.3",


### PR DESCRIPTION
Closes #1248 

This patch release was a precaution against a previously released malicious version https://github.com/conventional-changelog/conventional-changelog/issues/282#issuecomment-365367804