### PR TITLE
fix(test): Avoid EPIPE error in "web-ext sign" test

### DIFF
--- a/tests/functional/fake-amo-server.js
+++ b/tests/functional/fake-amo-server.js
@@ -29,9 +29,17 @@ http.createServer(function(req, res) {
   const reply = FAKE_REPLIES[replyIndex++];
 
   if (reply) {
-    res.writeHead(200, {'content-type': 'application/json'});
-    res.write(JSON.stringify(reply));
-    res.end();
+    req.on('data', function() {
+      // Ignore request body.
+    });
+    // Wait for the transfer of the request body to finish before sending a response.
+    // Otherwise the client could experience an EPIPE error:
+    // https://github.com/nodejs/node/issues/12339
+    req.once('end', function() {
+      res.writeHead(200, {'content-type': 'application/json'});
+      res.write(JSON.stringify(reply));
+      res.end();
+    });
   } else {
     process.exit(1);
   }


### PR DESCRIPTION
In our fake AMO server, we are immediately sending a response without consuming the HTTP request body. This code pattern is known to cause EPIPE failures (see https://github.com/nodejs/node/issues/12339). The fix is to consume the request body before responding.

Minimal local reproduction (tested with Node.js v10.6.0):

```sh
path/to/web-ext/tests/functional/fake-amo-server.js
```

```sh
$ node -e 'require("http").request({port:8989,method:"POST"},res=>{console.log(res.statusCode); res.pipe(process.stdout)}).end("x".repeat(1E7))'
200
{"url":"http://localhost:8989/validation-results/"}events.js:167
      throw er; // Unhandled 'error' event
      ^

Error: write EPIPE
    at WriteWrap.afterWrite [as oncomplete] (net.js:835:14)
Emitted 'error' event at:
    at Socket.socketErrorListener (_http_client.js:382:9)
    at Socket.emit (events.js:182:13)
    at onwriteError (_stream_writable.js:431:12)
    at onwrite (_stream_writable.js:456:5)
    at _destroy (internal/streams/destroy.js:40:7)
    at Socket._destroy (net.js:605:3)
    at Socket.destroy (internal/streams/destroy.js:32:8)
    at WriteWrap.afterWrite [as oncomplete] (net.js:837:10)
```

After this patch, the above error does not occur any more. I have also verified that `GET` requests also complete successfully.