### PR TITLE
chore: bump package version for release 2.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-ext",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "description": "A command line tool to help build, run, and test web extensions",
   "main": "dist/web-ext.js",
   "engines": {


### PR DESCRIPTION
This is going to be the last web-ext version still compatible with nodejs 6 👋.

### Features

* Added release channel as optional sign parameter (simple test) ([#1400](https://github.com/mozilla/web-ext/issues/1400)) ([942c308](https://github.com/mozilla/web-ext/commit/942c308))
* Updated `web-ext lint` to use addons-linter to version 1.4.1 ([#1407](https://github.com/mozilla/web-ext/issues/1407)) ([4eb7ca0](https://github.com/mozilla/web-ext/commit/4eb7ca0))
  * Added support for `browser_specific_settings` as an alias for the `applications` manifest key (mozilla/addons-linter#2280)
  * Added [new linting rules for the validation of static themes](https://mozilla.github.io/addons-linter/#static-theme-%2F-manifest.json) (mozilla/addons-linter#2271, mozilla/addons-linter#2051)
 * See all addons-linter changes: [1.3.8...1.4.1](https://github.com/mozilla/addons-linter/compare/1.3.8...1.4.1)
