### PR TITLE
chore: Updated fx-runner to version 1.0.10

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -6,6 +6,7 @@
     "https://npmjs.com/advisories/678",
     "https://npmjs.com/advisories/720",
     "https://npmjs.com/advisories/725",
-    "https://npmjs.com/advisories/745"
+    "https://npmjs.com/advisories/745",
+    "https://npmjs.com/advisories/782"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "es6-promisify": "5.0.0",
     "event-to-promise": "0.8.0",
     "firefox-profile": "1.2.0",
-    "fx-runner": "1.0.9",
+    "fx-runner": "1.0.10",
     "git-rev-sync": "1.9.1",
     "mkdirp": "0.5.1",
     "multimatch": "2.1.0",


### PR DESCRIPTION
This PR updates the fx-runner npm dependency to version 1.0.10, which fixes failures on travis due to npm audit detecting a security advisory related to the lodash version used in the previous fx-runner version (https://npmjs.com/advisories/782).

I had to still add that advisory to the list of the ones to ignore (by including it into the .nsprc file) because there are still 2 dev dependency that depends on the vulnerable one (I'll deal with that in a follow up, once I can remove or update those dev dependency). 