### PR TITLE
fix: Improve web-ext start-up time by lazy loading some modules

### DIFF
--- a/src/cmd/docs.js
+++ b/src/cmd/docs.js
@@ -5,12 +5,12 @@ import {createLogger} from '../util/logger';
 
 const log = createLogger(__filename);
 
-type DocsParams = {
+export type DocsParams = {
   noInput?: boolean,
   shouldExitProgram?: boolean,
 }
 
-type DocsOptions = {
+export type DocsOptions = {
   openUrl?: typeof defaultUrlOpener,
 }
 

--- a/src/cmd/index.js
+++ b/src/cmd/index.js
@@ -1,8 +1,57 @@
 /* @flow */
-import build from './build';
-import lint from './lint';
-import run from './run';
-import sign from './sign';
-import docs from './docs';
+
+import type {
+  BuildCmdParams, BuildCmdOptions, ExtensionBuildResult,
+} from './build';
+import type {LintCmdParams, LintCmdOptions} from './lint';
+import type {CmdRunParams, CmdRunOptions} from './run';
+import type {MultiExtensionRunner} from '../extension-runners';
+import type {SignParams, SignOptions, SignResult} from './sign';
+import type {DocsParams, DocsOptions} from './docs';
+
+// This module exports entry points for all supported commands. For performance
+// reasons (faster start-up), the implementations are not statically imported
+// at the top of the file, but lazily loaded in the (exported) functions.
+// The latter would slow down start-up by several seconds, as seen in #1302 .
+
+async function build(
+  params: BuildCmdParams, options: BuildCmdOptions
+): Promise<ExtensionBuildResult> {
+  // TODO: use async import instead of require - https://github.com/mozilla/web-ext/issues/1306
+  const {default: runCommand} = require('./build');
+  return runCommand(params, options);
+}
+
+async function lint(
+  params: LintCmdParams, options: LintCmdOptions
+): Promise<void> {
+  // TODO: use async import instead of require - https://github.com/mozilla/web-ext/issues/1306
+  const {default: runCommand} = require('./lint');
+  return runCommand(params, options);
+}
+
+async function run(
+  params: CmdRunParams, options: CmdRunOptions
+): Promise<MultiExtensionRunner> {
+  // TODO: use async import instead of require - https://github.com/mozilla/web-ext/issues/1306
+  const {default: runCommand} = require('./run');
+  return runCommand(params, options);
+}
+
+async function sign(
+  params: SignParams, options: SignOptions
+): Promise<SignResult> {
+  // TODO: use async import instead of require - https://github.com/mozilla/web-ext/issues/1306
+  const {default: runCommand} = require('./sign');
+  return runCommand(params, options);
+}
+
+async function docs(
+  params: DocsParams, options: DocsOptions
+): Promise<void> {
+  // TODO: use async import instead of require - https://github.com/mozilla/web-ext/issues/1306
+  const {default: runCommand} = require('./docs');
+  return runCommand(params, options);
+}
 
 export default {build, lint, run, sign, docs};

--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -1,6 +1,5 @@
 /* @flow */
 import defaultBuildExtension from './build';
-import DefaultADBUtils from '../util/adb';
 import {
   showDesktopNotification as defaultDesktopNotifications,
 } from '../util/desktop-notifier';
@@ -14,11 +13,11 @@ import {
   defaultReloadStrategy,
   MultiExtensionRunner as DefaultMultiExtensionRunner,
 } from '../extension-runners';
-import {
-  FirefoxDesktopExtensionRunner as DefaultFirefoxDesktopExtensionRunner,
+import typeof {
+  FirefoxDesktopExtensionRunner as FirefoxDesktopExtensionRunnerType,
 } from '../extension-runners/firefox-desktop';
-import {
-  FirefoxAndroidExtensionRunner as defaultFirefoxAndroidExtensionRunner,
+import typeof {
+  FirefoxAndroidExtensionRunner as FirefoxAndroidExtensionRunnerType,
 } from '../extension-runners/firefox-android';
 // Import objects that are only used as Flow types.
 import type {FirefoxPreferences} from '../firefox/preferences';
@@ -58,8 +57,8 @@ export type CmdRunOptions = {|
   firefoxClient: typeof defaultFirefoxClient,
   reloadStrategy: typeof defaultReloadStrategy,
   shouldExitProgram?: boolean,
-  FirefoxAndroidExtensionRunner?: typeof defaultFirefoxAndroidExtensionRunner,
-  FirefoxDesktopExtensionRunner?: typeof DefaultFirefoxDesktopExtensionRunner,
+  FirefoxAndroidExtensionRunner?: FirefoxAndroidExtensionRunnerType,
+  FirefoxDesktopExtensionRunner?: FirefoxDesktopExtensionRunnerType,
   MultiExtensionRunner?: typeof DefaultMultiExtensionRunner,
   getValidatedManifest?: typeof defaultGetValidatedManifest,
 |};
@@ -92,8 +91,8 @@ export default async function run(
     firefoxApp = defaultFirefoxApp,
     firefoxClient = defaultFirefoxClient,
     reloadStrategy = defaultReloadStrategy,
-    FirefoxAndroidExtensionRunner = defaultFirefoxAndroidExtensionRunner,
-    FirefoxDesktopExtensionRunner = DefaultFirefoxDesktopExtensionRunner,
+    FirefoxAndroidExtensionRunner,
+    FirefoxDesktopExtensionRunner,
     MultiExtensionRunner = DefaultMultiExtensionRunner,
     getValidatedManifest = defaultGetValidatedManifest,
   }: CmdRunOptions = {}): Promise<DefaultMultiExtensionRunner> {
@@ -136,6 +135,11 @@ export default async function run(
       firefoxClient,
     };
 
+    if (!FirefoxDesktopExtensionRunner) {
+      ({FirefoxDesktopExtensionRunner} =
+        require('../extension-runners/firefox-desktop'));
+    }
+
     const firefoxDesktopRunner = new FirefoxDesktopExtensionRunner(
       firefoxDesktopRunnerParams
     );
@@ -161,7 +165,6 @@ export default async function run(
       // Injected dependencies.
       firefoxApp,
       firefoxClient,
-      ADBUtils: DefaultADBUtils,
       desktopNotifications: defaultDesktopNotifications,
       buildSourceDir: (extensionSourceDir: string, tmpArtifactsDir: string) => {
         return buildExtension({
@@ -177,6 +180,11 @@ export default async function run(
         });
       },
     };
+
+    if (!FirefoxAndroidExtensionRunner) {
+      ({FirefoxAndroidExtensionRunner} =
+        require('../extension-runners/firefox-android'));
+    }
 
     const firefoxAndroidRunner = new FirefoxAndroidExtensionRunner({
       ...commonRunnerParams,

--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -10,15 +10,10 @@ import {
 import {createLogger} from '../util/logger';
 import defaultGetValidatedManifest from '../util/manifest';
 import {
+  createExtensionRunner,
   defaultReloadStrategy,
   MultiExtensionRunner as DefaultMultiExtensionRunner,
 } from '../extension-runners';
-import typeof {
-  FirefoxDesktopExtensionRunner as FirefoxDesktopExtensionRunnerType,
-} from '../extension-runners/firefox-desktop';
-import typeof {
-  FirefoxAndroidExtensionRunner as FirefoxAndroidExtensionRunnerType,
-} from '../extension-runners/firefox-android';
 // Import objects that are only used as Flow types.
 import type {FirefoxPreferences} from '../firefox/preferences';
 
@@ -57,8 +52,6 @@ export type CmdRunOptions = {|
   firefoxClient: typeof defaultFirefoxClient,
   reloadStrategy: typeof defaultReloadStrategy,
   shouldExitProgram?: boolean,
-  FirefoxAndroidExtensionRunner?: FirefoxAndroidExtensionRunnerType,
-  FirefoxDesktopExtensionRunner?: FirefoxDesktopExtensionRunnerType,
   MultiExtensionRunner?: typeof DefaultMultiExtensionRunner,
   getValidatedManifest?: typeof defaultGetValidatedManifest,
 |};
@@ -91,8 +84,6 @@ export default async function run(
     firefoxApp = defaultFirefoxApp,
     firefoxClient = defaultFirefoxClient,
     reloadStrategy = defaultReloadStrategy,
-    FirefoxAndroidExtensionRunner,
-    FirefoxDesktopExtensionRunner,
     MultiExtensionRunner = DefaultMultiExtensionRunner,
     getValidatedManifest = defaultGetValidatedManifest,
   }: CmdRunOptions = {}): Promise<DefaultMultiExtensionRunner> {
@@ -135,15 +126,10 @@ export default async function run(
       firefoxClient,
     };
 
-    if (!FirefoxDesktopExtensionRunner) {
-      ({FirefoxDesktopExtensionRunner} =
-        require('../extension-runners/firefox-desktop'));
-    }
-
-    const firefoxDesktopRunner = new FirefoxDesktopExtensionRunner(
-      firefoxDesktopRunnerParams
-    );
-
+    const firefoxDesktopRunner = await createExtensionRunner({
+      target: 'firefox-desktop',
+      params: firefoxDesktopRunnerParams,
+    });
     runners.push(firefoxDesktopRunner);
   }
 
@@ -181,16 +167,10 @@ export default async function run(
       },
     };
 
-    if (!FirefoxAndroidExtensionRunner) {
-      ({FirefoxAndroidExtensionRunner} =
-        require('../extension-runners/firefox-android'));
-    }
-
-    const firefoxAndroidRunner = new FirefoxAndroidExtensionRunner({
-      ...commonRunnerParams,
-      ...firefoxAndroidRunnerParams,
+    const firefoxAndroidRunner = await createExtensionRunner({
+      target: 'firefox-android',
+      params: firefoxAndroidRunnerParams,
     });
-
     runners.push(firefoxAndroidRunner);
   }
 

--- a/src/extension-runners/firefox-android.js
+++ b/src/extension-runners/firefox-android.js
@@ -63,7 +63,7 @@ export type FirefoxAndroidExtensionRunnerParams = {|
   // Injected Dependencies.
   firefoxApp: typeof defaultFirefoxApp,
   firefoxClient: typeof defaultFirefoxConnector,
-  ADBUtils: typeof DefaultADBUtils,
+  ADBUtils?: typeof DefaultADBUtils,
   buildSourceDir: (string, string) => Promise<ExtensionBuildResult>,
   desktopNotifications: typeof defaultDesktopNotifications,
   stdin?: stream$Readable,
@@ -107,9 +107,10 @@ export class FirefoxAndroidExtensionRunner {
       adbBin,
       adbHost,
       adbPort,
+      ADBUtils = DefaultADBUtils,
     } = this.params;
 
-    this.adbUtils = new this.params.ADBUtils({
+    this.adbUtils = new ADBUtils({
       adbBin, adbHost, adbPort,
     });
 

--- a/tests/unit/test-cmd/test.run.js
+++ b/tests/unit/test-cmd/test.run.js
@@ -20,47 +20,47 @@ const tempInstallResult = {
   addon: {id: 'some-addon@test-suite'},
 };
 
+function prepareRun(fakeInstallResult) {
+  const sourceDir = fixturePath('minimal-web-ext');
+
+  const argv = {
+    artifactsDir: path.join(sourceDir, 'web-ext-artifacts'),
+    sourceDir,
+    noReload: true,
+    keepProfileChanges: false,
+    browserConsole: false,
+  };
+  const options = {
+    buildExtension: sinon.spy(() => {}),
+    firefoxApp: getFakeFirefox(),
+    firefoxClient: sinon.spy(() => {
+      return Promise.resolve(getFakeRemoteFirefox({
+        installTemporaryAddon: () =>
+          Promise.resolve(
+            fakeInstallResult || tempInstallResult
+          ),
+      }));
+    }),
+    reloadStrategy: sinon.spy(() => {
+      log.debug('fake: reloadStrategy()');
+    }),
+    MultiExtensionRunner: sinon.spy(FakeExtensionRunner),
+    desktopNotifications: sinon.spy(() => {}),
+  };
+
+  return {
+    argv,
+    options,
+    run: (customArgv = {}, customOpt = {}) => run(
+      {...argv, ...customArgv},
+      {...options, ...customOpt}
+    ),
+  };
+}
+
 describe('run', () => {
   let androidRunnerStub: sinon.SinonStub;
   let desktopRunnerStub: sinon.SinonStub;
-
-  function prepareRun(fakeInstallResult) {
-    const sourceDir = fixturePath('minimal-web-ext');
-
-    const argv = {
-      artifactsDir: path.join(sourceDir, 'web-ext-artifacts'),
-      sourceDir,
-      noReload: true,
-      keepProfileChanges: false,
-      browserConsole: false,
-    };
-    const options = {
-      buildExtension: sinon.spy(() => {}),
-      firefoxApp: getFakeFirefox(),
-      firefoxClient: sinon.spy(() => {
-        return Promise.resolve(getFakeRemoteFirefox({
-          installTemporaryAddon: () =>
-            Promise.resolve(
-              fakeInstallResult || tempInstallResult
-            ),
-        }));
-      }),
-      reloadStrategy: sinon.spy(() => {
-        log.debug('fake: reloadStrategy()');
-      }),
-      MultiExtensionRunner: sinon.spy(FakeExtensionRunner),
-      desktopNotifications: sinon.spy(() => {}),
-    };
-
-    return {
-      argv,
-      options,
-      run: (customArgv = {}, customOpt = {}) => run(
-        {...argv, ...customArgv},
-        {...options, ...customOpt}
-      ),
-    };
-  }
 
   beforeEach(() => {
     androidRunnerStub = sinon.stub(

--- a/tests/unit/test-cmd/test.run.js
+++ b/tests/unit/test-cmd/test.run.js
@@ -1,7 +1,7 @@
 /* @flow */
 import path from 'path';
 
-import {describe, it} from 'mocha';
+import {afterEach, beforeEach, describe, it} from 'mocha';
 import {assert} from 'chai';
 import sinon from 'sinon';
 
@@ -21,6 +21,8 @@ const tempInstallResult = {
 };
 
 describe('run', () => {
+  let androidRunnerStub: sinon.SinonStub;
+  let desktopRunnerStub: sinon.SinonStub;
 
   function prepareRun(fakeInstallResult) {
     const sourceDir = fixturePath('minimal-web-ext');
@@ -46,7 +48,6 @@ describe('run', () => {
       reloadStrategy: sinon.spy(() => {
         log.debug('fake: reloadStrategy()');
       }),
-      FirefoxDesktopExtensionRunner: sinon.spy(FakeExtensionRunner),
       MultiExtensionRunner: sinon.spy(FakeExtensionRunner),
       desktopNotifications: sinon.spy(() => {}),
     };
@@ -61,25 +62,38 @@ describe('run', () => {
     };
   }
 
+  beforeEach(() => {
+    androidRunnerStub = sinon.stub(
+      // TODO: use async import instead of require - https://github.com/mozilla/web-ext/issues/1306
+      require('../../../src/extension-runners/firefox-android'),
+      'FirefoxAndroidExtensionRunner');
+
+    desktopRunnerStub = sinon.stub(
+      // TODO: use async import instead of require - https://github.com/mozilla/web-ext/issues/1306
+      require('../../../src/extension-runners/firefox-desktop'),
+      'FirefoxDesktopExtensionRunner');
+  });
+  afterEach(() => {
+    androidRunnerStub.restore();
+    androidRunnerStub = undefined;
+    desktopRunnerStub.restore();
+    desktopRunnerStub = undefined;
+  });
+
   it('passes a custom Firefox binary when specified', async () => {
     const firefox = '/pretend/path/to/Firefox/firefox-bin';
     const cmd = prepareRun();
-    const FirefoxDesktopExtensionRunner = sinon.spy(FakeExtensionRunner);
-    await cmd.run({firefox}, {FirefoxDesktopExtensionRunner});
-    sinon.assert.calledWithMatch(
-      FirefoxDesktopExtensionRunner, {firefoxBinary: firefox}
-    );
+    await cmd.run({firefox});
+    sinon.assert.calledWithMatch(desktopRunnerStub, {firefoxBinary: firefox});
   });
 
   it('passes startUrl parameter to Firefox when specified', async () => {
     const cmd = prepareRun();
     const expectedStartUrls = ['www.example.com'];
-    const FirefoxDesktopExtensionRunner = sinon.spy(FakeExtensionRunner);
 
-    await cmd.run({startUrl: expectedStartUrls},
-                  {FirefoxDesktopExtensionRunner});
+    await cmd.run({startUrl: expectedStartUrls});
     sinon.assert.calledWithMatch(
-      FirefoxDesktopExtensionRunner, {startUrl: expectedStartUrls}
+      desktopRunnerStub, {startUrl: expectedStartUrls}
     );
   });
 
@@ -94,12 +108,10 @@ describe('run', () => {
       firefoxProfile: '/path/to/custom/profile',
     };
 
-    const FirefoxDesktopExtensionRunner = sinon.spy(FakeExtensionRunner);
+    await cmd.run(runOptions);
 
-    await cmd.run(runOptions, {FirefoxDesktopExtensionRunner});
-
-    assert.ok(FirefoxDesktopExtensionRunner.called);
-    const runnerParams = FirefoxDesktopExtensionRunner.firstCall.args[0];
+    sinon.assert.calledOnce(desktopRunnerStub);
+    const runnerParams = desktopRunnerStub.firstCall.args[0];
 
     // The runner should receive the same parameters as the options sent
     // to run() with just a few minor adjustments.
@@ -124,11 +136,10 @@ describe('run', () => {
   it('passes the expected dependencies to the extension runner', async () => {
     const cmd = prepareRun();
     const {firefoxApp, firefoxClient} = cmd.options;
-    const FirefoxDesktopExtensionRunner = sinon.spy(FakeExtensionRunner);
 
-    await cmd.run({}, {FirefoxDesktopExtensionRunner});
-    assert.ok(FirefoxDesktopExtensionRunner.called);
-    const runnerParams = FirefoxDesktopExtensionRunner.firstCall.args[0];
+    await cmd.run({});
+    sinon.assert.calledOnce(desktopRunnerStub);
+    const runnerParams = desktopRunnerStub.firstCall.args[0];
     assert.deepEqual({
       firefoxApp: runnerParams.firefoxApp,
       firefoxClient: runnerParams.firefoxClient,
@@ -189,66 +200,49 @@ describe('run', () => {
   it('creates a Firefox Desktop runner if targets is an empty array',
      async () => {
        const cmd = prepareRun();
-       const FirefoxDesktopExtensionRunner = sinon.spy(FakeExtensionRunner);
-       await cmd.run({target: []}, {FirefoxDesktopExtensionRunner});
-       sinon.assert.calledOnce(FirefoxDesktopExtensionRunner);
+       await cmd.run({target: []});
+       sinon.assert.notCalled(androidRunnerStub);
+       sinon.assert.calledOnce(desktopRunnerStub);
      });
 
   it('creates a Firefox Desktop runner if "firefox-desktop" is in target',
      async () => {
        const cmd = prepareRun();
-       const FirefoxDesktopExtensionRunner = sinon.spy(FakeExtensionRunner);
-       await cmd.run({target: ['firefox-desktop']}, {
-         FirefoxDesktopExtensionRunner,
-       });
-       sinon.assert.calledOnce(FirefoxDesktopExtensionRunner);
+       await cmd.run({target: ['firefox-desktop']});
+       sinon.assert.notCalled(androidRunnerStub);
+       sinon.assert.calledOnce(desktopRunnerStub);
      });
 
   it('creates a Firefox Android runner if "firefox-android" is in target',
      async () => {
        const cmd = prepareRun();
-       const FirefoxDesktopExtensionRunner = sinon.spy(FakeExtensionRunner);
-       const FirefoxAndroidExtensionRunner = sinon.spy(FakeExtensionRunner);
-       await cmd.run({target: ['firefox-android']}, {
-         FirefoxDesktopExtensionRunner,
-         FirefoxAndroidExtensionRunner,
-       });
+       await cmd.run({target: ['firefox-android']});
 
-       sinon.assert.calledOnce(FirefoxAndroidExtensionRunner);
-       sinon.assert.notCalled(FirefoxDesktopExtensionRunner);
+       sinon.assert.calledOnce(androidRunnerStub);
+       sinon.assert.notCalled(desktopRunnerStub);
      });
 
   it('creates multiple extension runners', async () => {
     const cmd = prepareRun();
-    const FirefoxDesktopExtensionRunner = sinon.spy(FakeExtensionRunner);
-    const FirefoxAndroidExtensionRunner = sinon.spy(FakeExtensionRunner);
-    await cmd.run({target: ['firefox-android', 'firefox-desktop']}, {
-      FirefoxDesktopExtensionRunner,
-      FirefoxAndroidExtensionRunner,
-    });
+    await cmd.run({target: ['firefox-android', 'firefox-desktop']});
 
-    sinon.assert.calledOnce(FirefoxAndroidExtensionRunner);
-    sinon.assert.calledOnce(FirefoxDesktopExtensionRunner);
+    sinon.assert.calledOnce(androidRunnerStub);
+    sinon.assert.calledOnce(desktopRunnerStub);
   });
 
   it('provides a buildSourceDir method to the Firefox Android runner',
      async () => {
        const cmd = prepareRun();
-       const FirefoxDesktopExtensionRunner = sinon.spy(FakeExtensionRunner);
-       const FirefoxAndroidExtensionRunner = sinon.spy(FakeExtensionRunner);
-       await cmd.run({target: ['firefox-android']}, {
-         FirefoxDesktopExtensionRunner,
-         FirefoxAndroidExtensionRunner,
-       });
+       await cmd.run({target: ['firefox-android']});
 
        sinon.assert.calledWithMatch(
-         FirefoxAndroidExtensionRunner,
+         androidRunnerStub,
          {
            buildSourceDir: sinon.match.func,
          }
        );
 
-       const {buildSourceDir} = FirefoxAndroidExtensionRunner.firstCall.args[0];
+       const {buildSourceDir} = androidRunnerStub.firstCall.args[0];
 
        await buildSourceDir('/fake/source/dir');
 

--- a/tests/unit/test-extension-runners/test.extension-runners.js
+++ b/tests/unit/test-extension-runners/test.extension-runners.js
@@ -8,6 +8,7 @@ import {assert} from 'chai';
 import sinon from 'sinon';
 
 import {
+  createExtensionRunner,
   defaultWatcherCreator,
   defaultReloadStrategy,
   MultiExtensionRunner,
@@ -59,6 +60,13 @@ function exitKeypressLoop(stdin) {
 }
 
 describe('util/extension-runners', () => {
+  describe('createExtensionRunner', () => {
+    it('requires a valid target', async () => {
+      // $FLOW_IGNORE: Want to pass invalid argument and check the error.
+      const promise = createExtensionRunner({});
+      await assert.isRejected(promise, /Unknown target: "undefined"/);
+    });
+  });
 
   describe('MultiExtensionRunner', () => {
 

--- a/tests/unit/test.web-ext.js
+++ b/tests/unit/test.web-ext.js
@@ -1,10 +1,9 @@
 /* @flow */
-import {describe, it} from 'mocha';
+import {afterEach, describe, it} from 'mocha';
 import {assert} from 'chai';
+import sinon from 'sinon';
 
 import webExt from '../../src/main';
-import build from '../../src/cmd/build';
-import run from '../../src/cmd/run';
 import {main} from '../../src/program';
 import {consoleStream} from '../../src/util/logger';
 
@@ -14,13 +13,36 @@ describe('webExt', () => {
     assert.equal(webExt.main, main);
   });
 
-  it('exposes commands', () => {
-    // This just checks a sample of commands.
-    assert.equal(webExt.cmd.run, run);
-    assert.equal(webExt.cmd.build, build);
-  });
-
   it('gives you access to the log stream', () => {
     assert.equal(webExt.util.logger.consoleStream, consoleStream);
+  });
+
+  describe('exposes commands', () => {
+    let stub: sinon.Stub;
+    afterEach(() => {
+      stub.restore();
+      stub = undefined;
+    });
+    for (const cmd of ['run', 'lint', 'build', 'sign', 'docs']) {
+      it(`lazily loads cmd/${cmd}`, async () => {
+        // TODO: use async import instead of require - https://github.com/mozilla/web-ext/issues/1306
+        // $FLOW_IGNORE: non-literal require used only in tests.
+        const cmdModule = require(`../../src/cmd/${cmd}`);
+        stub = sinon.stub(cmdModule, 'default');
+
+        const params = {};
+        const options = {};
+        const expectedResult = {};
+        stub.returns(expectedResult);
+
+        const runCommand : Function = webExt.cmd[cmd];
+        const result = await runCommand(params, options);
+
+        // Check whether parameters and return values are forwarded as-is.
+        sinon.assert.calledOnce(stub);
+        sinon.assert.calledWithExactly(stub, params, options);
+        assert.equal(expectedResult, result);
+      });
+    }
   });
 });


### PR DESCRIPTION
Simple commands like `web-ext --help` now require less than a second instead of 4 seconds to complete.

And `web-ext run` also runs slightly over 3 seconds faster (https://github.com/mozilla/web-ext/pull/1302#issuecomment-380786023)

Fixes #1301