### PR TITLE
Look for magic configuration in XDG config directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "tmp": "0.0.33",
     "update-notifier": "2.3.0",
     "watchpack": "1.5.0",
+    "xdg-basedir": "3.0.0",
     "yargs": "6.6.0",
     "zip-dir": "1.0.2"
   },


### PR DESCRIPTION
> Keeps your $HOME tidy so your vacuum robot can safely clean the floor.

I've been reinstalling Linux on my notebook and since I learned about the [XDG base directory spec](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) I attempted to keep it as empty as possible.

web-ext is one of the tools that doesn't look in the XDG config dir for its config, so let's fix that!

The implementation here just follows how to find out where the config dir is, it doesn't fully follow the format or ideas. It looks for the configuration directly in the config dir, and not in a `web-ext` sub folder. It also only looks in the user specific config directory and not the system wide config directories.

The config found in the XDG config dir is applied before the one in $HOME, meaning it should only marginally impact any user that somehow already has a web-ext-config.js in their XDG config directory.

Alternatively a more generic module could be used, like https://www.npmjs.com/package/env-paths that does this for multiple OSes (specifically including Mac OS and windows).