### PR TITLE
feat: Support chromium-based browsers as web-ext run targets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3421,15 +3421,22 @@
       "dev": true
     },
     "chrome-launcher": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.10.7.tgz",
-      "integrity": "sha512-IoQLp64s2n8OQuvKZwt77CscVj3UlV2Dj7yZtd1EBMld9mSdGcsGy9fN5hd/r4vJuWZR09it78n1+A17gB+AIQ==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.11.2.tgz",
+      "integrity": "sha512-jx0kJDCXdB2ARcDMwNCtrf04oY1Up4rOmVu+fqJ5MTPOOIG8EhRcEU9NZfXZc6dMw9FU8o1r21PNp8V2M0zQ+g==",
       "requires": {
         "@types/node": "*",
-        "is-wsl": "^1.1.0",
+        "is-wsl": "^2.1.0",
         "lighthouse-logger": "^1.0.0",
         "mkdirp": "0.5.1",
         "rimraf": "^2.6.1"
+      },
+      "dependencies": {
+        "is-wsl": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.0.tgz",
+          "integrity": "sha512-pFTjpv/x5HRj8kbZ/Msxi9VrvtOMRBqaDi3OIcbwPI3OuH+r3lLxVWukLITBaOGJIbA/w2+M1eVmVa4XNQlAmQ=="
+        }
       }
     },
     "chrome-trace-event": {
@@ -13807,9 +13814,9 @@
       }
     },
     "ws": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.0.1.tgz",
-      "integrity": "sha512-ILHfMbuqLJvnSgYXLgy4kMntroJpe8hT41dOVWM8bxRuw6TK4mgMp9VJUNsZTEc5Bh+Mbs0DJT4M0N+wBG9l9A==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.1.2.tgz",
+      "integrity": "sha512-gftXq3XI81cJCgkUiAVixA0raD9IVmXqsylCrjRygw4+UOOGzPoxnQ6r/CnVL9i+mDncJo94tSkyrtuuQVBmrg==",
       "requires": {
         "async-limiter": "^1.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2081,6 +2081,11 @@
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ=="
     },
+    "async-limiter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -3414,6 +3419,18 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
       "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==",
       "dev": true
+    },
+    "chrome-launcher": {
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.10.7.tgz",
+      "integrity": "sha512-IoQLp64s2n8OQuvKZwt77CscVj3UlV2Dj7yZtd1EBMld9mSdGcsGy9fN5hd/r4vJuWZR09it78n1+A17gB+AIQ==",
+      "requires": {
+        "@types/node": "*",
+        "is-wsl": "^1.1.0",
+        "lighthouse-logger": "^1.0.0",
+        "mkdirp": "0.5.1",
+        "rimraf": "^2.6.1"
+      }
     },
     "chrome-trace-event": {
       "version": "1.0.2",
@@ -8393,6 +8410,15 @@
         "immediate": "~3.0.5"
       }
     },
+    "lighthouse-logger": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.2.0.tgz",
+      "integrity": "sha512-wzUvdIeJZhRsG6gpZfmSCfysaxNEr43i+QT+Hie94wvHDKFLi4n7C2GqZ4sTC+PH5b5iktmXJvU87rWvhP3lHw==",
+      "requires": {
+        "debug": "^2.6.8",
+        "marky": "^1.2.0"
+      }
+    },
     "load-json-file": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -8664,6 +8690,11 @@
       "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.3.tgz",
       "integrity": "sha512-XUi5HJhhV5R74k8/0H2oCbCiYf/u4cO/rX8tnGkRvrqhsr5BRNU6Mg0yt/8UIx1iIS8220BNJsDb7XnILhLepw==",
       "dev": true
+    },
+    "marky": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/marky/-/marky-1.2.1.tgz",
+      "integrity": "sha512-md9k+Gxa3qLH6sUKpeC2CNkJK/Ld+bEz5X96nYwloqphQE0CKCVEKco/6jxEZixinqNdz5RFi/KaCyfbMDMAXQ=="
     },
     "md5.js": {
       "version": "1.3.5",
@@ -13773,6 +13804,14 @@
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.2"
+      }
+    },
+    "ws": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.0.1.tgz",
+      "integrity": "sha512-ILHfMbuqLJvnSgYXLgy4kMntroJpe8hT41dOVWM8bxRuw6TK4mgMp9VJUNsZTEc5Bh+Mbs0DJT4M0N+wBG9l9A==",
+      "requires": {
+        "async-limiter": "^1.0.0"
       }
     },
     "x-is-string": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "addons-linter": "1.10.0",
     "bunyan": "1.8.12",
     "camelcase": "5.3.1",
+    "chrome-launcher": "0.10.7",
     "debounce": "1.2.0",
     "decamelize": "3.2.0",
     "es6-error": "4.1.1",
@@ -75,6 +76,7 @@
     "tmp": "0.1.0",
     "update-notifier": "3.0.1",
     "watchpack": "1.6.0",
+    "ws": "7.0.1",
     "yargs": "13.2.4",
     "zip-dir": "1.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "addons-linter": "1.10.0",
     "bunyan": "1.8.12",
     "camelcase": "5.3.1",
-    "chrome-launcher": "0.10.7",
+    "chrome-launcher": "0.11.2",
     "debounce": "1.2.0",
     "decamelize": "3.2.0",
     "es6-error": "4.1.1",
@@ -76,7 +76,7 @@
     "tmp": "0.1.0",
     "update-notifier": "3.0.1",
     "watchpack": "1.6.0",
-    "ws": "7.0.1",
+    "ws": "7.1.2",
     "yargs": "13.2.4",
     "zip-dir": "1.0.2"
   },

--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -44,6 +44,10 @@ export type CmdRunParams = {|
   adbPort?: string,
   adbDevice?: string,
   firefoxApk?: string,
+
+  // Chromium Desktop CLI options.
+  chromiumBinary?: string,
+  chromiumProfile?: string,
 |};
 
 export type CmdRunOptions = {|
@@ -72,13 +76,16 @@ export default async function run(
     sourceDir,
     startUrl,
     target,
+    args,
     // Android CLI options.
     adbBin,
     adbHost,
     adbPort,
     adbDevice,
     firefoxApk,
-    args,
+    // Chromium CLI options.
+    chromiumBinary,
+    chromiumProfile,
   }: CmdRunParams,
   {
     buildExtension = defaultBuildExtension,
@@ -175,6 +182,20 @@ export default async function run(
       params: firefoxAndroidRunnerParams,
     });
     runners.push(firefoxAndroidRunner);
+  }
+
+  if (target && target.includes('chromium')) {
+    const chromiumRunnerParams = {
+      ...commonRunnerParams,
+      chromiumBinary,
+      chromiumProfile,
+    };
+
+    const chromiumRunner = await createExtensionRunner({
+      target: 'chromium',
+      params: chromiumRunnerParams,
+    });
+    runners.push(chromiumRunner);
   }
 
   const extensionRunner = new MultiExtensionRunner({

--- a/src/extension-runners/chromium.js
+++ b/src/extension-runners/chromium.js
@@ -13,6 +13,7 @@ import mkdirp from 'mkdirp';
 import {
   LaunchedChrome,
   launch as defaultChromiumLaunch,
+  default as ChromeLauncher,
 } from 'chrome-launcher';
 import WebSocket from 'ws';
 
@@ -103,7 +104,10 @@ export class ChromiumExtensionRunner {
       log.debug(`(chromiumBinary: ${chromiumBinary})`);
     }
 
-    const chromeFlags = [`--load-extension=${extensions}`];
+    const chromeFlags = ChromeLauncher.defaultFlags()
+      .filter((flag) => flag !== '--disable-extensions');
+
+    chromeFlags.push(`--load-extension=${extensions}`);
 
     if (this.params.args) {
       chromeFlags.push(...this.params.args);
@@ -126,6 +130,8 @@ export class ChromiumExtensionRunner {
       chromePath: chromiumBinary,
       chromeFlags,
       startingUrl,
+      // Ignore default flags to keep the extension enabled.
+      ignoreDefaultFlags: true,
     });
 
     this.chromiumInstance.process.once('close', () => {

--- a/src/extension-runners/chromium.js
+++ b/src/extension-runners/chromium.js
@@ -295,7 +295,6 @@ export class ChromiumExtensionRunner {
       this.wss = null;
     }
 
-
     // Call all the registered cleanup callbacks.
     for (const fn of this.cleanupCallbacks) {
       try {

--- a/src/extension-runners/chromium.js
+++ b/src/extension-runners/chromium.js
@@ -175,20 +175,20 @@ export class ChromiumExtensionRunner {
 
     const wssInfo = this.wss.address();
 
-    const bgPage = `(function bgPage(webExtParams) {
+    const bgPage = `(function bgPage() {
       async function getAllDevExtensions() {
-        const [managerExtension, allExtensions] = await Promise.all([
-          new Promise(r => chrome.management.getSelf(r)),
-          new Promise(r => chrome.management.getAll(r)),
-        ]);
+        const allExtensions = await new Promise(
+          r => chrome.management.getAll(r));
 
         return allExtensions.filter((extension) => {
           return extension.installType === "development" &&
-            extension.id !== managerExtension.id;
+            extension.id !== chrome.runtime.id;
         });
       }
 
       const setEnabled = (extensionId, value) =>
+        chrome.runtime.id == extensionId ?
+        new Promise.resolve() :
         new Promise(r => chrome.management.setEnabled(extensionId, value, r));
 
       async function reloadExtension(extensionId) {

--- a/src/extension-runners/chromium.js
+++ b/src/extension-runners/chromium.js
@@ -234,9 +234,8 @@ export class ChromiumExtensionRunner {
   async reloadAllExtensions(): Promise<Array<ExtensionRunnerReloadResult>> {
     const runnerName = this.getName();
 
-    // TODO(rpl): file github issue to improve the chromium extension runner
-    // to actually wait for the wssBroadcast to be processed by the connected
-    // client (See https://github.com/mozilla/web-ext/pull/1392#discussion_r231535200).
+    // TODO(rpl): wait for the wssBroadcast to be processed by the connected
+    // client (https://github.com/mozilla/web-ext/issues/1686).
     this.wssBroadcast({
       type: 'webExtReloadAllExtensions',
     });
@@ -255,9 +254,9 @@ export class ChromiumExtensionRunner {
   async reloadExtensionBySourceDir(
     extensionSourceDir: string // eslint-disable-line no-unused-vars
   ): Promise<Array<ExtensionRunnerReloadResult>> {
-    // TODO(rpl): file github issue to improve the manager extension
-    // to make it able to detect the extension ids assigned to the
-    // target extensions and map it to the extensions source dir.
+    // TODO(rpl): detect the extension ids assigned to the
+    // target extensions and map it to the extensions source dir
+    // (https://github.com/mozilla/web-ext/issues/1687).
     return this.reloadAllExtensions();
   }
 

--- a/src/extension-runners/chromium.js
+++ b/src/extension-runners/chromium.js
@@ -72,10 +72,8 @@ export class ChromiumExtensionRunner {
   }
 
   async run(): Promise<void> {
-    if (!this._promiseSetupDone) {
-      this._promiseSetupDone = this.setupInstance();
-    }
-
+    // Run should never be called more than once.
+    this._promiseSetupDone = this.setupInstance();
     await this._promiseSetupDone;
   }
 

--- a/src/extension-runners/chromium.js
+++ b/src/extension-runners/chromium.js
@@ -1,0 +1,286 @@
+/* @flow */
+
+/**
+ * This module provide an ExtensionRunner subclass that manage an extension executed
+ * in a Chromium-based browser instance.
+ */
+
+import path from 'path';
+import {promisify} from 'util';
+
+import {fs} from 'mz';
+import mkdirp from 'mkdirp';
+import {
+  LaunchedChrome,
+  launch as defaultChromiumLaunch,
+} from 'chrome-launcher';
+import WebSocket from 'ws';
+
+import {createLogger} from '../util/logger';
+import {TempDir} from '../util/temp-dir';
+import type {
+  ExtensionRunnerParams,
+  ExtensionRunnerReloadResult,
+} from './base';
+
+type ChromiumSpecificRunnerParams = {|
+   chromiumBinary?: string,
+   chromiumProfile?: string,
+   chromiumLaunch?: typeof defaultChromiumLaunch,
+|};
+
+export type ChromiumExtensionRunnerParams = {|
+  ...ExtensionRunnerParams,
+  // Chromium desktop CLI params.
+  ...ChromiumSpecificRunnerParams,
+|};
+
+const log = createLogger(__filename);
+
+const asyncMkdirp = promisify(mkdirp);
+
+/**
+ * Implements an IExtensionRunner which manages a Chromium instance.
+ */
+export class ChromiumExtensionRunner {
+  cleanupCallbacks: Set<Function>;
+  params: ChromiumExtensionRunnerParams;
+  chromiumInstance: LaunchedChrome;
+  chromiumLaunch: typeof defaultChromiumLaunch;
+  reloadManagerExtension: string;
+  wss: WebSocket.Server;
+  exiting: boolean;
+
+  constructor(params: ChromiumExtensionRunnerParams) {
+    const {
+      chromiumLaunch = defaultChromiumLaunch,
+    } = params;
+    this.params = params;
+    this.chromiumLaunch = chromiumLaunch;
+    this.cleanupCallbacks = new Set();
+  }
+
+  // Method exported from the IExtensionRunner interface.
+
+  /**
+   * Returns the runner name.
+   */
+  getName() {
+    return 'Chromium';
+  }
+
+  /**
+   * Setup the Chromium Profile and run a Chromium instance.
+   */
+  async run(): Promise<void> {
+    // Start a websocket server on a free localhost TCP port.
+    this.wss = new WebSocket.Server({
+      port: 0,
+      host: 'localhost',
+    });
+
+    // Prevent unhandled socket error (e.g. when chrome
+    // is exiting, See https://github.com/websockets/ws/issues/1256).
+    this.wss.on('connection', function(socket) {
+      socket.on('error', (err) => {
+        log.debug(`websocket connection error: ${err}`);
+      });
+    });
+
+    // Create the extension that will manage the addon reloads
+    this.reloadManagerExtension = await this.createReloadManagerExtension();
+
+    // Start chrome pointing it to a given profile dir
+    const extensions = [this.reloadManagerExtension].concat(
+      this.params.extensions.map(({sourceDir}) => sourceDir)
+    ).join(',');
+
+    const {chromiumBinary} = this.params;
+
+    log.debug('Starting Chromium instance...');
+
+    if (chromiumBinary) {
+      log.debug(`(chromiumBinary: ${chromiumBinary})`);
+    }
+
+    const chromeFlags = [`--load-extension=${extensions}`];
+
+    if (this.params.args) {
+      chromeFlags.push(...this.params.args);
+    }
+
+    if (this.params.chromiumProfile) {
+      chromeFlags.push(`--user-data-dir=${this.params.chromiumProfile}`);
+    }
+
+    let startingUrl;
+    if (this.params.startUrl) {
+      const startingUrls = Array.isArray(this.params.startUrl) ?
+        this.params.startUrl : [this.params.startUrl];
+      startingUrl = startingUrls.shift();
+      chromeFlags.push(...startingUrls);
+    }
+
+    this.chromiumInstance = await this.chromiumLaunch({
+      enableExtensions: true,
+      chromePath: chromiumBinary,
+      chromeFlags,
+      startingUrl,
+    });
+
+    this.chromiumInstance.process.once('close', () => {
+      this.chromiumInstance = null;
+
+      if (!this.exiting) {
+        log.info('Exiting on Chromium instance disconnected.');
+        this.exit();
+      }
+    });
+  }
+
+  wssBroadcast(data: Object) {
+    for (const client of this.wss.clients) {
+      if (client.readyState === WebSocket.OPEN) {
+        client.send(JSON.stringify(data));
+      }
+    }
+  }
+
+  async createReloadManagerExtension() {
+    const tmpDir = new TempDir();
+    await tmpDir.create();
+    this.registerCleanup(() => tmpDir.remove());
+
+    const extPath = path.join(
+      tmpDir.path(),
+      `reload-manager-extension-${Date.now()}`
+    );
+
+    log.debug(`Creating reload-manager-extension in ${extPath}`);
+
+    await asyncMkdirp(extPath);
+
+    await fs.writeFile(
+      path.join(extPath, 'manifest.json'),
+      JSON.stringify({
+        manifest_version: 2,
+        name: 'web-ext Reload Manager Extension',
+        version: '1.0',
+        permissions: ['management', 'tabs'],
+        background: {
+          scripts: ['bg.js'],
+        },
+      })
+    );
+
+    const wssInfo = this.wss.address();
+
+    const bgPage = `(function bgPage(webExtParams) {
+      async function getAllDevExtensions() {
+        const [managerExtension, allExtensions] = await Promise.all([
+          new Promise(r => chrome.management.getSelf(r)),
+          new Promise(r => chrome.management.getAll(r)),
+        ]);
+
+        return allExtensions.filter((extension) => {
+          return extension.installType === "development" &&
+            extension.id !== managerExtension.id;
+        });
+      }
+
+      const setEnabled = (extensionId, value) =>
+        new Promise(r => chrome.management.setEnabled(extensionId, value, r));
+
+      async function reloadExtension(extensionId) {
+        await setEnabled(extensionId, false);
+        await setEnabled(extensionId, true);
+      }
+
+      const ws = new window.WebSocket(
+        "ws://${wssInfo.address}:${wssInfo.port}");
+
+      ws.onmessage = async (evt) => {
+        const msg = JSON.parse(evt.data);
+        if (msg.type === 'webExtReloadAllExtensions') {
+          const devExtensions = await getAllDevExtensions();
+          for (var ext of devExtensions) {
+            reloadExtension(ext.id);
+          }
+        }
+      };
+    })()`;
+
+    await fs.writeFile(path.join(extPath, 'bg.js'), bgPage);
+    return extPath;
+  }
+
+  /**
+   * Reloads all the extensions, collect any reload error and resolves to
+   * an array composed by a single ExtensionRunnerReloadResult object.
+   */
+  async reloadAllExtensions(): Promise<Array<ExtensionRunnerReloadResult>> {
+    const runnerName = this.getName();
+
+    // TODO(rpl): file github issue to improve the chromium extension runner
+    // to actually wait for the wssBroadcast to be processed by the connected
+    // client.
+    this.wssBroadcast({
+      type: 'webExtReloadAllExtensions',
+    });
+
+    process.stdout.write(
+      `\rLast extension reload: ${(new Date()).toTimeString()}`);
+    log.debug('\n');
+
+    return [{runnerName}];
+  }
+
+  /**
+   * Reloads a single extension, collect any reload error and resolves to
+   * an array composed by a single ExtensionRunnerReloadResult object.
+   */
+  async reloadExtensionBySourceDir(
+    extensionSourceDir: string // eslint-disable-line no-unused-vars
+  ): Promise<Array<ExtensionRunnerReloadResult>> {
+    // TODO(rpl): file github issue to improve the manager extension
+    // to make it able to detect the extension ids assigned to the
+    // target extensions and map it to the extensions source dir.
+    return this.reloadAllExtensions();
+  }
+
+  /**
+   * Register a callback to be called when the runner has been exited
+   * (e.g. the Chromium instance exits or the user has requested web-ext
+   * to exit).
+   */
+  registerCleanup(fn: Function): void {
+    this.cleanupCallbacks.add(fn);
+  }
+
+  /**
+   * Exits the runner, by closing the managed Chromium instance.
+   */
+  async exit(): Promise<void> {
+    this.exiting = true;
+
+    if (this.chromiumInstance) {
+      await this.chromiumInstance.kill();
+      this.chromiumInstance = null;
+    }
+
+    if (this.wss) {
+      await new Promise((resolve) => this.wss.close(resolve));
+      this.wss = null;
+    }
+
+
+    // Call all the registered cleanup callbacks.
+    for (const fn of this.cleanupCallbacks) {
+      try {
+        fn();
+      } catch (error) {
+        log.error(error);
+      }
+    }
+  }
+}

--- a/src/extension-runners/chromium.js
+++ b/src/extension-runners/chromium.js
@@ -223,7 +223,7 @@ export class ChromiumExtensionRunner {
 
     // TODO(rpl): file github issue to improve the chromium extension runner
     // to actually wait for the wssBroadcast to be processed by the connected
-    // client.
+    // client (See https://github.com/mozilla/web-ext/pull/1392#discussion_r231535200).
     this.wssBroadcast({
       type: 'webExtReloadAllExtensions',
     });

--- a/src/extension-runners/firefox-android.js
+++ b/src/extension-runners/firefox-android.js
@@ -592,8 +592,7 @@ export class FirefoxAndroidExtensionRunner {
       // $FLOW_FIXME: flow has his own opinions on this method signature.
       srv.listen(0, () => {
         const freeTcpPort = srv.address().port;
-        srv.close();
-        resolve(freeTcpPort);
+        srv.close(() => resolve(freeTcpPort));
       });
     });
   }

--- a/src/extension-runners/index.js
+++ b/src/extension-runners/index.js
@@ -14,6 +14,7 @@ import {
 } from '../util/desktop-notifier';
 import type {FirefoxAndroidExtensionRunnerParams} from './firefox-android';
 import type {FirefoxDesktopExtensionRunnerParams} from './firefox-desktop';
+import type {ChromiumExtensionRunnerParams} from './chromium';
 import {createLogger} from '../util/logger';
 import type {FileFilterCreatorFn} from '../util/file-filter';
 import {
@@ -34,6 +35,9 @@ export type ExtensionRunnerConfig = {|
 |} | {|
   target: 'firefox-android',
   params: FirefoxAndroidExtensionRunnerParams,
+|} | {|
+  target: 'chromium',
+  params: ChromiumExtensionRunnerParams,
 |};
 
 export type MultiExtensionRunnerParams = {|
@@ -52,6 +56,11 @@ export async function createExtensionRunner(config: ExtensionRunnerConfig) {
       // TODO: use async import instead of require - https://github.com/mozilla/web-ext/issues/1306
       const {FirefoxAndroidExtensionRunner} = require('./firefox-android');
       return new FirefoxAndroidExtensionRunner(config.params);
+    }
+    case 'chromium': {
+      // TODO: use async import instead of require - https://github.com/mozilla/web-ext/issues/1306
+      const {ChromiumExtensionRunner} = require('./chromium');
+      return new ChromiumExtensionRunner(config.params);
     }
     default:
       throw new WebExtError(`Unknown target: "${config.target}"`);

--- a/src/program.js
+++ b/src/program.js
@@ -450,7 +450,7 @@ Example: $0 --help run.
         default: 'firefox-desktop',
         demandOption: false,
         type: 'array',
-        choices: ['firefox-desktop', 'firefox-android'],
+        choices: ['firefox-desktop', 'firefox-android', 'chromium'],
       },
       'firefox': {
         alias: ['f', 'firefox-binary'],
@@ -468,6 +468,18 @@ Example: $0 --help run.
                   'can be specified as a directory or a name, such as one ' +
                   'you would see in the Profile Manager. If not specified, ' +
                   'a new temporary profile will be created.',
+        demandOption: false,
+        type: 'string',
+      },
+      'chromium-binary': {
+        describe: 'Path or alias to a Chromium executable such as ' +
+          'google-chrome, google-chrome.exe or opera.exe etc. ' +
+          'If not specified, the default Google Chrome will be used.',
+        demandOption: false,
+        type: 'string',
+      },
+      'chromium-profile': {
+        describe: 'Path to a custom Chromium profile',
         demandOption: false,
         type: 'string',
       },

--- a/src/util/manifest.js
+++ b/src/util/manifest.js
@@ -27,6 +27,7 @@ export type ExtensionManifest = {|
   version: string,
   default_locale?: string,
   applications?: ExtensionManifestApplications,
+  permissions?: Array<string>,
 |};
 
 export default async function getValidatedManifest(

--- a/tests/functional/test.cli.run.js
+++ b/tests/functional/test.cli.run.js
@@ -53,8 +53,9 @@ describe('web-ext run', () => {
     const argv = [
       'run',
       '--target', 'firefox-desktop',
-      '--target', 'not-supported',
       '--target', 'firefox-android',
+      '--target', 'chromium',
+      '--target', 'not-supported',
     ];
 
     return execWebExt(argv, {}).waitForExit.then(({exitCode, stderr}) => {

--- a/tests/unit/test-cmd/test.run.js
+++ b/tests/unit/test-cmd/test.run.js
@@ -61,6 +61,7 @@ function prepareRun(fakeInstallResult) {
 describe('run', () => {
   let androidRunnerStub: sinon.SinonStub;
   let desktopRunnerStub: sinon.SinonStub;
+  let chromiumRunnerStub: sinon.SinonStub;
 
   beforeEach(() => {
     androidRunnerStub = sinon.stub(
@@ -72,12 +73,19 @@ describe('run', () => {
       // TODO: use async import instead of require - https://github.com/mozilla/web-ext/issues/1306
       require('../../../src/extension-runners/firefox-desktop'),
       'FirefoxDesktopExtensionRunner');
+
+    chromiumRunnerStub = sinon.stub(
+      // TODO: use async import instead of require - https://github.com/mozilla/web-ext/issues/1306
+      require('../../../src/extension-runners/chromium'),
+      'ChromiumExtensionRunner');
   });
   afterEach(() => {
     androidRunnerStub.restore();
     androidRunnerStub = undefined;
     desktopRunnerStub.restore();
     desktopRunnerStub = undefined;
+    chromiumRunnerStub.restore();
+    chromiumRunnerStub = undefined;
   });
 
   it('passes a custom Firefox binary when specified', async () => {
@@ -224,6 +232,58 @@ describe('run', () => {
 
        sinon.assert.calledOnce(androidRunnerStub);
        sinon.assert.notCalled(desktopRunnerStub);
+     });
+
+  it('creates a Chromium runner if "chromium" is in target',
+     async () => {
+       const cmd = prepareRun();
+       await cmd.run({target: ['chromium']});
+
+       sinon.assert.calledOnce(chromiumRunnerStub);
+       sinon.assert.notCalled(androidRunnerStub);
+       sinon.assert.notCalled(desktopRunnerStub);
+     });
+
+  it('provides a chromiumBinary option to the Chromium runner',
+     async () => {
+       const fakeChromiumBinary = '/bin/fake-chrome/binary';
+       const cmd = prepareRun();
+       await cmd.run({
+         target: ['chromium'],
+         chromiumBinary: fakeChromiumBinary,
+       });
+
+       sinon.assert.calledWithMatch(
+         chromiumRunnerStub,
+         {
+           chromiumBinary: sinon.match.string,
+         }
+       );
+
+       const {chromiumBinary} = chromiumRunnerStub.firstCall.args[0];
+       assert.equal(chromiumBinary, fakeChromiumBinary,
+                    'Got the expected chromiumBinary option');
+     });
+
+  it('provides a chromiumProfile option to the Chromium runner',
+     async () => {
+       const fakeChromiumProfile = '/fake/chrome/profile';
+       const cmd = prepareRun();
+       await cmd.run({
+         target: ['chromium'],
+         chromiumProfile: fakeChromiumProfile,
+       });
+
+       sinon.assert.calledWithMatch(
+         chromiumRunnerStub,
+         {
+           chromiumProfile: sinon.match.string,
+         }
+       );
+
+       const {chromiumProfile} = chromiumRunnerStub.firstCall.args[0];
+       assert.equal(chromiumProfile, fakeChromiumProfile,
+                    'Got the expected chromiumProfile option');
      });
 
   it('creates multiple extension runners', async () => {

--- a/tests/unit/test-extension-runners/test.chromium.js
+++ b/tests/unit/test-extension-runners/test.chromium.js
@@ -7,6 +7,7 @@ import {describe, it} from 'mocha';
 import deepcopy from 'deepcopy';
 import fs from 'mz/fs';
 import sinon from 'sinon';
+import ChromeLauncher from 'chrome-launcher';
 import WebSocket from 'ws';
 
 import getValidatedManifest from '../../../src/util/manifest';
@@ -23,6 +24,9 @@ import type {
 import {
   consoleStream, // instance is imported to inspect logged messages
 } from '../../../src/util/logger';
+
+const defaultChromeFlags = ChromeLauncher.defaultFlags()
+  .filter((flag) => flag !== '--disable-extensions');
 
 function prepareExtensionRunnerParams({params} = {}) {
   const fakeChromeInstance = {
@@ -59,9 +63,11 @@ describe('util/extension-runners/chromium', async () => {
 
     sinon.assert.calledOnce(params.chromiumLaunch);
     sinon.assert.calledWithMatch(params.chromiumLaunch, {
+      ignoreDefaultFlags: true,
       enableExtensions: true,
       chromePath: undefined,
       chromeFlags: [
+        ...defaultChromeFlags,
         `--load-extension=${reloadManagerExtension},/fake/sourceDir`,
       ],
       startingUrl: undefined,
@@ -219,9 +225,11 @@ describe('util/extension-runners/chromium', async () => {
 
     sinon.assert.calledOnce(params.chromiumLaunch);
     sinon.assert.calledWithMatch(params.chromiumLaunch, {
+      ignoreDefaultFlags: true,
       enableExtensions: true,
       chromePath: '/my/custom/chrome-bin',
       chromeFlags: [
+        ...defaultChromeFlags,
         `--load-extension=${reloadManagerExtension},/fake/sourceDir`,
       ],
       startingUrl: undefined,
@@ -242,9 +250,11 @@ describe('util/extension-runners/chromium', async () => {
 
     sinon.assert.calledOnce(params.chromiumLaunch);
     sinon.assert.calledWithMatch(params.chromiumLaunch, {
+      ignoreDefaultFlags: true,
       enableExtensions: true,
       chromePath: undefined,
       chromeFlags: [
+        ...defaultChromeFlags,
         `--load-extension=${reloadManagerExtension},/fake/sourceDir`,
         'url2',
         'url3',
@@ -270,9 +280,11 @@ describe('util/extension-runners/chromium', async () => {
 
     sinon.assert.calledOnce(params.chromiumLaunch);
     sinon.assert.calledWithMatch(params.chromiumLaunch, {
+      ignoreDefaultFlags: true,
       enableExtensions: true,
       chromePath: undefined,
       chromeFlags: [
+        ...defaultChromeFlags,
         `--load-extension=${reloadManagerExtension},/fake/sourceDir`,
         '--arg1',
         'arg2',
@@ -300,9 +312,11 @@ describe('util/extension-runners/chromium', async () => {
 
     sinon.assert.calledOnce(params.chromiumLaunch);
     sinon.assert.calledWithMatch(params.chromiumLaunch, {
+      ignoreDefaultFlags: true,
       enableExtensions: true,
       chromePath: undefined,
       chromeFlags: [
+        ...defaultChromeFlags,
         `--load-extension=${reloadManagerExtension},/fake/sourceDir`,
         '--user-data-dir=/fake/chrome/profile',
       ],

--- a/tests/unit/test-extension-runners/test.chromium.js
+++ b/tests/unit/test-extension-runners/test.chromium.js
@@ -1,0 +1,276 @@
+/* @flow */
+
+import {assert} from 'chai';
+import {describe, it} from 'mocha';
+import deepcopy from 'deepcopy';
+import fs from 'mz/fs';
+import sinon from 'sinon';
+import WebSocket from 'ws';
+
+import getValidatedManifest from '../../../src/util/manifest';
+import {
+  basicManifest,
+  StubChildProcess,
+} from '../helpers';
+import {
+  ChromiumExtensionRunner,
+} from '../../../src/extension-runners/chromium';
+import type {
+  ChromiumExtensionRunnerParams,
+} from '../../../src/extension-runners/chromium';
+
+function prepareExtensionRunnerParams({params} = {}) {
+  const fakeChromeInstance = {
+    process: new StubChildProcess(),
+    kill: sinon.spy(async () => {}),
+  };
+  const runnerParams: ChromiumExtensionRunnerParams = {
+    extensions: [{
+      sourceDir: '/fake/sourceDir',
+      manifestData: deepcopy(basicManifest),
+    }],
+    keepProfileChanges: false,
+    startUrl: undefined,
+    chromiumLaunch: sinon.spy(async () => {
+      return fakeChromeInstance;
+    }),
+    desktopNotifications: sinon.spy(() => {}),
+    ...(params || {}),
+  };
+
+  return {params: runnerParams, fakeChromeInstance};
+}
+
+describe('util/extension-runners/chromium', async () => {
+
+  it('installs and runs the extension', async () => {
+    const {params, fakeChromeInstance} = prepareExtensionRunnerParams();
+    const runnerInstance = new ChromiumExtensionRunner(params);
+    assert.equal(runnerInstance.getName(), 'Chromium');
+
+    await runnerInstance.run();
+
+    const {reloadManagerExtension} = runnerInstance;
+
+    sinon.assert.calledOnce(params.chromiumLaunch);
+    sinon.assert.calledWithMatch(params.chromiumLaunch, {
+      enableExtensions: true,
+      chromePath: undefined,
+      chromeFlags: [
+        `--load-extension=${reloadManagerExtension},/fake/sourceDir`,
+      ],
+      startingUrl: undefined,
+    });
+
+    await runnerInstance.exit();
+    sinon.assert.calledOnce(fakeChromeInstance.kill);
+  });
+
+  it('installs a "reload manager" companion extension', async () => {
+    const {params} = prepareExtensionRunnerParams();
+    const runnerInstance = new ChromiumExtensionRunner(params);
+    await runnerInstance.run();
+
+    const {reloadManagerExtension} = runnerInstance;
+
+    assert.equal(await fs.exists(reloadManagerExtension), true);
+    const managerExtManifest = await getValidatedManifest(
+      reloadManagerExtension);
+    assert.deepEqual(managerExtManifest.permissions, ['management', 'tabs']);
+
+    await runnerInstance.exit();
+  });
+
+
+  it('controls the "reload manager" from a websocket server', async () => {
+    const {params} = prepareExtensionRunnerParams();
+    const runnerInstance = new ChromiumExtensionRunner(params);
+    await runnerInstance.run();
+
+    const wssInfo = runnerInstance.wss.address();
+    const wsURL = `ws://${wssInfo.address}:${wssInfo.port}`;
+    const wsClient = new WebSocket(wsURL);
+
+    await new Promise((resolve) => wsClient.on('open', resolve));
+
+    const waitForReloadAll = new Promise((resolve) =>
+      wsClient.on('message', resolve));
+    await runnerInstance.reloadAllExtensions();
+    assert.deepEqual(JSON.parse(await waitForReloadAll),
+                     {type: 'webExtReloadAllExtensions'});
+
+    // TODO(rpl): change this once we improve the manager extension to be able
+    // to reload a single extension.
+    const waitForReloadOne = new Promise((resolve) =>
+      wsClient.on('message', resolve));
+    await runnerInstance.reloadExtensionBySourceDir('/fake/sourceDir');
+    assert.deepEqual(JSON.parse(await waitForReloadOne),
+                     {type: 'webExtReloadAllExtensions'});
+
+    // Verify that if one websocket connection gets closed, a second websocket
+    // connection still receives the control messages.
+    const wsClient2 = new WebSocket(wsURL);
+    await new Promise((resolve) => wsClient2.on('open', resolve));
+    wsClient.close();
+
+    await runnerInstance.reloadAllExtensions();
+    const waitForReloadAllAgain = new Promise((resolve) =>
+      wsClient2.on('message', resolve));
+    await runnerInstance.reloadAllExtensions();
+    assert.deepEqual(JSON.parse(await waitForReloadAllAgain),
+                     {type: 'webExtReloadAllExtensions'});
+
+    await runnerInstance.exit();
+  });
+
+  it('exits if the chrome instance is shutting down', async () => {
+    const {params, fakeChromeInstance} = prepareExtensionRunnerParams();
+    const runnerInstance = new ChromiumExtensionRunner(params);
+    await runnerInstance.run();
+
+    const onceExiting = new Promise((resolve) =>
+      runnerInstance.registerCleanup(resolve));
+
+    fakeChromeInstance.process.emit('close');
+
+    await onceExiting;
+  });
+
+  it('calls all cleanup callbacks on exit', async () => {
+    const {params} = prepareExtensionRunnerParams();
+    const runnerInstance = new ChromiumExtensionRunner(params);
+    await runnerInstance.run();
+
+    runnerInstance.registerCleanup(function fnThrowsError() {
+      throw new Error('fake cleanup exception');
+    });
+
+    const onceExiting = new Promise((resolve) =>
+      runnerInstance.registerCleanup(resolve));
+
+    await runnerInstance.exit();
+    await onceExiting;
+  });
+
+  it('does not call exit if chrome instance exits while shutting down',
+     async () => {
+       const {params, fakeChromeInstance} = prepareExtensionRunnerParams();
+       const runnerInstance = new ChromiumExtensionRunner(params);
+       await runnerInstance.run();
+
+       sinon.spy(runnerInstance, 'exit');
+
+       const exitDone = runnerInstance.exit();
+       fakeChromeInstance.process.emit('close');
+
+       await exitDone;
+
+       sinon.assert.calledOnce(runnerInstance.exit);
+     });
+
+  it('does use a custom chromium binary when passed', async () => {
+    const {params} = prepareExtensionRunnerParams({
+      params: {chromiumBinary: '/my/custom/chrome-bin'},
+    });
+
+    const runnerInstance = new ChromiumExtensionRunner(params);
+    await runnerInstance.run();
+
+    const {reloadManagerExtension} = runnerInstance;
+
+    sinon.assert.calledOnce(params.chromiumLaunch);
+    sinon.assert.calledWithMatch(params.chromiumLaunch, {
+      enableExtensions: true,
+      chromePath: '/my/custom/chrome-bin',
+      chromeFlags: [
+        `--load-extension=${reloadManagerExtension},/fake/sourceDir`,
+      ],
+      startingUrl: undefined,
+    });
+
+    await runnerInstance.exit();
+  });
+
+  it('does pass multiple starting urls to chrome', async () => {
+    const {params} = prepareExtensionRunnerParams({
+      params: {startUrl: ['url1', 'url2', 'url3']},
+    });
+
+    const runnerInstance = new ChromiumExtensionRunner(params);
+    await runnerInstance.run();
+
+    const {reloadManagerExtension} = runnerInstance;
+
+    sinon.assert.calledOnce(params.chromiumLaunch);
+    sinon.assert.calledWithMatch(params.chromiumLaunch, {
+      enableExtensions: true,
+      chromePath: undefined,
+      chromeFlags: [
+        `--load-extension=${reloadManagerExtension},/fake/sourceDir`,
+        'url2',
+        'url3',
+      ],
+      startingUrl: 'url1',
+    });
+
+    await runnerInstance.exit();
+  });
+
+  it('does pass additional args to chrome', async () => {
+    const {params} = prepareExtensionRunnerParams({
+      params: {
+        args: ['--arg1', 'arg2', '--arg3'],
+        startUrl: ['url1', 'url2', 'url3'],
+      },
+    });
+
+    const runnerInstance = new ChromiumExtensionRunner(params);
+    await runnerInstance.run();
+
+    const {reloadManagerExtension} = runnerInstance;
+
+    sinon.assert.calledOnce(params.chromiumLaunch);
+    sinon.assert.calledWithMatch(params.chromiumLaunch, {
+      enableExtensions: true,
+      chromePath: undefined,
+      chromeFlags: [
+        `--load-extension=${reloadManagerExtension},/fake/sourceDir`,
+        '--arg1',
+        'arg2',
+        '--arg3',
+        'url2',
+        'url3',
+      ],
+      startingUrl: 'url1',
+    });
+
+    await runnerInstance.exit();
+  });
+
+  it('does pass a user-data-dir flag to chrome', async () => {
+    const {params} = prepareExtensionRunnerParams({
+      params: {
+        chromiumProfile: '/fake/chrome/profile',
+      },
+    });
+
+    const runnerInstance = new ChromiumExtensionRunner(params);
+    await runnerInstance.run();
+
+    const {reloadManagerExtension} = runnerInstance;
+
+    sinon.assert.calledOnce(params.chromiumLaunch);
+    sinon.assert.calledWithMatch(params.chromiumLaunch, {
+      enableExtensions: true,
+      chromePath: undefined,
+      chromeFlags: [
+        `--load-extension=${reloadManagerExtension},/fake/sourceDir`,
+        '--user-data-dir=/fake/chrome/profile',
+      ],
+      startingUrl: undefined,
+    });
+
+    await runnerInstance.exit();
+  });
+
+});

--- a/tests/unit/test-extension-runners/test.chromium.js
+++ b/tests/unit/test-extension-runners/test.chromium.js
@@ -114,15 +114,10 @@ describe('util/extension-runners/chromium', async () => {
     // Emit a fake socket object as a new wss connection.
 
     const fakeSocket = new EventEmitter();
-    const onFn = fakeSocket.on;
-    // $FLOW_IGNORE: override read-only prop for testing purpose.
-    fakeSocket.on = sinon.spy((...args) => {
-      onFn.apply(fakeSocket, args);
-    });
-
+    sinon.spy(fakeSocket, 'on');
     runnerInstance.wss.emit('connection', fakeSocket);
-
     sinon.assert.calledOnce(fakeSocket.on);
+
     fakeSocket.emit('error', new Error('Fake wss socket ERROR'));
 
     // Retrieve captures logs and stop capturing.

--- a/tests/unit/test-extension-runners/test.chromium.js
+++ b/tests/unit/test-extension-runners/test.chromium.js
@@ -112,21 +112,18 @@ describe('util/extension-runners/chromium', async () => {
     consoleStream.makeVerbose();
 
     // Emit a fake socket object as a new wss connection.
-    const socket = await new Promise((resolve) => {
-      const fakeSocket = new EventEmitter();
 
-      const onFn = fakeSocket.on;
-      // $FLOW_IGNORE: override read-only prop for testing purpose.
-      fakeSocket.on = sinon.spy((...args) => {
-        onFn.apply(fakeSocket, args);
-        resolve(fakeSocket);
-      });
-
-      runnerInstance.wss.emit('connection', fakeSocket);
+    const fakeSocket = new EventEmitter();
+    const onFn = fakeSocket.on;
+    // $FLOW_IGNORE: override read-only prop for testing purpose.
+    fakeSocket.on = sinon.spy((...args) => {
+      onFn.apply(fakeSocket, args);
     });
 
-    sinon.assert.calledOnce(socket.on);
-    socket.emit('error', new Error('Fake wss socket ERROR'));
+    runnerInstance.wss.emit('connection', fakeSocket);
+
+    sinon.assert.calledOnce(fakeSocket.on);
+    fakeSocket.emit('error', new Error('Fake wss socket ERROR'));
 
     // Retrieve captures logs and stop capturing.
     const {capturedMessages} = consoleStream;

--- a/tests/unit/test-extension-runners/test.firefox-desktop.js
+++ b/tests/unit/test-extension-runners/test.firefox-desktop.js
@@ -102,7 +102,7 @@ describe('util/extension-runners/firefox-desktop', () => {
     const runnerInstance = new FirefoxDesktopExtensionRunner(params);
     await runnerInstance.run();
 
-    assert.ok(runnerInstance.getName(), 'Firefox Desktop');
+    assert.equal(runnerInstance.getName(), 'Firefox Desktop');
     sinon.assert.calledOnce(remoteFirefox.installTemporaryAddon);
     sinon.assert.calledWithMatch(remoteFirefox.installTemporaryAddon,
                                  params.extensions[0].sourceDir);


### PR DESCRIPTION
This PR introduces a new `'chromium'` target and a new `--chromium-binary` cli option 
(which covers #809 and part of #1130).

Internally it uses the `chrome-launcher` npm package to manage the chromium instance and so by default it tries to discover and launch the Chrome or Chromium version installed in the system.

Nevertheless other Chromium-based browsers that support extensions (like Opera and Vivaldi) can be launched using this target (with the addition of the `--chromium-binary` option):

[![Quick demo of the `web-ext run` used to run an extension on Chrome, Opera and Vivaldi](https://img.youtube.com/vi/L4sLn1OD7vM/0.jpg)](https://www.youtube.com/watch?v=L4sLn1OD7vM)

TODO:

- [x] add tests for the chromium extension-runner module