### PR TITLE
feat(addons-linter): Updated addons-linter to version 1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@cliqz-oss/firefox-client": "0.3.1",
     "@cliqz-oss/node-firefox-connect": "1.2.1",
     "adbkit": "2.11.0",
-    "addons-linter": "1.3.8",
+    "addons-linter": "1.4.1",
     "babel-polyfill": "6.26.0",
     "babel-runtime": "6.26.0",
     "bunyan": "1.8.12",


### PR DESCRIPTION
This PR updates the addons-linter dependency to version 1.4.1, which is also the last addons-linter version that is still compatible with nodejs 6.

Starting from addons-linter 1.4.2, the addons-linter includes mdn-browser-compat-data as an additional npm dependency, and mdn-browser-compat-data uses some js syntaxes that are not supported on nodejs 6.

