### PR TITLE
fix(package): update addons-linter to version 1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@cliqz-oss/firefox-client": "0.3.1",
     "@cliqz-oss/node-firefox-connect": "1.2.1",
     "adbkit": "2.11.0",
-    "addons-linter": "1.2.6",
+    "addons-linter": "1.3.1",
     "babel-polyfill": "6.26.0",
     "babel-runtime": "6.26.0",
     "bunyan": "1.8.12",


### PR DESCRIPTION
This PR updates the addons-linter npm dependency from version 1.2.6 to version 1.3.1 (and supersedes #1353).

The updated addons-linter provides the following additional features/fixes (as mentioned in https://github.com/mozilla/web-ext/pull/1353#issuecomment-411187167):

- Added basic support for WebExtension dictionaries
- WebExtensions API Schemas updated up to Firefox 62b15
- Added support for ES6 modules