### PR TITLE
chore(package): update flow-bin to version 0.68.0 and fixed new related errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "eslint-plugin-async-await": "0.0.0",
     "eslint-plugin-flowtype": "2.46.1",
     "eslint-plugin-import": "2.8.0",
-    "flow-bin": "0.65.0",
+    "flow-bin": "0.68.0",
     "grunt": "1.0.2",
     "grunt-contrib-clean": "1.1.0",
     "grunt-contrib-copy": "1.0.0",

--- a/src/extension-runners/index.js
+++ b/src/extension-runners/index.js
@@ -278,7 +278,7 @@ export function defaultReloadStrategy(
     }
   });
 
-  if (allowInput && stdin.isTTY && stdin instanceof tty.ReadStream) {
+  if (allowInput && stdin instanceof tty.ReadStream && stdin.isTTY) {
     readline.emitKeypressEvents(stdin);
     stdin.setRawMode(true);
 

--- a/src/util/temp-dir.js
+++ b/src/util/temp-dir.js
@@ -6,8 +6,8 @@ import {createLogger} from './logger';
 
 const log = createLogger(__filename);
 
-
 export type MakePromiseCallback = (tmpDir: TempDir) => any;
+
 
 /*
  * Work with a self-destructing temporary directory in a promise chain.
@@ -33,7 +33,6 @@ export function withTempDir(makePromise: MakePromiseCallback): Promise<any> {
     .catch(tmpDir.errorHandler())
     .then(tmpDir.successHandler());
 }
-
 
 /*
  * Work with a self-destructing temporary directory object.


### PR DESCRIPTION
This pull request supersedes #1259 by updating flow-bin to version 0.68.0 and contextually fixing a new flow check error that the previous flow version wasn't yet able to catch (basically flow 0.68.0 is figuring out the `stdin.isTTY` is going to be available only if we already checked that it is an instance of `tty.ReadStream`, which is actually true and so reversing the order of those checks fixes the flow error).

Thanks to @hiikezoe for fixing in #1292 and #1293 the other two issues that were making the flow-check step to fail with flow-bin 0.68.0 (flow is definitely becoming smarter and it is able to catch more type issues at every new version, and it is definitely worth to update it sooner than later).

(there is also a small change, in a separate commit, applied to src/utils/temp-dir.js which is actually unrelated, but given that it is just some minor coding style fixes related to empty lines we could just "rebase and merge" this pull request to fix both, and still keeping them into two separate commits). 