### PR TITLE
chore: Skipped nsp-check and travis-pr-title-lint npm scripts on travis windows workers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
 
 before_script:
 # If this command fails and you can't fix it, file an issue and add an exception to .nsprc
-- npm run nsp-check
+- if [[ "$TRAVIS_OS_NAME" != 'windows' ]]; then npm run nsp-check; fi
 
 # Keep this in sync with appveyor.yml
 script:
@@ -46,7 +46,7 @@ script:
 - rm artifacts/production/package.json
 
 ## lint the github PR title.
-- npm run travis-pr-title-lint
+- if [[ "$TRAVIS_OS_NAME" != 'windows' ]]; then npm run travis-pr-title-lint; fi
 
 after_script: npm run publish-coverage
 


### PR DESCRIPTION
This PR skips some redundant steps from the travis windows workers (basically skipping steps that are not really needed to run on the slower travis window workers, because the exact same step is already executed in the faster travis linux workers and so an issue is likely already been caught by them).