### PR TITLE
fix(parse-json): Fixed incompatibility with json-parse-better-errors 1.0.2

### DIFF
--- a/src/cmd/build.js
+++ b/src/cmd/build.js
@@ -78,7 +78,7 @@ export async function getDefaultLocalizedName(
   }
 
   try {
-    messageData = parseJSON(messageContents, messageFile);
+    messageData = parseJSON(String(messageContents), messageFile);
   } catch (error) {
     throw new UsageError(
       `Error parsing messages.json ${error}`);


### PR DESCRIPTION
This pull request applies a super small change to fix an incompatibility with json-parse-better-errors 1.0.2, due to this change (and the fact that we pass a nodejs Buffer instead on a plain string):

- https://github.com/zkat/json-parse-better-errors/compare/v1.0.1...latest#diff-168726dbe96b3ce427e7fedce31bb0bcR9

Not that we have asked for a new version, but its a "relaxed" dependency of one of our dependencies:
- https://github.com/sindresorhus/parse-json/blob/a35850ac2881cba5be3b10cd8ffd5c8567f3cd02/package.json#L36

and so, new installations get json-parse-better-errors 1.0.2 and the different behavior (included any new travis job: https://travis-ci.org/rpl/web-ext/builds/365291384#L2733)

isn't that fun?