### PR TITLE
replace open with opn

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "mkdirp": "0.5.1",
     "mz": "2.7.0",
     "node-notifier": "5.2.1",
-    "open": "0.0.5",
+    "opn": "^5.3.0",
     "parse-json": "4.0.0",
     "regenerator-runtime": "0.11.1",
     "require-uncached": "1.0.3",

--- a/src/cmd/docs.js
+++ b/src/cmd/docs.js
@@ -1,5 +1,5 @@
 /* @flow */
-import defaultUrlOpener from 'open';
+import opn from 'opn';
 
 import {createLogger} from '../util/logger';
 
@@ -11,14 +11,14 @@ export type DocsParams = {
 }
 
 export type DocsOptions = {
-  openUrl?: typeof defaultUrlOpener,
+  openUrl?: typeof opn,
 }
 
 export const url = 'https://developer.mozilla.org/en-US/Add-ons' +
   '/WebExtensions/Getting_started_with_web-ext';
 
 export default function docs(
-  params: DocsParams, {openUrl = defaultUrlOpener}: DocsOptions = {}
+  params: DocsParams, {openUrl = opn}: DocsOptions = {}
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     openUrl(url, (error) => {


### PR DESCRIPTION
open has a [security vulnerability](https://nodesecurity.io/advisories/663) and seems to be unmaintained.

Since is just used to open docs I think couldn't be a problem to change for an alternative package.

http://www.npmtrends.com/open-vs-opener-vs-opn
https://npmcompare.com/compare/open,opener,opn

Currently [opn](https://www.npmjs.com/package/opn) seems to be better maintained package.