### PR TITLE
fix(firefox-android): Support abstract sockets for RDB

### DIFF
--- a/src/extension-runners/firefox-android.js
+++ b/src/extension-runners/firefox-android.js
@@ -578,9 +578,13 @@ export class FirefoxAndroidExtensionRunner {
     // to connect the Firefox DevTools to the Firefox for Android instance).
     log.info(`You can connect to this Android device on TCP port ${tcpPort}`);
 
+    const forwardSocketSpec = this.selectedRDPSocketFile.startsWith('@') ?
+      `localabstract:${this.selectedRDPSocketFile.substr(1)}`
+      : `localfilesystem:${this.selectedRDPSocketFile}`;
+
     await adbUtils.setupForward(
       selectedAdbDevice,
-      `localfilesystem:${this.selectedRDPSocketFile}`,
+      forwardSocketSpec,
       `tcp:${tcpPort}`
     );
 


### PR DESCRIPTION
New versions of firefox-android appear to use abstract unix sockets instead of filesystem sockets
for the debugging connection. This change ensures support for both the original filesystem
namespace and also the abstract namespace.