### PR TITLE
fix: Deprecated support for nodejs 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ os:
 - windows
 
 node_js:
-- '6'
 - '8'
 - '10'
 
@@ -15,8 +14,6 @@ node_js:
 matrix:
   fast_finish: true
   exclude:
-  - node_js: '6'
-    os: windows
   - node_js: '8'
     os: windows
 

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "A command line tool to help build, run, and test web extensions",
   "main": "dist/web-ext.js",
   "engines": {
-    "node": ">=6.0.0",
-    "npm": ">=3.0.0"
+    "node": ">=8.0.0",
+    "npm": ">=5.0.0"
   },
   "engine-strict": true,
   "bin": {


### PR DESCRIPTION
As announced in the [2.9.3 release notes](https://github.com/mozilla/web-ext/releases/tag/2.9.3), this PR is going to officially deprecate support for node versions < 8 (and remove node 6 from the travis job matrix).

:wave: nodejs 6 