### PR TITLE
chore: Skip node_js 6 on travis windows workers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,13 @@ node_js:
 - '6'
 - '8'
 
+# Skip node_js 6 on travis windows workers (as it often fails because
+# travis fails to init the node_js 6 environment).
+matrix:
+  exclude:
+  - node_js: '6'
+    os: windows
+
 before_script:
 # If this command fails and you can't fix it, file an issue and add an exception to .nsprc
 - npm run nsp-check


### PR DESCRIPTION
This PR is a small follow up related to #1385, the travis windows workers are pretty slow (not very surprising to be fair) and it seems that travis is having issues to initialize the node_js 6 environment from time to time (and so in that case the job is marked as errored even if the tests haven't been executed at all).

I think that it would be reasonable to run on windows only the last nodejs version that we are testing web-ext on CI, so that we can speed up the CI job a bit and spare Travis from allocating two windows worker for every CI job.