### PR TITLE
fix(test): Fixed remaining issues for run test successfully on node >= 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 # Keep this in sync with appveyor.yml
 node_js:
 - '6'
+- '8'
 
 before_script:
 # If this command fails and you can't fix it, file an issue and add an exception to .nsprc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,7 @@ shallow_clone: true
 environment:
   matrix:
     - nodejs_version: '6'
+    - nodejs_version: '8'
 
 test_script:
   - node --version

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -1,6 +1,7 @@
 /* @flow */
 import path from 'path';
 import EventEmitter from 'events';
+import tty from 'tty';
 
 import sinon from 'sinon';
 import yauzl from 'yauzl';
@@ -334,4 +335,11 @@ export function getFakeFirefox(
 
 export function getFakeRemoteFirefox(implementations: Object = {}) {
   return fake(RemoteFirefox.prototype, implementations);
+}
+
+export class FakeStdin extends tty.ReadStream {
+  constructor() {
+    // $FLOW_FIXME: flow doesn't yet recognize 0 as a valid parameter of tty.ReadStream.
+    super(0);
+  }
 }

--- a/tests/unit/test-extension-runners/test.extension-runners.js
+++ b/tests/unit/test-extension-runners/test.extension-runners.js
@@ -1,7 +1,5 @@
 /* @flow */
-
 import stream from 'stream';
-import tty from 'tty';
 
 import {describe, it} from 'mocha';
 import {assert} from 'chai';
@@ -15,6 +13,7 @@ import {
 } from '../../../src/extension-runners';
 import {
   FakeExtensionRunner,
+  FakeStdin,
 } from '../helpers';
 import type {
   IExtensionRunner, // eslint-disable-line import/named
@@ -488,7 +487,7 @@ describe('util/extension-runners', () => {
     it('can reload when user presses R in shell console', async () => {
       const {extensionRunner, reloadStrategy} = prepare();
 
-      const fakeStdin = new tty.ReadStream();
+      const fakeStdin = new FakeStdin();
       sinon.spy(fakeStdin, 'setRawMode');
       sinon.spy(extensionRunner, 'reloadAllExtensions');
 
@@ -510,7 +509,7 @@ describe('util/extension-runners', () => {
       const {extensionRunner, reloadStrategy} = prepare();
       sinon.spy(extensionRunner, 'registerCleanup');
 
-      const fakeStdin = new tty.ReadStream();
+      const fakeStdin = new FakeStdin();
       sinon.spy(fakeStdin, 'pause');
       sinon.spy(fakeStdin, 'setRawMode');
 
@@ -537,7 +536,7 @@ describe('util/extension-runners', () => {
            },
          });
 
-         const fakeStdin = new tty.ReadStream();
+         const fakeStdin = new FakeStdin();
          sinon.spy(fakeStdin, 'setRawMode');
 
          try {
@@ -567,7 +566,8 @@ describe('util/extension-runners', () => {
              async exit() {},
            },
          });
-         const fakeStdin = new tty.ReadStream();
+
+         const fakeStdin = new FakeStdin();
 
          try {
            await reloadStrategy({}, {stdin: fakeStdin});
@@ -588,7 +588,9 @@ describe('util/extension-runners', () => {
 
     it('pauses the web-ext process (CTRL+Z in shell console)', async () => {
       const {reloadStrategy} = prepare();
-      const fakeStdin = new tty.ReadStream();
+
+      const fakeStdin = new FakeStdin();
+
       const setRawMode = sinon.spy(fakeStdin, 'setRawMode');
       const fakeKill = sinon.spy(() => {});
 

--- a/tests/unit/test-extension-runners/test.firefox-android.js
+++ b/tests/unit/test-extension-runners/test.firefox-android.js
@@ -1,7 +1,6 @@
 /* @flow */
 
 import EventEmitter from 'events';
-import tty from 'tty';
 
 import {assert} from 'chai';
 import {describe, it} from 'mocha';
@@ -23,6 +22,7 @@ import {
   basicManifest,
   getFakeFirefox,
   getFakeRemoteFirefox,
+  FakeStdin,
 } from '../helpers';
 
 // Fake result for client.installTemporaryAddon().then(installResult => ...)
@@ -588,7 +588,7 @@ describe('util/extension-runners/firefox-android', () => {
            throw new UsageError('fake user exit');
          });
 
-         const fakeStdin = new tty.ReadStream();
+         const fakeStdin = new FakeStdin();
 
          params.stdin = fakeStdin;
 

--- a/tests/unit/test-util/test.logger.js
+++ b/tests/unit/test-util/test.logger.js
@@ -1,5 +1,5 @@
 /* @flow */
-import {WriteStream} from 'tty';
+import {Writable as WritableStream} from 'stream';
 
 import bunyan from 'bunyan';
 import sinon from 'sinon';
@@ -37,7 +37,7 @@ describe('logger', () => {
 
     // NOTE: create a fake process that makes flow happy.
     function fakeProcess() {
-      class FakeWritableStream extends WriteStream {
+      class FakeWritableStream extends WritableStream {
         write(): boolean {
           return true;
         }


### PR DESCRIPTION
This PR contains some additional changes to the test units needed to successfully run all the tests on node >= 8 (and fix the remaining issues from #1129).

In particular it fixes the ` RangeError [ERR_INVALID_FD]: "fd" must be a positive integer: undefined` errors due to the ReadStream/WriteStream instances created in tests (e.g. to mock the stdin stream).

On this fixes we currently need to suppress some flow type errors (due to the nodejs type definitions already defined in flow not yet including this changes between node6 and node8).

Once ReadStream/WriteStream type definitions are updated in flow itself, flow is going to complain that these suppress comments are not suppressing any actual error and we will know that we can remove the suppress comments from there.