### PR TITLE
fix: Use default javascript.options.strict=false

### DIFF
--- a/src/firefox/preferences.js
+++ b/src/firefox/preferences.js
@@ -22,9 +22,6 @@ export type PreferencesAppName = 'firefox' | 'fennec';
 const prefsCommon: FirefoxPreferences = {
   // Allow debug output via dump to be printed to the system console
   'browser.dom.window.dump.enabled': true,
-  // Warn about possibly incorrect code.
-  'javascript.options.strict': true,
-  'javascript.options.showInConsole': true,
 
   // Allow remote connections to the debugger.
   'devtools.debugger.remote-enabled': true,


### PR DESCRIPTION
The `javascript.options.strict` option results in lots of log spam, which not only makes debugging harder, but also slows down Firefox.

The `javascript.options.showInConsole` option was removed too because true is already the default value.

Fixes #1355