### PR TITLE
Drop support for Node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 
 # Keep this in sync with appveyor.yml
 node_js:
-- '6'
 - '8'
 - '10'
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,8 +16,8 @@ shallow_clone: true
 # Keep the following configs in sync with .travis.yml
 environment:
   matrix:
-    - nodejs_version: '6'
     - nodejs_version: '8'
+    - nodejs_version: '10'
 
 test_script:
   - node --version


### PR DESCRIPTION
addons-linter 1.0 has dropped support for Node 6, which is causing recent builds to fail (especially #1326), this drops support for it.