### PR TITLE
fix(package): update addons-linter to version 0.41.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@cliqz-oss/firefox-client": "0.3.1",
     "@cliqz-oss/node-firefox-connect": "1.2.1",
     "adbkit": "2.11.0",
-    "addons-linter": "0.36.1",
+    "addons-linter": "0.41.0",
     "babel-polyfill": "6.26.0",
     "babel-runtime": "6.26.0",
     "bunyan": "1.8.12",


### PR DESCRIPTION
This pull request updated the addons-linter dependency to the last released version 0.41.0
(and it supersedes #1252).