### PR TITLE
fix(package): update addons-linter to version 1.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@cliqz-oss/firefox-client": "0.3.1",
     "@cliqz-oss/node-firefox-connect": "1.2.1",
     "adbkit": "2.11.0",
-    "addons-linter": "1.0.0",
+    "addons-linter": "1.2.6",
     "babel-polyfill": "6.26.0",
     "babel-runtime": "6.26.0",
     "bunyan": "1.8.12",


### PR DESCRIPTION
This PR updates the addons-linter to version 1.2.6, and so it supersedes and fix #1326.