### PR TITLE
chore: Replaced es6-promisify with nodejs 8 util.promisify helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,53 +34,6 @@
         "source-map": "0.5.7"
       },
       "dependencies": {
-        "@babel/generator": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.4.tgz",
-          "integrity": "sha512-8EXhHRFqlVVWXPezBW5keTiQi/rJMQTg/Y9uVCEZ0CAF3PKtCCaVRnp64Ii1ujhkoDhhF1fVsImoN4yJ2uz4Wg==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.3.4",
-            "jsesc": "2.5.2",
-            "lodash": "4.17.11",
-            "source-map": "0.5.7",
-            "trim-right": "1.0.1"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.4.tgz",
-          "integrity": "sha512-tXZCqWtlOOP4wgCp6RjRvLmfuhnqTLy9VHwRochJBCP2nDm27JnnuFEnXFASVyQNHk36jD1tAammsCEEqgscIQ==",
-          "dev": true
-        },
-        "@babel/traverse": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.3.4.tgz",
-          "integrity": "sha512-TvTHKp6471OYEcE/91uWmhR6PrrYywQntCHSaZ8CM8Vmp+pjAusal4nGB2WCCQd0rvI7nOMKn9GnbcvTUz3/ZQ==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0",
-            "@babel/generator": "7.3.4",
-            "@babel/helper-function-name": "7.1.0",
-            "@babel/helper-split-export-declaration": "7.0.0",
-            "@babel/parser": "7.3.4",
-            "@babel/types": "7.3.4",
-            "debug": "4.1.1",
-            "globals": "11.11.0",
-            "lodash": "4.17.11"
-          }
-        },
-        "@babel/types": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.4.tgz",
-          "integrity": "sha512-WEkp8MsLftM7O/ty580wAmZzN1nDmCACc5+jFzUt+GUFNNIi3LdRlueYz0YIlmJhlZx1QYDMZL5vdWCL0fNjFQ==",
-          "dev": true,
-          "requires": {
-            "esutils": "2.0.2",
-            "lodash": "4.17.11",
-            "to-fast-properties": "2.0.0"
-          }
-        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -105,12 +58,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.3.tgz",
-      "integrity": "sha512-aEADYwRRZjJyMnKN7llGIlircxTCofm3dtV5pmY6ob18MSIuipHpA2yZWkPlycwu5HJcx/pADS3zssd8eY7/6A==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.4.tgz",
+      "integrity": "sha512-8EXhHRFqlVVWXPezBW5keTiQi/rJMQTg/Y9uVCEZ0CAF3PKtCCaVRnp64Ii1ujhkoDhhF1fVsImoN4yJ2uz4Wg==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.3.3",
+        "@babel/types": "7.3.4",
         "jsesc": "2.5.2",
         "lodash": "4.17.11",
         "source-map": "0.5.7",
@@ -131,7 +84,7 @@
       "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.3.3"
+        "@babel/types": "7.3.4"
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
@@ -141,7 +94,7 @@
       "dev": true,
       "requires": {
         "@babel/helper-explode-assignable-expression": "7.1.0",
-        "@babel/types": "7.3.3"
+        "@babel/types": "7.3.4"
       }
     },
     "@babel/helper-call-delegate": {
@@ -151,8 +104,22 @@
       "dev": true,
       "requires": {
         "@babel/helper-hoist-variables": "7.0.0",
-        "@babel/traverse": "7.2.3",
-        "@babel/types": "7.3.3"
+        "@babel/traverse": "7.3.4",
+        "@babel/types": "7.3.4"
+      }
+    },
+    "@babel/helper-create-class-features-plugin": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.3.4.tgz",
+      "integrity": "sha512-uFpzw6L2omjibjxa8VGZsJUPL5wJH0zzGKpoz0ccBkzIa6C8kWNUbiBmQ0rgOKWlHJ6qzmfa6lTiGchiV8SC+g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/helper-member-expression-to-functions": "7.0.0",
+        "@babel/helper-optimise-call-expression": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-replace-supers": "7.3.4",
+        "@babel/helper-split-export-declaration": "7.0.0"
       }
     },
     "@babel/helper-define-map": {
@@ -162,7 +129,7 @@
       "dev": true,
       "requires": {
         "@babel/helper-function-name": "7.1.0",
-        "@babel/types": "7.3.3",
+        "@babel/types": "7.3.4",
         "lodash": "4.17.11"
       }
     },
@@ -172,8 +139,8 @@
       "integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
       "dev": true,
       "requires": {
-        "@babel/traverse": "7.2.3",
-        "@babel/types": "7.3.3"
+        "@babel/traverse": "7.3.4",
+        "@babel/types": "7.3.4"
       }
     },
     "@babel/helper-function-name": {
@@ -184,7 +151,7 @@
       "requires": {
         "@babel/helper-get-function-arity": "7.0.0",
         "@babel/template": "7.2.2",
-        "@babel/types": "7.3.3"
+        "@babel/types": "7.3.4"
       }
     },
     "@babel/helper-get-function-arity": {
@@ -193,7 +160,7 @@
       "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.3.3"
+        "@babel/types": "7.3.4"
       }
     },
     "@babel/helper-hoist-variables": {
@@ -202,7 +169,7 @@
       "integrity": "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.3.3"
+        "@babel/types": "7.3.4"
       }
     },
     "@babel/helper-member-expression-to-functions": {
@@ -211,7 +178,7 @@
       "integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.3.3"
+        "@babel/types": "7.3.4"
       }
     },
     "@babel/helper-module-imports": {
@@ -220,7 +187,7 @@
       "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.3.3"
+        "@babel/types": "7.3.4"
       }
     },
     "@babel/helper-module-transforms": {
@@ -233,7 +200,7 @@
         "@babel/helper-simple-access": "7.1.0",
         "@babel/helper-split-export-declaration": "7.0.0",
         "@babel/template": "7.2.2",
-        "@babel/types": "7.3.3",
+        "@babel/types": "7.3.4",
         "lodash": "4.17.11"
       }
     },
@@ -243,7 +210,7 @@
       "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.3.3"
+        "@babel/types": "7.3.4"
       }
     },
     "@babel/helper-plugin-utils": {
@@ -270,20 +237,20 @@
         "@babel/helper-annotate-as-pure": "7.0.0",
         "@babel/helper-wrap-function": "7.2.0",
         "@babel/template": "7.2.2",
-        "@babel/traverse": "7.2.3",
-        "@babel/types": "7.3.3"
+        "@babel/traverse": "7.3.4",
+        "@babel/types": "7.3.4"
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.2.3.tgz",
-      "integrity": "sha512-GyieIznGUfPXPWu0yLS6U55Mz67AZD9cUk0BfirOWlPrXlBcan9Gz+vHGz+cPfuoweZSnPzPIm67VtQM0OWZbA==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.3.4.tgz",
+      "integrity": "sha512-pvObL9WVf2ADs+ePg0jrqlhHoxRXlOa+SHRHzAXIz2xkYuOHfGl+fKxPMaS4Fq+uje8JQPobnertBBvyrWnQ1A==",
       "dev": true,
       "requires": {
         "@babel/helper-member-expression-to-functions": "7.0.0",
         "@babel/helper-optimise-call-expression": "7.0.0",
-        "@babel/traverse": "7.2.3",
-        "@babel/types": "7.3.3"
+        "@babel/traverse": "7.3.4",
+        "@babel/types": "7.3.4"
       }
     },
     "@babel/helper-simple-access": {
@@ -293,7 +260,7 @@
       "dev": true,
       "requires": {
         "@babel/template": "7.2.2",
-        "@babel/types": "7.3.3"
+        "@babel/types": "7.3.4"
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -302,7 +269,7 @@
       "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.3.3"
+        "@babel/types": "7.3.4"
       }
     },
     "@babel/helper-wrap-function": {
@@ -313,8 +280,8 @@
       "requires": {
         "@babel/helper-function-name": "7.1.0",
         "@babel/template": "7.2.2",
-        "@babel/traverse": "7.2.3",
-        "@babel/types": "7.3.3"
+        "@babel/traverse": "7.3.4",
+        "@babel/types": "7.3.4"
       }
     },
     "@babel/helpers": {
@@ -324,8 +291,8 @@
       "dev": true,
       "requires": {
         "@babel/template": "7.2.2",
-        "@babel/traverse": "7.2.3",
-        "@babel/types": "7.3.3"
+        "@babel/traverse": "7.3.4",
+        "@babel/types": "7.3.4"
       }
     },
     "@babel/highlight": {
@@ -339,9 +306,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.3.tgz",
-      "integrity": "sha512-xsH1CJoln2r74hR+y7cg2B5JCPaTh+Hd+EbBRk9nWGSNspuo6krjhX0Om6RnRQuIvFq8wVXCLKH3kwKDYhanSg==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.4.tgz",
+      "integrity": "sha512-tXZCqWtlOOP4wgCp6RjRvLmfuhnqTLy9VHwRochJBCP2nDm27JnnuFEnXFASVyQNHk36jD1tAammsCEEqgscIQ==",
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
@@ -363,102 +330,6 @@
       "requires": {
         "@babel/helper-create-class-features-plugin": "7.3.4",
         "@babel/helper-plugin-utils": "7.0.0"
-      },
-      "dependencies": {
-        "@babel/generator": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.4.tgz",
-          "integrity": "sha512-8EXhHRFqlVVWXPezBW5keTiQi/rJMQTg/Y9uVCEZ0CAF3PKtCCaVRnp64Ii1ujhkoDhhF1fVsImoN4yJ2uz4Wg==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.3.4",
-            "jsesc": "2.5.2",
-            "lodash": "4.17.11",
-            "source-map": "0.5.7",
-            "trim-right": "1.0.1"
-          }
-        },
-        "@babel/helper-create-class-features-plugin": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.3.4.tgz",
-          "integrity": "sha512-uFpzw6L2omjibjxa8VGZsJUPL5wJH0zzGKpoz0ccBkzIa6C8kWNUbiBmQ0rgOKWlHJ6qzmfa6lTiGchiV8SC+g==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-function-name": "7.1.0",
-            "@babel/helper-member-expression-to-functions": "7.0.0",
-            "@babel/helper-optimise-call-expression": "7.0.0",
-            "@babel/helper-plugin-utils": "7.0.0",
-            "@babel/helper-replace-supers": "7.3.4",
-            "@babel/helper-split-export-declaration": "7.0.0"
-          }
-        },
-        "@babel/helper-replace-supers": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.3.4.tgz",
-          "integrity": "sha512-pvObL9WVf2ADs+ePg0jrqlhHoxRXlOa+SHRHzAXIz2xkYuOHfGl+fKxPMaS4Fq+uje8JQPobnertBBvyrWnQ1A==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-member-expression-to-functions": "7.0.0",
-            "@babel/helper-optimise-call-expression": "7.0.0",
-            "@babel/traverse": "7.3.4",
-            "@babel/types": "7.3.4"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.4.tgz",
-          "integrity": "sha512-tXZCqWtlOOP4wgCp6RjRvLmfuhnqTLy9VHwRochJBCP2nDm27JnnuFEnXFASVyQNHk36jD1tAammsCEEqgscIQ==",
-          "dev": true
-        },
-        "@babel/traverse": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.3.4.tgz",
-          "integrity": "sha512-TvTHKp6471OYEcE/91uWmhR6PrrYywQntCHSaZ8CM8Vmp+pjAusal4nGB2WCCQd0rvI7nOMKn9GnbcvTUz3/ZQ==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0",
-            "@babel/generator": "7.3.4",
-            "@babel/helper-function-name": "7.1.0",
-            "@babel/helper-split-export-declaration": "7.0.0",
-            "@babel/parser": "7.3.4",
-            "@babel/types": "7.3.4",
-            "debug": "4.1.1",
-            "globals": "11.11.0",
-            "lodash": "4.17.11"
-          }
-        },
-        "@babel/types": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.4.tgz",
-          "integrity": "sha512-WEkp8MsLftM7O/ty580wAmZzN1nDmCACc5+jFzUt+GUFNNIi3LdRlueYz0YIlmJhlZx1QYDMZL5vdWCL0fNjFQ==",
-          "dev": true,
-          "requires": {
-            "esutils": "2.0.2",
-            "lodash": "4.17.11",
-            "to-fast-properties": "2.0.0"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
       }
     },
     "@babel/plugin-proposal-json-strings": {
@@ -469,6 +340,16 @@
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0",
         "@babel/plugin-syntax-json-strings": "7.2.0"
+      }
+    },
+    "@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.3.4.tgz",
+      "integrity": "sha512-j7VQmbbkA+qrzNqbKHrBsW3ddFnOeva6wzSe/zB7T+xaxGc+RCpwo44wCmRixAIGRoIpmVgvzFzNJqQcO3/9RA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-syntax-object-rest-spread": "7.2.0"
       }
     },
     "@babel/plugin-proposal-optional-catch-binding": {
@@ -489,7 +370,7 @@
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0",
         "@babel/helper-regex": "7.0.0",
-        "regexpu-core": "4.4.0"
+        "regexpu-core": "4.5.3"
       }
     },
     "@babel/plugin-syntax-async-generators": {
@@ -546,6 +427,17 @@
         "@babel/helper-plugin-utils": "7.0.0"
       }
     },
+    "@babel/plugin-transform-async-to-generator": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.3.4.tgz",
+      "integrity": "sha512-Y7nCzv2fw/jEZ9f678MuKdMo99MFDJMT/PvD9LisrR5JDFcJH6vYeH6RnjVt3p5tceyGRvTtEN0VOlU+rgHZjA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-remap-async-to-generator": "7.1.0"
+      }
+    },
     "@babel/plugin-transform-block-scoped-functions": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz",
@@ -553,6 +445,32 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0"
+      }
+    },
+    "@babel/plugin-transform-block-scoping": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.3.4.tgz",
+      "integrity": "sha512-blRr2O8IOZLAOJklXLV4WhcEzpYafYQKSGT3+R26lWG41u/FODJuBggehtOwilVAcFu393v3OFj+HmaE6tVjhA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0",
+        "lodash": "4.17.11"
+      }
+    },
+    "@babel/plugin-transform-classes": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.3.4.tgz",
+      "integrity": "sha512-J9fAvCFBkXEvBimgYxCjvaVDzL6thk0j0dBvCeZmIUDBwyt+nv6HfbImsSrWsYXfDNDivyANgJlFXDUWRTZBuA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "7.0.0",
+        "@babel/helper-define-map": "7.1.0",
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/helper-optimise-call-expression": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-replace-supers": "7.3.4",
+        "@babel/helper-split-export-declaration": "7.0.0",
+        "globals": "11.11.0"
       }
     },
     "@babel/plugin-transform-computed-properties": {
@@ -581,7 +499,7 @@
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0",
         "@babel/helper-regex": "7.0.0",
-        "regexpu-core": "4.4.0"
+        "regexpu-core": "4.5.3"
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
@@ -604,9 +522,9 @@
       }
     },
     "@babel/plugin-transform-flow-strip-types": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.2.3.tgz",
-      "integrity": "sha512-xnt7UIk9GYZRitqCnsVMjQK1O2eKZwFB3CvvHjf5SGx6K6vr/MScCKQDnf1DxRaj501e3pXjti+inbSXX2ZUoQ==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.3.4.tgz",
+      "integrity": "sha512-PmQC9R7DwpBFA+7ATKMyzViz3zCaMNouzZMPZN2K5PnbBbtL3AXFYTkDk+Hey5crQq2A90UG5Uthz0mel+XZrA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0",
@@ -662,6 +580,16 @@
         "@babel/helper-simple-access": "7.1.0"
       }
     },
+    "@babel/plugin-transform-modules-systemjs": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.3.4.tgz",
+      "integrity": "sha512-VZ4+jlGOF36S7TjKs8g4ojp4MEI+ebCQZdswWb/T9I4X84j8OtFAyjXjt/M16iIm5RIZn0UMQgg/VgIwo/87vw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0"
+      }
+    },
     "@babel/plugin-transform-modules-umd": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz",
@@ -678,7 +606,7 @@
       "integrity": "sha512-NxIoNVhk9ZxS+9lSoAQ/LM0V2UEvARLttEHUrRDGKFaAxOYQcrkN/nLRE+BbbicCAvZPl7wMP0X60HsHE5DtQw==",
       "dev": true,
       "requires": {
-        "regexp-tree": "0.1.4"
+        "regexp-tree": "0.1.5"
       }
     },
     "@babel/plugin-transform-new-target": {
@@ -697,7 +625,7 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/helper-replace-supers": "7.2.3"
+        "@babel/helper-replace-supers": "7.3.4"
       }
     },
     "@babel/plugin-transform-parameters": {
@@ -709,6 +637,15 @@
         "@babel/helper-call-delegate": "7.1.0",
         "@babel/helper-get-function-arity": "7.0.0",
         "@babel/helper-plugin-utils": "7.0.0"
+      }
+    },
+    "@babel/plugin-transform-regenerator": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.3.4.tgz",
+      "integrity": "sha512-hvJg8EReQvXT6G9H2MvNPXkv9zK36Vxa1+csAVTpE1J3j0zlHplw76uudEbJxgvqZzAq9Yh45FLD4pk5mKRFQA==",
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "0.13.4"
       }
     },
     "@babel/plugin-transform-runtime": {
@@ -778,7 +715,7 @@
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0",
         "@babel/helper-regex": "7.0.0",
-        "regexpu-core": "4.4.0"
+        "regexpu-core": "4.5.3"
       }
     },
     "@babel/polyfill": {
@@ -835,167 +772,10 @@
         "@babel/plugin-transform-template-literals": "7.2.0",
         "@babel/plugin-transform-typeof-symbol": "7.2.0",
         "@babel/plugin-transform-unicode-regex": "7.2.0",
-        "browserslist": "4.4.1",
+        "browserslist": "4.4.2",
         "invariant": "2.2.4",
         "js-levenshtein": "1.1.6",
         "semver": "5.6.0"
-      },
-      "dependencies": {
-        "@babel/generator": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.4.tgz",
-          "integrity": "sha512-8EXhHRFqlVVWXPezBW5keTiQi/rJMQTg/Y9uVCEZ0CAF3PKtCCaVRnp64Ii1ujhkoDhhF1fVsImoN4yJ2uz4Wg==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.3.4",
-            "jsesc": "2.5.2",
-            "lodash": "4.17.11",
-            "source-map": "0.5.7",
-            "trim-right": "1.0.1"
-          }
-        },
-        "@babel/helper-replace-supers": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.3.4.tgz",
-          "integrity": "sha512-pvObL9WVf2ADs+ePg0jrqlhHoxRXlOa+SHRHzAXIz2xkYuOHfGl+fKxPMaS4Fq+uje8JQPobnertBBvyrWnQ1A==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-member-expression-to-functions": "7.0.0",
-            "@babel/helper-optimise-call-expression": "7.0.0",
-            "@babel/traverse": "7.3.4",
-            "@babel/types": "7.3.4"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.4.tgz",
-          "integrity": "sha512-tXZCqWtlOOP4wgCp6RjRvLmfuhnqTLy9VHwRochJBCP2nDm27JnnuFEnXFASVyQNHk36jD1tAammsCEEqgscIQ==",
-          "dev": true
-        },
-        "@babel/plugin-proposal-object-rest-spread": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.3.4.tgz",
-          "integrity": "sha512-j7VQmbbkA+qrzNqbKHrBsW3ddFnOeva6wzSe/zB7T+xaxGc+RCpwo44wCmRixAIGRoIpmVgvzFzNJqQcO3/9RA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-plugin-utils": "7.0.0",
-            "@babel/plugin-syntax-object-rest-spread": "7.2.0"
-          }
-        },
-        "@babel/plugin-transform-async-to-generator": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.3.4.tgz",
-          "integrity": "sha512-Y7nCzv2fw/jEZ9f678MuKdMo99MFDJMT/PvD9LisrR5JDFcJH6vYeH6RnjVt3p5tceyGRvTtEN0VOlU+rgHZjA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-module-imports": "7.0.0",
-            "@babel/helper-plugin-utils": "7.0.0",
-            "@babel/helper-remap-async-to-generator": "7.1.0"
-          }
-        },
-        "@babel/plugin-transform-block-scoping": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.3.4.tgz",
-          "integrity": "sha512-blRr2O8IOZLAOJklXLV4WhcEzpYafYQKSGT3+R26lWG41u/FODJuBggehtOwilVAcFu393v3OFj+HmaE6tVjhA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-plugin-utils": "7.0.0",
-            "lodash": "4.17.11"
-          }
-        },
-        "@babel/plugin-transform-classes": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.3.4.tgz",
-          "integrity": "sha512-J9fAvCFBkXEvBimgYxCjvaVDzL6thk0j0dBvCeZmIUDBwyt+nv6HfbImsSrWsYXfDNDivyANgJlFXDUWRTZBuA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-annotate-as-pure": "7.0.0",
-            "@babel/helper-define-map": "7.1.0",
-            "@babel/helper-function-name": "7.1.0",
-            "@babel/helper-optimise-call-expression": "7.0.0",
-            "@babel/helper-plugin-utils": "7.0.0",
-            "@babel/helper-replace-supers": "7.3.4",
-            "@babel/helper-split-export-declaration": "7.0.0",
-            "globals": "11.11.0"
-          }
-        },
-        "@babel/plugin-transform-modules-systemjs": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.3.4.tgz",
-          "integrity": "sha512-VZ4+jlGOF36S7TjKs8g4ojp4MEI+ebCQZdswWb/T9I4X84j8OtFAyjXjt/M16iIm5RIZn0UMQgg/VgIwo/87vw==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-hoist-variables": "7.0.0",
-            "@babel/helper-plugin-utils": "7.0.0"
-          }
-        },
-        "@babel/plugin-transform-regenerator": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.3.4.tgz",
-          "integrity": "sha512-hvJg8EReQvXT6G9H2MvNPXkv9zK36Vxa1+csAVTpE1J3j0zlHplw76uudEbJxgvqZzAq9Yh45FLD4pk5mKRFQA==",
-          "dev": true,
-          "requires": {
-            "regenerator-transform": "0.13.4"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.3.4.tgz",
-          "integrity": "sha512-TvTHKp6471OYEcE/91uWmhR6PrrYywQntCHSaZ8CM8Vmp+pjAusal4nGB2WCCQd0rvI7nOMKn9GnbcvTUz3/ZQ==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0",
-            "@babel/generator": "7.3.4",
-            "@babel/helper-function-name": "7.1.0",
-            "@babel/helper-split-export-declaration": "7.0.0",
-            "@babel/parser": "7.3.4",
-            "@babel/types": "7.3.4",
-            "debug": "4.1.1",
-            "globals": "11.11.0",
-            "lodash": "4.17.11"
-          }
-        },
-        "@babel/types": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.4.tgz",
-          "integrity": "sha512-WEkp8MsLftM7O/ty580wAmZzN1nDmCACc5+jFzUt+GUFNNIi3LdRlueYz0YIlmJhlZx1QYDMZL5vdWCL0fNjFQ==",
-          "dev": true,
-          "requires": {
-            "esutils": "2.0.2",
-            "lodash": "4.17.11",
-            "to-fast-properties": "2.0.0"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-          "dev": true
-        },
-        "regenerator-transform": {
-          "version": "0.13.4",
-          "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.4.tgz",
-          "integrity": "sha512-T0QMBjK3J0MtxjPmdIMXm72Wvj2Abb0Bd4HADdfijwMdoIsyQZ6fWC7kDFhk2YinBBEMZDL7Y7wh0J1sGx3S4A==",
-          "dev": true,
-          "requires": {
-            "private": "0.1.8"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
       }
     },
     "@babel/preset-flow": {
@@ -1005,7 +785,7 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/plugin-transform-flow-strip-types": "7.2.3"
+        "@babel/plugin-transform-flow-strip-types": "7.3.4"
       }
     },
     "@babel/register": {
@@ -1021,18 +801,6 @@
         "mkdirp": "0.5.1",
         "pirates": "4.0.1",
         "source-map-support": "0.5.10"
-      },
-      "dependencies": {
-        "source-map-support": {
-          "version": "0.5.10",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
-          "integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
-          "dev": true,
-          "requires": {
-            "buffer-from": "1.1.1",
-            "source-map": "0.6.1"
-          }
-        }
       }
     },
     "@babel/runtime": {
@@ -1059,22 +827,22 @@
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.0.0",
-        "@babel/parser": "7.3.3",
-        "@babel/types": "7.3.3"
+        "@babel/parser": "7.3.4",
+        "@babel/types": "7.3.4"
       }
     },
     "@babel/traverse": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.2.3.tgz",
-      "integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.3.4.tgz",
+      "integrity": "sha512-TvTHKp6471OYEcE/91uWmhR6PrrYywQntCHSaZ8CM8Vmp+pjAusal4nGB2WCCQd0rvI7nOMKn9GnbcvTUz3/ZQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.0.0",
-        "@babel/generator": "7.3.3",
+        "@babel/generator": "7.3.4",
         "@babel/helper-function-name": "7.1.0",
         "@babel/helper-split-export-declaration": "7.0.0",
-        "@babel/parser": "7.3.3",
-        "@babel/types": "7.3.3",
+        "@babel/parser": "7.3.4",
+        "@babel/types": "7.3.4",
         "debug": "4.1.1",
         "globals": "11.11.0",
         "lodash": "4.17.11"
@@ -1098,9 +866,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.3.tgz",
-      "integrity": "sha512-2tACZ80Wg09UnPg5uGAOUvvInaqLk3l/IAhQzlxLQOIXacr6bMsra5SH6AWw/hIDRCSbCdHP2KzSOD+cT7TzMQ==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.4.tgz",
+      "integrity": "sha512-WEkp8MsLftM7O/ty580wAmZzN1nDmCACc5+jFzUt+GUFNNIi3LdRlueYz0YIlmJhlZx1QYDMZL5vdWCL0fNjFQ==",
       "dev": true,
       "requires": {
         "esutils": "2.0.2",
@@ -1167,124 +935,10 @@
             "supports-color": "5.5.0"
           }
         },
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "2.0.0"
-          }
-        },
-        "get-stdin": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
-          "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
-          "dev": true
-        },
-        "load-json-file": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.15",
-            "parse-json": "4.0.0",
-            "pify": "3.0.0",
-            "strip-bom": "3.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "2.0.0",
-            "path-exists": "3.0.0"
-          }
-        },
-        "meow": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
-          "integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
-          "dev": true,
-          "requires": {
-            "camelcase-keys": "4.2.0",
-            "decamelize-keys": "1.1.0",
-            "loud-rejection": "1.6.0",
-            "minimist-options": "3.0.2",
-            "normalize-package-data": "2.5.0",
-            "read-pkg-up": "3.0.0",
-            "redent": "2.0.0",
-            "trim-newlines": "2.0.0",
-            "yargs-parser": "10.1.0"
-          }
-        },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "dev": true,
-          "requires": {
-            "p-try": "1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "dev": true,
-          "requires": {
-            "p-limit": "1.3.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-          "dev": true
-        },
-        "path-type": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-          "dev": true,
-          "requires": {
-            "pify": "3.0.0"
-          }
-        },
-        "read-pkg": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "4.0.0",
-            "normalize-package-data": "2.5.0",
-            "path-type": "3.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-          "dev": true,
-          "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "3.0.0"
-          }
-        },
         "regenerator-runtime": {
           "version": "0.10.5",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
-          "dev": true
-        },
-        "yargs-parser": {
-          "version": "10.1.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
           "dev": true
         }
       }
@@ -1374,33 +1028,6 @@
         "conventional-changelog-angular": "1.6.6",
         "conventional-commits-parser": "2.1.7",
         "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "conventional-changelog-angular": {
-          "version": "1.6.6",
-          "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
-          "integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
-          "dev": true,
-          "requires": {
-            "compare-func": "1.3.2",
-            "q": "1.5.1"
-          }
-        },
-        "conventional-commits-parser": {
-          "version": "2.1.7",
-          "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz",
-          "integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
-          "dev": true,
-          "requires": {
-            "JSONStream": "1.3.5",
-            "is-text-path": "1.0.1",
-            "lodash": "4.17.11",
-            "meow": "4.0.1",
-            "split2": "2.2.0",
-            "through2": "2.0.5",
-            "trim-off-newlines": "1.0.1"
-          }
-        }
       }
     },
     "@commitlint/read": {
@@ -1413,21 +1040,6 @@
         "@marionebl/sander": "0.6.1",
         "babel-runtime": "6.26.0",
         "git-raw-commits": "1.3.6"
-      },
-      "dependencies": {
-        "git-raw-commits": {
-          "version": "1.3.6",
-          "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.6.tgz",
-          "integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
-          "dev": true,
-          "requires": {
-            "dargs": "4.1.0",
-            "lodash.template": "4.4.0",
-            "meow": "4.0.1",
-            "split2": "2.2.0",
-            "through2": "2.0.5"
-          }
-        }
       }
     },
     "@commitlint/resolve-extends": {
@@ -1527,30 +1139,31 @@
       }
     },
     "@sinonjs/commons": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
-      "integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
+      "integrity": "sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
       }
     },
     "@sinonjs/formatio": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.1.0.tgz",
-      "integrity": "sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
+      "integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
       "dev": true,
       "requires": {
-        "@sinonjs/samsam": "3.1.1"
+        "@sinonjs/commons": "1.4.0",
+        "@sinonjs/samsam": "3.2.0"
       }
     },
     "@sinonjs/samsam": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.1.1.tgz",
-      "integrity": "sha512-ILlwvQUwAiaVBzr3qz8oT1moM7AIUHqUc2UmEjQcH9lLe+E+BZPwUMuc9FFojMswRK4r96x5zDTTrowMLw/vuA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.2.0.tgz",
+      "integrity": "sha512-j5F1rScewLtx6pbTK0UAjA3jJj4RYiSKOix53YWv+Jzy/AZ69qHxUpU8fwVLjyKbEEud9QrLpv6Ggs7WqTimYw==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "1.3.0",
+        "@sinonjs/commons": "1.4.0",
         "array-from": "2.1.1",
         "lodash": "4.17.11"
       }
@@ -1591,9 +1204,185 @@
       }
     },
     "@types/node": {
-      "version": "11.9.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.9.4.tgz",
-      "integrity": "sha512-Zl8dGvAcEmadgs1tmSPcvwzO1YRsz38bVJQvH1RvRqSR9/5n61Q1ktcDL0ht3FXWR+ZpVmXVwN1LuH4Ax23NsA=="
+      "version": "11.10.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.10.4.tgz",
+      "integrity": "sha512-wa09itaLE8L705aXd8F80jnFpxz3Y1/KRHfKsYL2bPc0XF+wEWu8sR9n5bmeu8Ba1N9z2GRNzm/YdHcghLkLKg=="
+    },
+    "@webassemblyjs/ast": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
+      "integrity": "sha512-aJMfngIZ65+t71C3y2nBBg5FFG0Okt9m0XEgWZ7Ywgn1oMAT8cNwx00Uv1cQyHtidq0Xn94R4TAywO+LCQ+ZAQ==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/helper-module-context": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/wast-parser": "1.8.5"
+      }
+    },
+    "@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz",
+      "integrity": "sha512-9p+79WHru1oqBh9ewP9zW95E3XAo+90oth7S5Re3eQnECGq59ly1Ri5tsIipKGpiStHsUYmY3zMLqtk3gTcOtQ==",
+      "dev": true
+    },
+    "@webassemblyjs/helper-api-error": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz",
+      "integrity": "sha512-Za/tnzsvnqdaSPOUXHyKJ2XI7PDX64kWtURyGiJJZKVEdFOsdKUCPTNEVFZq3zJ2R0G5wc2PZ5gvdTRFgm81zA==",
+      "dev": true
+    },
+    "@webassemblyjs/helper-buffer": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz",
+      "integrity": "sha512-Ri2R8nOS0U6G49Q86goFIPNgjyl6+oE1abW1pS84BuhP1Qcr5JqMwRFT3Ah3ADDDYGEgGs1iyb1DGX+kAi/c/Q==",
+      "dev": true
+    },
+    "@webassemblyjs/helper-code-frame": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz",
+      "integrity": "sha512-VQAadSubZIhNpH46IR3yWO4kZZjMxN1opDrzePLdVKAZ+DFjkGD/rf4v1jap744uPVU6yjL/smZbRIIJTOUnKQ==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/wast-printer": "1.8.5"
+      }
+    },
+    "@webassemblyjs/helper-fsm": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz",
+      "integrity": "sha512-kRuX/saORcg8se/ft6Q2UbRpZwP4y7YrWsLXPbbmtepKr22i8Z4O3V5QE9DbZK908dh5Xya4Un57SDIKwB9eow==",
+      "dev": true
+    },
+    "@webassemblyjs/helper-module-context": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz",
+      "integrity": "sha512-/O1B236mN7UNEU4t9X7Pj38i4VoU8CcMHyy3l2cV/kIF4U5KoHXDVqcDuOs1ltkac90IM4vZdHc52t1x8Yfs3g==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.8.5",
+        "mamacro": "0.0.3"
+      }
+    },
+    "@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz",
+      "integrity": "sha512-Cu4YMYG3Ddl72CbmpjU/wbP6SACcOPVbHN1dI4VJNJVgFwaKf1ppeFJrwydOG3NDHxVGuCfPlLZNyEdIYlQ6QQ==",
+      "dev": true
+    },
+    "@webassemblyjs/helper-wasm-section": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz",
+      "integrity": "sha512-VV083zwR+VTrIWWtgIUpqfvVdK4ff38loRmrdDBgBT8ADXYsEZ5mPQ4Nde90N3UYatHdYoDIFb7oHzMncI02tA==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-buffer": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/wasm-gen": "1.8.5"
+      }
+    },
+    "@webassemblyjs/ieee754": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz",
+      "integrity": "sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==",
+      "dev": true,
+      "requires": {
+        "@xtuc/ieee754": "1.2.0"
+      }
+    },
+    "@webassemblyjs/leb128": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.8.5.tgz",
+      "integrity": "sha512-plYUuUwleLIziknvlP8VpTgO4kqNaH57Y3JnNa6DLpu/sGcP6hbVdfdX5aHAV716pQBKrfuU26BJK29qY37J7A==",
+      "dev": true,
+      "requires": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "@webassemblyjs/utf8": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.8.5.tgz",
+      "integrity": "sha512-U7zgftmQriw37tfD934UNInokz6yTmn29inT2cAetAsaU9YeVCveWEwhKL1Mg4yS7q//NGdzy79nlXh3bT8Kjw==",
+      "dev": true
+    },
+    "@webassemblyjs/wasm-edit": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz",
+      "integrity": "sha512-A41EMy8MWw5yvqj7MQzkDjU29K7UJq1VrX2vWLzfpRHt3ISftOXqrtojn7nlPsZ9Ijhp5NwuODuycSvfAO/26Q==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-buffer": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/helper-wasm-section": "1.8.5",
+        "@webassemblyjs/wasm-gen": "1.8.5",
+        "@webassemblyjs/wasm-opt": "1.8.5",
+        "@webassemblyjs/wasm-parser": "1.8.5",
+        "@webassemblyjs/wast-printer": "1.8.5"
+      }
+    },
+    "@webassemblyjs/wasm-gen": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz",
+      "integrity": "sha512-BCZBT0LURC0CXDzj5FXSc2FPTsxwp3nWcqXQdOZE4U7h7i8FqtFK5Egia6f9raQLpEKT1VL7zr4r3+QX6zArWg==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/ieee754": "1.8.5",
+        "@webassemblyjs/leb128": "1.8.5",
+        "@webassemblyjs/utf8": "1.8.5"
+      }
+    },
+    "@webassemblyjs/wasm-opt": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz",
+      "integrity": "sha512-HKo2mO/Uh9A6ojzu7cjslGaHaUU14LdLbGEKqTR7PBKwT6LdPtLLh9fPY33rmr5wcOMrsWDbbdCHq4hQUdd37Q==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-buffer": "1.8.5",
+        "@webassemblyjs/wasm-gen": "1.8.5",
+        "@webassemblyjs/wasm-parser": "1.8.5"
+      }
+    },
+    "@webassemblyjs/wasm-parser": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz",
+      "integrity": "sha512-pi0SYE9T6tfcMkthwcgCpL0cM9nRYr6/6fjgDtL6q/ZqKHdMWvxitRi5JcZ7RI4SNJJYnYNaWy5UUrHQy998lw==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-api-error": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/ieee754": "1.8.5",
+        "@webassemblyjs/leb128": "1.8.5",
+        "@webassemblyjs/utf8": "1.8.5"
+      }
+    },
+    "@webassemblyjs/wast-parser": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz",
+      "integrity": "sha512-daXC1FyKWHF1i11obK086QRlsMsY4+tIOKgBqI1lxAnkp9xe9YMcgOxm9kLe+ttjs5aWV2KKE1TWJCN57/Btsg==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/floating-point-hex-parser": "1.8.5",
+        "@webassemblyjs/helper-api-error": "1.8.5",
+        "@webassemblyjs/helper-code-frame": "1.8.5",
+        "@webassemblyjs/helper-fsm": "1.8.5",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "@webassemblyjs/wast-printer": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz",
+      "integrity": "sha512-w0U0pD4EhlnvRyeJzBqaVSJAo9w/ce7/WPogeXLzGkO6hzhr4GnQIZ4W4uUt5b9ooAaXPtnXlj0gzsXEOUNYMg==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/wast-parser": "1.8.5",
+        "@xtuc/long": "4.2.2"
+      }
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -1623,9 +1412,9 @@
       }
     },
     "acorn": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.0.tgz",
-      "integrity": "sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw=="
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+      "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA=="
     },
     "acorn-dynamic-import": {
       "version": "4.0.0",
@@ -1712,37 +1501,31 @@
         "upath": "1.1.0",
         "whatwg-url": "7.0.0",
         "xmldom": "0.1.27",
+        "yargs": "13.2.1",
         "yauzl": "2.10.0"
       },
       "dependencies": {
-        "ajv": {
-          "version": "6.10.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-          "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
-          "requires": {
-            "fast-deep-equal": "2.0.1",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.4.1",
-            "uri-js": "4.2.2"
-          }
-        },
-        "es6-promisify": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.0.1.tgz",
-          "integrity": "sha512-J3ZkwbEnnO+fGAKrjVpeUAnZshAdfZvbhQpqfIH9kSAspReRC4nJnu8ewm55b4y9ElyeuhCTzJD0XiH8Tsbhlw=="
-        },
         "regenerator-runtime": {
           "version": "0.13.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.1.tgz",
           "integrity": "sha512-5KzMIyPLvfdPmvsdlYsHqITrDfK9k7bmvf97HvHSN4810i254ponbxCQ1NukpRWlu6en2MBWzAlhDExEKISwAA=="
         },
-        "relaxed-json": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/relaxed-json/-/relaxed-json-1.0.3.tgz",
-          "integrity": "sha512-b7wGPo7o2KE/g7SqkJDDbav6zmrEeP4TK2VpITU72J/M949TLe/23y/ZHJo+pskcGM52xIfFoT9hydwmgr1AEg==",
+        "yargs": {
+          "version": "13.2.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.1.tgz",
+          "integrity": "sha512-HgY0xHGmPPakg6kEDufqxZuXVtvPZcipORC8O7S44iEnwsUmP+qnhReHc6d1dyeIZkrPmYFblh45Z2oeDn++fQ==",
           "requires": {
-            "chalk": "2.4.2",
-            "commander": "2.19.0"
+            "cliui": "4.1.0",
+            "find-up": "3.0.0",
+            "get-caller-file": "2.0.1",
+            "os-locale": "3.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "2.0.0",
+            "set-blocking": "2.0.0",
+            "string-width": "3.0.0",
+            "which-module": "2.0.0",
+            "y18n": "4.0.0",
+            "yargs-parser": "13.0.0"
           }
         }
       }
@@ -1753,9 +1536,9 @@
       "integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw=="
     },
     "ajv": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",
-      "integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
       "requires": {
         "fast-deep-equal": "2.0.1",
         "fast-json-stable-stringify": "2.0.0",
@@ -1806,6 +1589,30 @@
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "requires": {
         "string-width": "2.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
       }
     },
     "ansi-colors": {
@@ -1958,6 +1765,11 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+    },
+    "array-differ": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-2.1.0.tgz",
+      "integrity": "sha512-KbUpJgx909ZscOc/7CLATBFam7P1Z1QRQInvgT0UztM9Q72aGKCunKASAl7WNW0tnPmPyEMeMhdsfWhfmW037w=="
     },
     "array-filter": {
       "version": "0.0.1",
@@ -2156,9 +1968,9 @@
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.0.0",
-        "@babel/parser": "7.3.3",
-        "@babel/traverse": "7.2.3",
-        "@babel/types": "7.3.3",
+        "@babel/parser": "7.3.4",
+        "@babel/traverse": "7.3.4",
+        "@babel/types": "7.3.4",
         "eslint-scope": "3.7.1",
         "eslint-visitor-keys": "1.0.0"
       },
@@ -2399,11 +2211,41 @@
       "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
       "requires": {
         "ansi-align": "2.0.0",
+        "camelcase": "4.1.0",
         "chalk": "2.4.2",
         "cli-boxes": "1.0.0",
         "string-width": "2.1.1",
         "term-size": "1.2.0",
         "widest-line": "2.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
       }
     },
     "brace-expansion": {
@@ -2498,7 +2340,7 @@
       "dev": true,
       "requires": {
         "bn.js": "4.11.8",
-        "randombytes": "2.0.6"
+        "randombytes": "2.1.0"
       }
     },
     "browserify-sign": {
@@ -2522,18 +2364,18 @@
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
       "requires": {
-        "pako": "1.0.8"
+        "pako": "1.0.10"
       }
     },
     "browserslist": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.4.1.tgz",
-      "integrity": "sha512-pEBxEXg7JwaakBXjATYw/D1YZh4QUSCX/Mnd/wnqSRPPSi1U39iDhDoKGoBUcraKdxDlrYqJxSI5nNvD+dWP2A==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.4.2.tgz",
+      "integrity": "sha512-ISS/AIAiHERJ3d45Fz0AVYKkgcy+F/eJHzKEvv1j0wwKGKD9T3BrwKr/5g45L+Y4XIK5PlTqefHciRFcfE1Jxg==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000938",
+        "caniuse-lite": "1.0.30000941",
         "electron-to-chromium": "1.3.113",
-        "node-releases": "1.1.7"
+        "node-releases": "1.1.9"
       }
     },
     "buffer": {
@@ -2694,14 +2536,23 @@
       "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
       "dev": true,
       "requires": {
+        "camelcase": "4.1.0",
         "map-obj": "2.0.0",
         "quick-lru": "1.1.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        }
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000938",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000938.tgz",
-      "integrity": "sha512-ekW8NQ3/FvokviDxhdKLZZAx7PptXNwxKgXtnR5y+PR3hckwuP3yJ1Ir+4/c97dsHNqtAyfKUGdw8P4EYzBNgw==",
+      "version": "1.0.30000941",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000941.tgz",
+      "integrity": "sha512-4vzGb2MfZcO20VMPj1j6nRAixhmtlhkypM4fL4zhgzEucQIYiRzSqPcWIu1OF8i0FETD93FMIPWfUJCAcFvrqA==",
       "dev": true
     },
     "capture-stack-trace": {
@@ -2790,9 +2641,9 @@
       }
     },
     "chokidar": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.1.tgz",
-      "integrity": "sha512-gfw3p2oQV2wEt+8VuMlNsPjCxDxvvgnm/kz+uATu805mWVF8IJN7uz9DN7iBz+RMJISmiVbCOBFs9qBGMjtPfQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.2.tgz",
+      "integrity": "sha512-IwXUx0FXc5ibYmPC2XeEj5mpXoV66sR+t3jqu2NS2GYwCktt3KF1/Qqjws/NkegajBA4RbZ5+DDwlOiJsxDHEg==",
       "requires": {
         "anymatch": "2.0.0",
         "async-each": "1.0.1",
@@ -3366,6 +3217,15 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -3608,12 +3468,24 @@
         "conventional-changelog-jquery": "3.0.4",
         "conventional-changelog-jshint": "2.0.1",
         "conventional-changelog-preset-loader": "2.0.2"
+      },
+      "dependencies": {
+        "conventional-changelog-angular": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.3.tgz",
+          "integrity": "sha512-YD1xzH7r9yXQte/HF9JBuEDfvjxxwDGGwZU1+ndanbY0oFgA+Po1T9JDSpPLdP0pZT6MhCAsdvFKC4TJ4MTJTA==",
+          "dev": true,
+          "requires": {
+            "compare-func": "1.3.2",
+            "q": "1.5.1"
+          }
+        }
       }
     },
     "conventional-changelog-angular": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.3.tgz",
-      "integrity": "sha512-YD1xzH7r9yXQte/HF9JBuEDfvjxxwDGGwZU1+ndanbY0oFgA+Po1T9JDSpPLdP0pZT6MhCAsdvFKC4TJ4MTJTA==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
+      "integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
       "dev": true,
       "requires": {
         "compare-func": "1.3.2",
@@ -3640,6 +3512,31 @@
         "lodash": "4.17.11",
         "meow": "4.0.1",
         "tempfile": "1.1.1"
+      },
+      "dependencies": {
+        "meow": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+          "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+          "dev": true,
+          "requires": {
+            "camelcase-keys": "4.2.0",
+            "decamelize-keys": "1.1.0",
+            "loud-rejection": "1.6.0",
+            "minimist": "1.2.0",
+            "minimist-options": "3.0.2",
+            "normalize-package-data": "2.5.0",
+            "read-pkg-up": "3.0.0",
+            "redent": "2.0.0",
+            "trim-newlines": "2.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
       }
     },
     "conventional-changelog-codemirror": {
@@ -3672,90 +3569,56 @@
         "through2": "2.0.5"
       },
       "dependencies": {
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+        "conventional-commits-parser": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.1.tgz",
+          "integrity": "sha512-P6U5UOvDeidUJ8ebHVDIoXzI7gMlQ1OF/id6oUvp8cnZvOXMt1n8nYl74Ey9YMn0uVQtxmCtjPQawpsssBWtGg==",
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "JSONStream": "1.3.5",
+            "is-text-path": "1.0.1",
+            "lodash": "4.17.11",
+            "meow": "4.0.1",
+            "split2": "2.2.0",
+            "through2": "2.0.5",
+            "trim-off-newlines": "1.0.1"
           }
         },
-        "load-json-file": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.15",
-            "parse-json": "4.0.0",
-            "pify": "3.0.0",
-            "strip-bom": "3.0.0"
-          }
-        },
-        "locate-path": {
+        "git-raw-commits": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.0.tgz",
+          "integrity": "sha512-w4jFEJFgKXMQJ0H0ikBk2S+4KP2VEjhCvLCNqbNRQC8BgGWgLKNCO7a9K9LI+TVT7Gfoloje502sEnctibffgg==",
           "dev": true,
           "requires": {
-            "p-locate": "2.0.0",
-            "path-exists": "3.0.0"
+            "dargs": "4.1.0",
+            "lodash.template": "4.4.0",
+            "meow": "4.0.1",
+            "split2": "2.2.0",
+            "through2": "2.0.5"
           }
         },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+        "meow": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+          "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
           "dev": true,
           "requires": {
-            "p-try": "1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "dev": true,
-          "requires": {
-            "p-limit": "1.3.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-          "dev": true
-        },
-        "path-type": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-          "dev": true,
-          "requires": {
-            "pify": "3.0.0"
-          }
-        },
-        "read-pkg": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "4.0.0",
+            "camelcase-keys": "4.2.0",
+            "decamelize-keys": "1.1.0",
+            "loud-rejection": "1.6.0",
+            "minimist": "1.2.0",
+            "minimist-options": "3.0.2",
             "normalize-package-data": "2.5.0",
-            "path-type": "3.0.0"
+            "read-pkg-up": "3.0.0",
+            "redent": "2.0.0",
+            "trim-newlines": "2.0.0"
           }
         },
-        "read-pkg-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-          "dev": true,
-          "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "3.0.0"
-          }
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
         }
       }
     },
@@ -3829,6 +3692,29 @@
         "through2": "2.0.5"
       },
       "dependencies": {
+        "meow": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+          "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+          "dev": true,
+          "requires": {
+            "camelcase-keys": "4.2.0",
+            "decamelize-keys": "1.1.0",
+            "loud-rejection": "1.6.0",
+            "minimist": "1.2.0",
+            "minimist-options": "3.0.2",
+            "normalize-package-data": "2.5.0",
+            "read-pkg-up": "3.0.0",
+            "redent": "2.0.0",
+            "trim-newlines": "2.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
         "split": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
@@ -3851,9 +3737,9 @@
       }
     },
     "conventional-commits-parser": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.1.tgz",
-      "integrity": "sha512-P6U5UOvDeidUJ8ebHVDIoXzI7gMlQ1OF/id6oUvp8cnZvOXMt1n8nYl74Ey9YMn0uVQtxmCtjPQawpsssBWtGg==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz",
+      "integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
       "dev": true,
       "requires": {
         "JSONStream": "1.3.5",
@@ -3863,6 +3749,31 @@
         "split2": "2.2.0",
         "through2": "2.0.5",
         "trim-off-newlines": "1.0.1"
+      },
+      "dependencies": {
+        "meow": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+          "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+          "dev": true,
+          "requires": {
+            "camelcase-keys": "4.2.0",
+            "decamelize-keys": "1.1.0",
+            "loud-rejection": "1.6.0",
+            "minimist": "1.2.0",
+            "minimist-options": "3.0.2",
+            "normalize-package-data": "2.5.0",
+            "read-pkg-up": "3.0.0",
+            "redent": "2.0.0",
+            "trim-newlines": "2.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
       }
     },
     "convert-source-map": {
@@ -3919,7 +3830,7 @@
       "dev": true,
       "requires": {
         "is-directory": "0.3.1",
-        "js-yaml": "3.12.1",
+        "js-yaml": "3.12.2",
         "parse-json": "4.0.0",
         "require-from-string": "2.0.2"
       }
@@ -3931,7 +3842,7 @@
       "dev": true,
       "requires": {
         "growl": "1.10.5",
-        "js-yaml": "3.12.1",
+        "js-yaml": "3.12.2",
         "lcov-parse": "0.0.10",
         "log-driver": "1.2.7",
         "minimist": "1.2.0",
@@ -4074,7 +3985,7 @@
         "inherits": "2.0.3",
         "pbkdf2": "3.0.17",
         "public-encrypt": "4.0.3",
-        "randombytes": "2.0.6",
+        "randombytes": "2.1.0",
         "randomfill": "1.0.4"
       }
     },
@@ -4119,7 +4030,7 @@
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "requires": {
-        "es5-ext": "0.10.47"
+        "es5-ext": "0.10.48"
       }
     },
     "dargs": {
@@ -4170,16 +4081,6 @@
       "integrity": "sha512-NUW7GyGP5Al0a4QIr3qj/FVzPNjpixU/HWPMJ7kuFlMpVnLcNeUrKsvOOMlywL2QPr/JG3am40S5a2G9F0REcw==",
       "requires": {
         "xregexp": "4.2.4"
-      },
-      "dependencies": {
-        "xregexp": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.2.4.tgz",
-          "integrity": "sha512-sO0bYdYeJAJBcJA8g7MJJX7UrOZIfJPd8U2SC7B2Dd/J24U0aQNoGp33shCaBSWeb0rD5rh6VBUIXOkGal1TZA==",
-          "requires": {
-            "@babel/runtime-corejs2": "7.3.4"
-          }
-        }
       }
     },
     "decamelize-keys": {
@@ -4338,7 +4239,7 @@
       "requires": {
         "bn.js": "4.11.8",
         "miller-rabin": "4.0.1",
-        "randombytes": "2.0.6"
+        "randombytes": "2.1.0"
       }
     },
     "dispensary": {
@@ -4433,9 +4334,9 @@
       }
     },
     "doctrine": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "requires": {
         "esutils": "2.0.2"
       }
@@ -4547,9 +4448,9 @@
       }
     },
     "ecdsa-sig-formatter": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
-      "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "requires": {
         "safe-buffer": "5.1.2"
       }
@@ -4661,9 +4562,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.47",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.47.tgz",
-      "integrity": "sha512-/1TItLfj+TTfWoeRcDn/0FbGV6SNo4R+On2GGVucPU/j3BWnXE2Co8h8CTo4Tu34gFJtnmwS9xiScKs4EjZhdw==",
+      "version": "0.10.48",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.48.tgz",
+      "integrity": "sha512-CdRvPlX/24Mj5L4NVxTs4804sxiS2CjVprgCmrgoDkdmjdY4D+ySHa7K3jJf8R40dFg0tIm3z/dk326LrnuSGw==",
       "requires": {
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
@@ -4681,7 +4582,7 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.47",
+        "es5-ext": "0.10.48",
         "es6-symbol": "3.1.1"
       }
     },
@@ -4691,7 +4592,7 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.47",
+        "es5-ext": "0.10.48",
         "es6-iterator": "2.0.3",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -4704,19 +4605,9 @@
       "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw="
     },
     "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "requires": {
-        "es6-promise": "4.2.6"
-      },
-      "dependencies": {
-        "es6-promise": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
-          "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q=="
-        }
-      }
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.0.1.tgz",
+      "integrity": "sha512-J3ZkwbEnnO+fGAKrjVpeUAnZshAdfZvbhQpqfIH9kSAspReRC4nJnu8ewm55b4y9ElyeuhCTzJD0XiH8Tsbhlw=="
     },
     "es6-set": {
       "version": "0.1.5",
@@ -4724,7 +4615,7 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.47",
+        "es5-ext": "0.10.48",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -4736,7 +4627,7 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.47"
+        "es5-ext": "0.10.48"
       }
     },
     "es6-weak-map": {
@@ -4745,7 +4636,7 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.47",
+        "es5-ext": "0.10.48",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
@@ -4772,7 +4663,7 @@
       "integrity": "sha512-NTcm6vQ+PTgN3UBsALw5BMhgO6i5EpIjQF/Xb5tIh3sk9QhrFafujUOczGz4J24JBlzWclSB9Vmx8d+9Z6bFCg==",
       "requires": {
         "@babel/code-frame": "7.0.0",
-        "ajv": "6.9.1",
+        "ajv": "6.10.0",
         "chalk": "2.4.2",
         "cross-spawn": "6.0.5",
         "debug": "4.1.1",
@@ -4791,7 +4682,7 @@
         "import-fresh": "3.0.0",
         "imurmurhash": "0.1.4",
         "inquirer": "6.2.2",
-        "js-yaml": "3.12.1",
+        "js-yaml": "3.12.2",
         "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.11",
@@ -4822,41 +4713,6 @@
             "ms": "2.1.1"
           }
         },
-        "doctrine": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-          "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-          "requires": {
-            "esutils": "2.0.2"
-          }
-        },
-        "eslint-scope": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.2.tgz",
-          "integrity": "sha512-5q1+B/ogmHl8+paxtOKx38Z8LtWkVGuNt3+GQNErqwLl6ViNp/gdJGMCjZNxZ8j/VYjDNZ2Fo+eQc1TAVPIzbg==",
-          "requires": {
-            "esrecurse": "4.2.1",
-            "estraverse": "4.2.0"
-          }
-        },
-        "file-entry-cache": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
-          "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
-          "requires": {
-            "flat-cache": "2.0.1"
-          }
-        },
-        "flat-cache": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
-          "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
-          "requires": {
-            "flatted": "2.0.0",
-            "rimraf": "2.6.3",
-            "write": "1.0.3"
-          }
-        },
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
@@ -4868,14 +4724,6 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
             "ansi-regex": "3.0.0"
-          }
-        },
-        "write": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
-          "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
-          "requires": {
-            "mkdirp": "0.5.1"
           }
         }
       }
@@ -5112,6 +4960,14 @@
             "restore-cursor": "1.0.1"
           }
         },
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "requires": {
+            "esutils": "2.0.2"
+          }
+        },
         "eslint": {
           "version": "3.19.0",
           "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
@@ -5135,7 +4991,7 @@
             "inquirer": "0.12.0",
             "is-my-json-valid": "2.19.0",
             "is-resolvable": "1.1.0",
-            "js-yaml": "3.12.1",
+            "js-yaml": "3.12.2",
             "json-stable-stringify": "1.0.1",
             "levn": "0.3.0",
             "lodash": "4.17.11",
@@ -5145,6 +5001,7 @@
             "path-is-inside": "1.0.2",
             "pluralize": "1.2.1",
             "progress": "1.1.8",
+            "require-uncached": "1.0.3",
             "shelljs": "0.7.8",
             "strip-bom": "3.0.0",
             "strip-json-comments": "2.0.1",
@@ -5169,6 +5026,26 @@
           "requires": {
             "escape-string-regexp": "1.0.5",
             "object-assign": "4.1.1"
+          }
+        },
+        "file-entry-cache": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+          "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+          "requires": {
+            "flat-cache": "1.3.4",
+            "object-assign": "4.1.1"
+          }
+        },
+        "flat-cache": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+          "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+          "requires": {
+            "circular-json": "0.3.3",
+            "graceful-fs": "4.1.15",
+            "rimraf": "2.6.3",
+            "write": "0.2.1"
           }
         },
         "globals": {
@@ -5218,6 +5095,20 @@
           "version": "1.1.8",
           "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
           "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74="
+        },
+        "require-uncached": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+          "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+          "requires": {
+            "caller-path": "0.1.0",
+            "resolve-from": "1.0.1"
+          }
+        },
+        "resolve-from": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+          "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
         },
         "restore-cursor": {
           "version": "1.0.1",
@@ -5307,14 +5198,21 @@
               }
             }
           }
+        },
+        "write": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+          "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+          "requires": {
+            "mkdirp": "0.5.1"
+          }
         }
       }
     },
     "eslint-scope": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
-      "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
-      "dev": true,
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.2.tgz",
+      "integrity": "sha512-5q1+B/ogmHl8+paxtOKx38Z8LtWkVGuNt3+GQNErqwLl6ViNp/gdJGMCjZNxZ8j/VYjDNZ2Fo+eQc1TAVPIzbg==",
       "requires": {
         "esrecurse": "4.2.1",
         "estraverse": "4.2.0"
@@ -5335,7 +5233,7 @@
       "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
       "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
       "requires": {
-        "acorn": "6.1.0",
+        "acorn": "6.1.1",
         "acorn-jsx": "5.0.1",
         "eslint-visitor-keys": "1.0.0"
       }
@@ -5377,7 +5275,7 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.47"
+        "es5-ext": "0.10.48"
       }
     },
     "event-to-promise": {
@@ -5458,7 +5356,7 @@
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "1.0.1"
+        "homedir-polyfill": "1.0.3"
       }
     },
     "extend": {
@@ -5624,12 +5522,11 @@
       }
     },
     "file-entry-cache": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
       "requires": {
-        "flat-cache": "1.3.4",
-        "object-assign": "4.1.1"
+        "flat-cache": "2.0.1"
       }
     },
     "fill-range": {
@@ -5778,14 +5675,13 @@
       }
     },
     "flat-cache": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
-      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
       "requires": {
-        "circular-json": "0.3.3",
-        "graceful-fs": "4.1.15",
+        "flatted": "2.0.0",
         "rimraf": "2.6.3",
-        "write": "0.2.1"
+        "write": "1.0.3"
       }
     },
     "flatstr": {
@@ -6045,10 +5941,9 @@
       }
     },
     "get-caller-file": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-      "dev": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.1.tgz",
+      "integrity": "sha512-SpOZHfz845AH0wJYVuZk2jWDqFmu7Xubsx+ldIpwzy5pDUpu7OJHK7QYNSA2NPlDSKQwM1GFaAkciOWjjW92Sg=="
     },
     "get-func-name": {
       "version": "2.0.0",
@@ -6091,6 +5986,22 @@
           "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "dev": true
         },
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "get-stdin": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+          "dev": true
+        },
         "indent-string": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
@@ -6098,6 +6009,19 @@
           "dev": true,
           "requires": {
             "repeating": "2.0.1"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.15",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           }
         },
         "map-obj": {
@@ -6130,6 +6054,62 @@
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.2"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.15",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.5.0",
+            "path-type": "1.1.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
+          }
+        },
         "redent": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
@@ -6138,6 +6118,15 @@
           "requires": {
             "indent-string": "2.1.0",
             "strip-indent": "1.0.1"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
           }
         },
         "strip-indent": {
@@ -6158,9 +6147,9 @@
       }
     },
     "get-stdin": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+      "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
       "dev": true
     },
     "get-stream": {
@@ -6193,9 +6182,9 @@
       }
     },
     "git-raw-commits": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.0.tgz",
-      "integrity": "sha512-w4jFEJFgKXMQJ0H0ikBk2S+4KP2VEjhCvLCNqbNRQC8BgGWgLKNCO7a9K9LI+TVT7Gfoloje502sEnctibffgg==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.6.tgz",
+      "integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
       "dev": true,
       "requires": {
         "dargs": "4.1.0",
@@ -6203,6 +6192,31 @@
         "meow": "4.0.1",
         "split2": "2.2.0",
         "through2": "2.0.5"
+      },
+      "dependencies": {
+        "meow": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+          "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+          "dev": true,
+          "requires": {
+            "camelcase-keys": "4.2.0",
+            "decamelize-keys": "1.1.0",
+            "loud-rejection": "1.6.0",
+            "minimist": "1.2.0",
+            "minimist-options": "3.0.2",
+            "normalize-package-data": "2.5.0",
+            "read-pkg-up": "3.0.0",
+            "redent": "2.0.0",
+            "trim-newlines": "2.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
       }
     },
     "git-remote-origin-url": {
@@ -6258,6 +6272,31 @@
       "requires": {
         "meow": "4.0.1",
         "semver": "5.6.0"
+      },
+      "dependencies": {
+        "meow": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+          "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+          "dev": true,
+          "requires": {
+            "camelcase-keys": "4.2.0",
+            "decamelize-keys": "1.1.0",
+            "loud-rejection": "1.6.0",
+            "minimist": "1.2.0",
+            "minimist-options": "3.0.2",
+            "normalize-package-data": "2.5.0",
+            "read-pkg-up": "3.0.0",
+            "redent": "2.0.0",
+            "trim-newlines": "2.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
       }
     },
     "gitconfiglocal": {
@@ -6327,7 +6366,7 @@
       "dev": true,
       "requires": {
         "expand-tilde": "2.0.2",
-        "homedir-polyfill": "1.0.1",
+        "homedir-polyfill": "1.0.3",
         "ini": "1.3.5",
         "is-windows": "1.0.2",
         "which": "1.3.1"
@@ -6417,7 +6456,7 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "requires": {
-        "ajv": "6.9.1",
+        "ajv": "6.10.0",
         "har-schema": "2.0.0"
       }
     },
@@ -6527,9 +6566,9 @@
       "dev": true
     },
     "homedir-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
-      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
       "dev": true,
       "requires": {
         "parse-passwd": "1.0.0"
@@ -6557,7 +6596,7 @@
         "domutils": "1.5.1",
         "entities": "1.1.2",
         "inherits": "2.0.3",
-        "readable-stream": "3.1.1"
+        "readable-stream": "3.2.0"
       }
     },
     "http-signature": {
@@ -6671,9 +6710,28 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w=="
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            }
+          }
         },
         "strip-ansi": {
           "version": "5.0.0",
@@ -6681,6 +6739,13 @@
           "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
           "requires": {
             "ansi-regex": "4.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+              "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w=="
+            }
           }
         }
       }
@@ -7082,11 +7147,11 @@
       "integrity": "sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==",
       "dev": true,
       "requires": {
-        "@babel/generator": "7.3.3",
-        "@babel/parser": "7.3.3",
+        "@babel/generator": "7.3.4",
+        "@babel/parser": "7.3.4",
         "@babel/template": "7.2.2",
-        "@babel/traverse": "7.2.3",
-        "@babel/types": "7.3.3",
+        "@babel/traverse": "7.3.4",
+        "@babel/types": "7.3.4",
         "istanbul-lib-coverage": "2.0.3",
         "semver": "5.6.0"
       }
@@ -7122,9 +7187,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
+      "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
       "requires": {
         "argparse": "1.0.10",
         "esprima": "4.0.1"
@@ -7270,7 +7335,7 @@
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.6.1.tgz",
       "integrity": "sha1-uI86ey5noqBIFSmCx6N1bZxIKPA=",
       "requires": {
-        "pako": "1.0.8"
+        "pako": "1.0.10"
       }
     },
     "just-extend": {
@@ -7280,12 +7345,12 @@
       "dev": true
     },
     "jwa": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.2.0.tgz",
-      "integrity": "sha512-Grku9ZST5NNQ3hqNUodSkDfEBqAmGA1R8yiyPHOnLzEKI0GaCQC/XhFmsheXYuXzFQJdILbh+lYBiliqG5R/Vg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.0.tgz",
+      "integrity": "sha512-mt6IHaq0ZZWDBspg0Pheu3r9sVNMEZn+GJe1zcdYyhFcDSclp3J8xEdO4PjZolZ2i8xlaVU1LetHM0nJejYsEw==",
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.10",
+        "ecdsa-sig-formatter": "1.0.11",
         "safe-buffer": "5.1.2"
       }
     },
@@ -7294,7 +7359,7 @@
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.1.tgz",
       "integrity": "sha512-bGA2omSrFUkd72dhh05bIAN832znP4wOU3lfuXtRBuGTbsmNmDXMQg28f0Vsxaxgk4myF5YkKQpz6qeRpMgX9g==",
       "requires": {
-        "jwa": "1.2.0",
+        "jwa": "1.4.0",
         "safe-buffer": "5.1.2"
       }
     },
@@ -7367,42 +7432,15 @@
       }
     },
     "load-json-file": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.15",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
-      },
-      "dependencies": {
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.2"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
-        }
+        "parse-json": "4.0.0",
+        "pify": "3.0.0",
+        "strip-bom": "3.0.0"
       }
     },
     "loader-runner": {
@@ -7685,111 +7723,35 @@
       }
     },
     "meow": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
-      "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
+      "integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
       "dev": true,
       "requires": {
         "camelcase-keys": "4.2.0",
         "decamelize-keys": "1.1.0",
         "loud-rejection": "1.6.0",
-        "minimist": "1.2.0",
         "minimist-options": "3.0.2",
         "normalize-package-data": "2.5.0",
         "read-pkg-up": "3.0.0",
         "redent": "2.0.0",
-        "trim-newlines": "2.0.0"
+        "trim-newlines": "2.0.0",
+        "yargs-parser": "10.1.0"
       },
       "dependencies": {
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "2.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.15",
-            "parse-json": "4.0.0",
-            "pify": "3.0.0",
-            "strip-bom": "3.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "2.0.0",
-            "path-exists": "3.0.0"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
         },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+        "yargs-parser": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
           "dev": true,
           "requires": {
-            "p-try": "1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "dev": true,
-          "requires": {
-            "p-limit": "1.3.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-          "dev": true
-        },
-        "path-type": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-          "dev": true,
-          "requires": {
-            "pify": "3.0.0"
-          }
-        },
-        "read-pkg": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "4.0.0",
-            "normalize-package-data": "2.5.0",
-            "path-type": "3.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-          "dev": true,
-          "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "3.0.0"
+            "camelcase": "4.1.0"
           }
         }
       }
@@ -7959,6 +7921,12 @@
         "yargs-unparser": "1.5.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
         "debug": {
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -7980,6 +7948,12 @@
           "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
           "dev": true
         },
+        "get-caller-file": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+          "dev": true
+        },
         "js-yaml": {
           "version": "3.12.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
@@ -7995,6 +7969,31 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
         },
         "supports-color": {
           "version": "6.0.0",
@@ -8023,6 +8022,16 @@
             "which-module": "2.0.0",
             "y18n": "4.0.0",
             "yargs-parser": "11.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "5.2.0",
+            "decamelize": "1.2.0"
           }
         }
       }
@@ -8067,13 +8076,6 @@
         "array-union": "1.0.2",
         "arrify": "1.0.1",
         "minimatch": "3.0.4"
-      },
-      "dependencies": {
-        "array-differ": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-2.1.0.tgz",
-          "integrity": "sha512-KbUpJgx909ZscOc/7CLATBFam7P1Z1QRQInvgT0UztM9Q72aGKCunKASAl7WNW0tnPmPyEMeMhdsfWhfmW037w=="
-        }
       }
     },
     "mute-stream": {
@@ -8187,7 +8189,7 @@
       "integrity": "sha512-sa0RRbj53dovjc7wombHmVli9ZihXbXCQ2uH3TNm03DyvOSIQbxg+pbqDKrk2oxMK1rtLGVlKxcB9rrc6X5YjA==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "3.1.0",
+        "@sinonjs/formatio": "3.2.1",
         "@sinonjs/text-encoding": "0.7.1",
         "just-extend": "4.0.2",
         "lolex": "2.7.5",
@@ -8311,9 +8313,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.7.tgz",
-      "integrity": "sha512-bKdrwaqJUPHqlCzDD7so/R+Nk0jGv9a11ZhLrD9f6i947qGLrGAhU3OxRENa19QQmwzGy/g6zCDEuLGDO8HPvA==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.9.tgz",
+      "integrity": "sha512-oic3GT4OtbWWKfRolz5Syw0Xus0KRFxeorLNj0s93ofX6PWyuzKjsiGxsCtWktBwwmTF6DdRRf2KreGqeOk5KA==",
       "dev": true,
       "requires": {
         "semver": "5.6.0"
@@ -9609,9 +9611,9 @@
       "integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg=="
     },
     "p-limit": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
-      "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+      "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
       "requires": {
         "p-try": "2.0.0"
       }
@@ -9621,7 +9623,7 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "requires": {
-        "p-limit": "2.1.0"
+        "p-limit": "2.2.0"
       }
     },
     "p-try": {
@@ -9641,9 +9643,9 @@
       }
     },
     "pako": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.8.tgz",
-      "integrity": "sha512-6i0HVbUfcKaTv+EG8ZTr75az7GFXcLYk9UyLEg7Notv/Ma+z/UG3TCoz6GiNeOrn1E/e63I0X/Hpw18jHOTUnA=="
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
+      "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw=="
     },
     "parallel-transform": {
       "version": "1.1.0",
@@ -9705,9 +9707,9 @@
       }
     },
     "parse-entities": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.0.tgz",
-      "integrity": "sha512-XXtDdOPLSB0sHecbEapQi6/58U/ODj/KWfIXmmMCJF/eRn8laX6LZbOyioMoETOOJoWRW8/qTSl5VQkUIfKM5g==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.1.tgz",
+      "integrity": "sha512-NBWYLQm1KSoDKk7GAHyioLTvCZ5QjdH/ASBBQTD3iLiAWJXS5bg1jEWI8nIJ+vgVvsceBVBcDGRWSo0KVQBvvg==",
       "dev": true,
       "requires": {
         "character-entities": "1.2.2",
@@ -9744,7 +9746,7 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
       "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
       "requires": {
-        "@types/node": "11.9.4"
+        "@types/node": "11.10.4"
       }
     },
     "pascalcase": {
@@ -9806,22 +9808,12 @@
       }
     },
     "path-type": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.15",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        }
+        "pify": "3.0.0"
       }
     },
     "pathval": {
@@ -10101,7 +10093,7 @@
         "browserify-rsa": "4.0.1",
         "create-hash": "1.2.0",
         "parse-asn1": "5.1.4",
-        "randombytes": "2.0.6",
+        "randombytes": "2.1.0",
         "safe-buffer": "5.1.2"
       }
     },
@@ -10177,9 +10169,9 @@
       "dev": true
     },
     "randombytes": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
-      "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
       "requires": {
         "safe-buffer": "5.1.2"
@@ -10191,7 +10183,7 @@
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dev": true,
       "requires": {
-        "randombytes": "2.0.6",
+        "randombytes": "2.1.0",
         "safe-buffer": "5.1.2"
       }
     },
@@ -10214,51 +10206,75 @@
       }
     },
     "read-pkg": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
       "dev": true,
       "requires": {
-        "load-json-file": "1.1.0",
+        "load-json-file": "4.0.0",
         "normalize-package-data": "2.5.0",
-        "path-type": "1.1.0"
+        "path-type": "3.0.0"
       }
     },
     "read-pkg-up": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+      "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "find-up": "2.1.0",
+        "read-pkg": "3.0.0"
       },
       "dependencies": {
         "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "locate-path": "2.0.0"
           }
         },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
           }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "1.3.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
         }
       }
     },
     "readable-stream": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
-      "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
+      "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
       "requires": {
         "inherits": "2.0.3",
         "string_decoder": "1.2.0",
@@ -10349,9 +10365,9 @@
       "dev": true
     },
     "regenerate-unicode-properties": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz",
-      "integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.0.1.tgz",
+      "integrity": "sha512-HTjMafphaH5d5QDHuwW8Me6Hbc/GhXg8luNqTkPVwZ/oCZhnoifjWhGYsu2BzepMELTlbnoVcXvV0f+2uDDvoQ==",
       "dev": true,
       "requires": {
         "regenerate": "1.4.0"
@@ -10361,6 +10377,15 @@
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
       "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+    },
+    "regenerator-transform": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.4.tgz",
+      "integrity": "sha512-T0QMBjK3J0MtxjPmdIMXm72Wvj2Abb0Bd4HADdfijwMdoIsyQZ6fWC7kDFhk2YinBBEMZDL7Y7wh0J1sGx3S4A==",
+      "dev": true,
+      "requires": {
+        "private": "0.1.8"
+      }
     },
     "regex-not": {
       "version": "1.0.2",
@@ -10372,9 +10397,9 @@
       }
     },
     "regexp-tree": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.4.tgz",
-      "integrity": "sha512-DohP6WXzgrc7gFs9GsTQgigUfMXZqXkPk+20qkMF6YCy0Qk0FsHL1/KtxTycGR/62DHRtJ1MHQF2g8YzywP4kA==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.5.tgz",
+      "integrity": "sha512-nUmxvfJyAODw+0B13hj8CFVAxhe7fDEAgJgaotBu3nnR+IgGgZq59YedJP5VYTlkEfqjuK6TuRpnymKdatLZfQ==",
       "dev": true
     },
     "regexpp": {
@@ -10383,17 +10408,17 @@
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw=="
     },
     "regexpu-core": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.4.0.tgz",
-      "integrity": "sha512-eDDWElbwwI3K0Lo6CqbQbA6FwgtCz4kYTarrri1okfkRLZAqstU+B3voZBCjg8Fl6iq0gXrJG6MvRgLthfvgOA==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.3.tgz",
+      "integrity": "sha512-LON8666bTAlViVEPXMv65ZqiaR3rMNLz36PIaQ7D+er5snu93k0peR7FSvO0QteYbZ3GOkvfHKbGr/B1xDu9FA==",
       "dev": true,
       "requires": {
         "regenerate": "1.4.0",
-        "regenerate-unicode-properties": "7.0.0",
+        "regenerate-unicode-properties": "8.0.1",
         "regjsgen": "0.5.0",
         "regjsparser": "0.6.0",
         "unicode-match-property-ecmascript": "1.0.4",
-        "unicode-match-property-value-ecmascript": "1.0.2"
+        "unicode-match-property-value-ecmascript": "1.1.0"
       }
     },
     "registry-auth-token": {
@@ -10436,6 +10461,15 @@
         }
       }
     },
+    "relaxed-json": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/relaxed-json/-/relaxed-json-1.0.3.tgz",
+      "integrity": "sha512-b7wGPo7o2KE/g7SqkJDDbav6zmrEeP4TK2VpITU72J/M949TLe/23y/ZHJo+pskcGM52xIfFoT9hydwmgr1AEg==",
+      "requires": {
+        "chalk": "2.4.2",
+        "commander": "2.19.0"
+      }
+    },
     "remark-frontmatter": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-1.3.1.tgz",
@@ -10458,7 +10492,7 @@
         "is-whitespace-character": "1.0.2",
         "is-word-character": "1.0.2",
         "markdown-escapes": "1.0.2",
-        "parse-entities": "1.2.0",
+        "parse-entities": "1.2.1",
         "repeat-string": "1.6.1",
         "state-toggle": "1.0.1",
         "trim": "0.0.1",
@@ -10538,10 +10572,9 @@
       "dev": true
     },
     "require-main-filename": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "require-uncached": {
       "version": "2.0.0",
@@ -10693,7 +10726,7 @@
       "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
       "dev": true,
       "requires": {
-        "ajv": "6.9.1",
+        "ajv": "6.10.0",
         "ajv-errors": "1.0.1",
         "ajv-keywords": "3.4.0"
       },
@@ -10844,6 +10877,19 @@
           "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.0.0.tgz",
           "integrity": "sha1-8JTHBB9mJZm7EnINoFnWucf/D0A="
         },
+        "es6-promise": {
+          "version": "4.2.6",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
+          "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q=="
+        },
+        "es6-promisify": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+          "requires": {
+            "es6-promise": "4.2.6"
+          }
+        },
         "fast-deep-equal": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
@@ -10944,45 +10990,13 @@
       "integrity": "sha512-rlrre9F80pIQr3M36gOdoCEWzFAMDgHYD8+tocqOw+Zw9OZ8F84a80Ds69eZfcjnzDqqG88ulFld0oin/6rG/g==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "1.3.1",
+        "@sinonjs/commons": "1.4.0",
         "@sinonjs/formatio": "3.2.1",
         "@sinonjs/samsam": "3.2.0",
         "diff": "3.5.0",
         "lolex": "3.1.0",
         "nise": "1.4.10",
         "supports-color": "5.5.0"
-      },
-      "dependencies": {
-        "@sinonjs/commons": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.1.tgz",
-          "integrity": "sha512-rgmZk5CrBGAMATk0HlHOFvo8V44/r+On6cKS80tqid0Eljd+fFBWBOXZp9H2/EB3faxdNdzXTx6QZIKLkbJ7mA==",
-          "dev": true,
-          "requires": {
-            "type-detect": "4.0.8"
-          }
-        },
-        "@sinonjs/formatio": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
-          "integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
-          "dev": true,
-          "requires": {
-            "@sinonjs/commons": "1.3.1",
-            "@sinonjs/samsam": "3.2.0"
-          }
-        },
-        "@sinonjs/samsam": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.2.0.tgz",
-          "integrity": "sha512-j5F1rScewLtx6pbTK0UAjA3jJj4RYiSKOix53YWv+Jzy/AZ69qHxUpU8fwVLjyKbEEud9QrLpv6Ggs7WqTimYw==",
-          "dev": true,
-          "requires": {
-            "@sinonjs/commons": "1.3.1",
-            "array-from": "2.1.1",
-            "lodash": "4.17.11"
-          }
-        }
       }
     },
     "slice-ansi": {
@@ -11399,25 +11413,26 @@
       }
     },
     "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.0.0.tgz",
+      "integrity": "sha512-rr8CUxBbvOZDUvc5lNIJ+OC1nPVpz+Siw9VBtUjB9b6jZehZLFt0JMCZzShFHIsI8cbhm0EsNIfWJMFV3cu3Ew==",
       "requires": {
+        "emoji-regex": "7.0.3",
         "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "strip-ansi": "5.0.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w=="
         },
         "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "4.0.0"
           }
         }
       }
@@ -11498,35 +11513,10 @@
       "resolved": "https://registry.npmjs.org/table/-/table-5.2.3.tgz",
       "integrity": "sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==",
       "requires": {
-        "ajv": "6.9.1",
+        "ajv": "6.10.0",
         "lodash": "4.17.11",
         "slice-ansi": "2.1.0",
         "string-width": "3.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w=="
-        },
-        "string-width": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.0.0.tgz",
-          "integrity": "sha512-rr8CUxBbvOZDUvc5lNIJ+OC1nPVpz+Siw9VBtUjB9b6jZehZLFt0JMCZzShFHIsI8cbhm0EsNIfWJMFV3cu3Ew==",
-          "requires": {
-            "emoji-regex": "7.0.3",
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "5.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
-          "requires": {
-            "ansi-regex": "4.0.0"
-          }
-        }
       }
     },
     "tapable": {
@@ -11646,23 +11636,13 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
           "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
           "dev": true
-        },
-        "source-map-support": {
-          "version": "0.5.10",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
-          "integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
-          "dev": true,
-          "requires": {
-            "buffer-from": "1.1.1",
-            "source-map": "0.6.1"
-          }
         }
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.2.tgz",
-      "integrity": "sha512-1DMkTk286BzmfylAvLXwpJrI7dWa5BnFmscV/2dCr8+c56egFcbaeFAl7+sujAjdmpLam21XRdhA4oifLyiWWg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.3.tgz",
+      "integrity": "sha512-GOK7q85oAb/5kE12fMuLdn2btOS9OBZn4VsecpHDywoUC/jLhSAKOiYo0ezx7ss2EXPMzyEWFoE0s1WLE+4+oA==",
       "dev": true,
       "requires": {
         "cacache": "11.3.2",
@@ -11709,38 +11689,6 @@
         "require-main-filename": "1.0.1"
       },
       "dependencies": {
-        "load-json-file": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.15",
-            "parse-json": "4.0.0",
-            "pify": "3.0.0",
-            "strip-bom": "3.0.0"
-          }
-        },
-        "path-type": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-          "dev": true,
-          "requires": {
-            "pify": "3.0.0"
-          }
-        },
-        "read-pkg": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "4.0.0",
-            "normalize-package-data": "2.5.0",
-            "path-type": "3.0.0"
-          }
-        },
         "read-pkg-up": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
@@ -11750,6 +11698,12 @@
             "find-up": "3.0.0",
             "read-pkg": "3.0.0"
           }
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "dev": true
         }
       }
     },
@@ -12059,19 +12013,19 @@
       "dev": true,
       "requires": {
         "unicode-canonical-property-names-ecmascript": "1.0.4",
-        "unicode-property-aliases-ecmascript": "1.0.4"
+        "unicode-property-aliases-ecmascript": "1.0.5"
       }
     },
     "unicode-match-property-value-ecmascript": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz",
-      "integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
+      "integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
       "dev": true
     },
     "unicode-property-aliases-ecmascript": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
-      "integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
+      "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
       "dev": true
     },
     "unified": {
@@ -12401,7 +12355,7 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
       "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
       "requires": {
-        "chokidar": "2.1.1",
+        "chokidar": "2.1.2",
         "graceful-fs": "4.1.15",
         "neo-async": "2.6.0"
       }
@@ -12429,13 +12383,13 @@
         "@webassemblyjs/helper-module-context": "1.8.5",
         "@webassemblyjs/wasm-edit": "1.8.5",
         "@webassemblyjs/wasm-parser": "1.8.5",
-        "acorn": "6.1.0",
+        "acorn": "6.1.1",
         "acorn-dynamic-import": "4.0.0",
-        "ajv": "6.9.1",
+        "ajv": "6.10.0",
         "ajv-keywords": "3.4.0",
         "chrome-trace-event": "1.0.0",
         "enhanced-resolve": "4.1.0",
-        "eslint-scope": "4.0.0",
+        "eslint-scope": "4.0.2",
         "json-parse-better-errors": "1.0.2",
         "loader-runner": "2.4.0",
         "loader-utils": "1.2.3",
@@ -12446,187 +12400,11 @@
         "node-libs-browser": "2.2.0",
         "schema-utils": "1.0.0",
         "tapable": "1.1.1",
-        "terser-webpack-plugin": "1.2.2",
+        "terser-webpack-plugin": "1.2.3",
         "watchpack": "1.6.0",
         "webpack-sources": "1.3.0"
       },
       "dependencies": {
-        "@webassemblyjs/ast": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
-          "integrity": "sha512-aJMfngIZ65+t71C3y2nBBg5FFG0Okt9m0XEgWZ7Ywgn1oMAT8cNwx00Uv1cQyHtidq0Xn94R4TAywO+LCQ+ZAQ==",
-          "dev": true,
-          "requires": {
-            "@webassemblyjs/helper-module-context": "1.8.5",
-            "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-            "@webassemblyjs/wast-parser": "1.8.5"
-          }
-        },
-        "@webassemblyjs/floating-point-hex-parser": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz",
-          "integrity": "sha512-9p+79WHru1oqBh9ewP9zW95E3XAo+90oth7S5Re3eQnECGq59ly1Ri5tsIipKGpiStHsUYmY3zMLqtk3gTcOtQ==",
-          "dev": true
-        },
-        "@webassemblyjs/helper-api-error": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz",
-          "integrity": "sha512-Za/tnzsvnqdaSPOUXHyKJ2XI7PDX64kWtURyGiJJZKVEdFOsdKUCPTNEVFZq3zJ2R0G5wc2PZ5gvdTRFgm81zA==",
-          "dev": true
-        },
-        "@webassemblyjs/helper-buffer": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz",
-          "integrity": "sha512-Ri2R8nOS0U6G49Q86goFIPNgjyl6+oE1abW1pS84BuhP1Qcr5JqMwRFT3Ah3ADDDYGEgGs1iyb1DGX+kAi/c/Q==",
-          "dev": true
-        },
-        "@webassemblyjs/helper-code-frame": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz",
-          "integrity": "sha512-VQAadSubZIhNpH46IR3yWO4kZZjMxN1opDrzePLdVKAZ+DFjkGD/rf4v1jap744uPVU6yjL/smZbRIIJTOUnKQ==",
-          "dev": true,
-          "requires": {
-            "@webassemblyjs/wast-printer": "1.8.5"
-          }
-        },
-        "@webassemblyjs/helper-fsm": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz",
-          "integrity": "sha512-kRuX/saORcg8se/ft6Q2UbRpZwP4y7YrWsLXPbbmtepKr22i8Z4O3V5QE9DbZK908dh5Xya4Un57SDIKwB9eow==",
-          "dev": true
-        },
-        "@webassemblyjs/helper-module-context": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz",
-          "integrity": "sha512-/O1B236mN7UNEU4t9X7Pj38i4VoU8CcMHyy3l2cV/kIF4U5KoHXDVqcDuOs1ltkac90IM4vZdHc52t1x8Yfs3g==",
-          "dev": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "mamacro": "0.0.3"
-          }
-        },
-        "@webassemblyjs/helper-wasm-bytecode": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz",
-          "integrity": "sha512-Cu4YMYG3Ddl72CbmpjU/wbP6SACcOPVbHN1dI4VJNJVgFwaKf1ppeFJrwydOG3NDHxVGuCfPlLZNyEdIYlQ6QQ==",
-          "dev": true
-        },
-        "@webassemblyjs/helper-wasm-section": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz",
-          "integrity": "sha512-VV083zwR+VTrIWWtgIUpqfvVdK4ff38loRmrdDBgBT8ADXYsEZ5mPQ4Nde90N3UYatHdYoDIFb7oHzMncI02tA==",
-          "dev": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "@webassemblyjs/helper-buffer": "1.8.5",
-            "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-            "@webassemblyjs/wasm-gen": "1.8.5"
-          }
-        },
-        "@webassemblyjs/ieee754": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz",
-          "integrity": "sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==",
-          "dev": true,
-          "requires": {
-            "@xtuc/ieee754": "1.2.0"
-          }
-        },
-        "@webassemblyjs/leb128": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.8.5.tgz",
-          "integrity": "sha512-plYUuUwleLIziknvlP8VpTgO4kqNaH57Y3JnNa6DLpu/sGcP6hbVdfdX5aHAV716pQBKrfuU26BJK29qY37J7A==",
-          "dev": true,
-          "requires": {
-            "@xtuc/long": "4.2.2"
-          }
-        },
-        "@webassemblyjs/utf8": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.8.5.tgz",
-          "integrity": "sha512-U7zgftmQriw37tfD934UNInokz6yTmn29inT2cAetAsaU9YeVCveWEwhKL1Mg4yS7q//NGdzy79nlXh3bT8Kjw==",
-          "dev": true
-        },
-        "@webassemblyjs/wasm-edit": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz",
-          "integrity": "sha512-A41EMy8MWw5yvqj7MQzkDjU29K7UJq1VrX2vWLzfpRHt3ISftOXqrtojn7nlPsZ9Ijhp5NwuODuycSvfAO/26Q==",
-          "dev": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "@webassemblyjs/helper-buffer": "1.8.5",
-            "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-            "@webassemblyjs/helper-wasm-section": "1.8.5",
-            "@webassemblyjs/wasm-gen": "1.8.5",
-            "@webassemblyjs/wasm-opt": "1.8.5",
-            "@webassemblyjs/wasm-parser": "1.8.5",
-            "@webassemblyjs/wast-printer": "1.8.5"
-          }
-        },
-        "@webassemblyjs/wasm-gen": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz",
-          "integrity": "sha512-BCZBT0LURC0CXDzj5FXSc2FPTsxwp3nWcqXQdOZE4U7h7i8FqtFK5Egia6f9raQLpEKT1VL7zr4r3+QX6zArWg==",
-          "dev": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-            "@webassemblyjs/ieee754": "1.8.5",
-            "@webassemblyjs/leb128": "1.8.5",
-            "@webassemblyjs/utf8": "1.8.5"
-          }
-        },
-        "@webassemblyjs/wasm-opt": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz",
-          "integrity": "sha512-HKo2mO/Uh9A6ojzu7cjslGaHaUU14LdLbGEKqTR7PBKwT6LdPtLLh9fPY33rmr5wcOMrsWDbbdCHq4hQUdd37Q==",
-          "dev": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "@webassemblyjs/helper-buffer": "1.8.5",
-            "@webassemblyjs/wasm-gen": "1.8.5",
-            "@webassemblyjs/wasm-parser": "1.8.5"
-          }
-        },
-        "@webassemblyjs/wasm-parser": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz",
-          "integrity": "sha512-pi0SYE9T6tfcMkthwcgCpL0cM9nRYr6/6fjgDtL6q/ZqKHdMWvxitRi5JcZ7RI4SNJJYnYNaWy5UUrHQy998lw==",
-          "dev": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "@webassemblyjs/helper-api-error": "1.8.5",
-            "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-            "@webassemblyjs/ieee754": "1.8.5",
-            "@webassemblyjs/leb128": "1.8.5",
-            "@webassemblyjs/utf8": "1.8.5"
-          }
-        },
-        "@webassemblyjs/wast-parser": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz",
-          "integrity": "sha512-daXC1FyKWHF1i11obK086QRlsMsY4+tIOKgBqI1lxAnkp9xe9YMcgOxm9kLe+ttjs5aWV2KKE1TWJCN57/Btsg==",
-          "dev": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "@webassemblyjs/floating-point-hex-parser": "1.8.5",
-            "@webassemblyjs/helper-api-error": "1.8.5",
-            "@webassemblyjs/helper-code-frame": "1.8.5",
-            "@webassemblyjs/helper-fsm": "1.8.5",
-            "@xtuc/long": "4.2.2"
-          }
-        },
-        "@webassemblyjs/wast-printer": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz",
-          "integrity": "sha512-w0U0pD4EhlnvRyeJzBqaVSJAo9w/ce7/WPogeXLzGkO6hzhr4GnQIZ4W4uUt5b9ooAaXPtnXlj0gzsXEOUNYMg==",
-          "dev": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "@webassemblyjs/wast-parser": "1.8.5",
-            "@xtuc/long": "4.2.2"
-          }
-        },
         "ajv-keywords": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
@@ -12680,6 +12458,33 @@
       "dev": true,
       "requires": {
         "string-width": "2.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
       }
     },
     "widest-line": {
@@ -12688,6 +12493,30 @@
       "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
       "requires": {
         "string-width": "2.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
       }
     },
     "winreg": {
@@ -12744,9 +12573,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
       "requires": {
         "mkdirp": "0.5.1"
       }
@@ -12791,6 +12620,14 @@
       "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
       "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
     },
+    "xregexp": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.2.4.tgz",
+      "integrity": "sha512-sO0bYdYeJAJBcJA8g7MJJX7UrOZIfJPd8U2SC7B2Dd/J24U0aQNoGp33shCaBSWeb0rD5rh6VBUIXOkGal1TZA==",
+      "requires": {
+        "@babel/runtime-corejs2": "7.3.4"
+      }
+    },
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
@@ -12822,78 +12659,21 @@
         "which-module": "2.0.0",
         "y18n": "4.0.0",
         "yargs-parser": "13.0.0"
+      }
+    },
+    "yargs-parser": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.0.0.tgz",
+      "integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
+      "requires": {
+        "camelcase": "5.2.0",
+        "decamelize": "1.2.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w=="
-        },
         "decamelize": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
           "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
-        },
-        "get-caller-file": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.1.tgz",
-          "integrity": "sha512-SpOZHfz845AH0wJYVuZk2jWDqFmu7Xubsx+ldIpwzy5pDUpu7OJHK7QYNSA2NPlDSKQwM1GFaAkciOWjjW92Sg=="
-        },
-        "require-main-filename": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
-        },
-        "string-width": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.0.0.tgz",
-          "integrity": "sha512-rr8CUxBbvOZDUvc5lNIJ+OC1nPVpz+Siw9VBtUjB9b6jZehZLFt0JMCZzShFHIsI8cbhm0EsNIfWJMFV3cu3Ew==",
-          "requires": {
-            "emoji-regex": "7.0.3",
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "5.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
-          "requires": {
-            "ansi-regex": "4.0.0"
-          }
-        },
-        "yargs-parser": {
-          "version": "13.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.0.0.tgz",
-          "integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
-          "requires": {
-            "camelcase": "5.2.0",
-            "decamelize": "1.2.0"
-          }
-        }
-      }
-    },
-    "yargs-parser": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-      "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
-      "dev": true,
-      "requires": {
-        "camelcase": "5.0.0",
-        "decamelize": "1.2.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
-          "dev": true
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-          "dev": true
         }
       }
     },
@@ -12908,11 +12688,48 @@
         "yargs": "12.0.5"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
         "decamelize": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
           "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "dev": true
+        },
+        "get-caller-file": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
         },
         "yargs": {
           "version": "12.0.5",
@@ -12932,6 +12749,16 @@
             "which-module": "2.0.0",
             "y18n": "4.0.0",
             "yargs-parser": "11.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "5.2.0",
+            "decamelize": "1.2.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "debounce": "1.2.0",
     "decamelize": "3.0.0",
     "es6-error": "4.1.1",
-    "es6-promisify": "5.0.0",
     "event-to-promise": "0.8.0",
     "firefox-profile": "1.2.0",
     "fx-runner": "1.0.10",

--- a/src/firefox/index.js
+++ b/src/firefox/index.js
@@ -6,9 +6,9 @@ import {default as defaultFxRunner} from 'fx-runner';
 import FirefoxProfile, {copyFromUserProfile as defaultUserProfileCopier}
   from 'firefox-profile';
 import {fs} from 'mz';
-import promisify from 'es6-promisify';
 import eventToPromise from 'event-to-promise';
 
+import promisify from '../util/promisify';
 import isDirectory from '../util/is-directory';
 import {isErrorWithCode, UsageError, WebExtError} from '../errors';
 import {getPrefs as defaultPrefGetter} from './preferences';

--- a/src/firefox/index.js
+++ b/src/firefox/index.js
@@ -1,6 +1,7 @@
 /* @flow */
 import nodeFs from 'fs';
 import path from 'path';
+import {promisify} from 'util';
 
 import {default as defaultFxRunner} from 'fx-runner';
 import FirefoxProfile, {copyFromUserProfile as defaultUserProfileCopier}
@@ -8,7 +9,6 @@ import FirefoxProfile, {copyFromUserProfile as defaultUserProfileCopier}
 import {fs} from 'mz';
 import eventToPromise from 'event-to-promise';
 
-import promisify from '../util/promisify';
 import isDirectory from '../util/is-directory';
 import {isErrorWithCode, UsageError, WebExtError} from '../errors';
 import {getPrefs as defaultPrefGetter} from './preferences';
@@ -238,7 +238,7 @@ export async function isDefaultProfile(
 
   // Check for profile dir path.
   const finder = new ProfileFinder(baseProfileDir);
-  const readProfiles = promisify(finder.readProfiles, finder);
+  const readProfiles = promisify(finder.readProfiles.bind(finder));
 
   await readProfiles();
 
@@ -333,8 +333,8 @@ export function defaultCreateProfileFinder(
   }: CreateProfileFinderParams = {}
 ): getProfileFn {
   const finder = new FxProfile.Finder(userDirectoryPath);
-  const readProfiles = promisify(finder.readProfiles, finder);
-  const getPath = promisify(finder.getPath, finder);
+  const readProfiles = promisify(finder.readProfiles.bind(finder));
+  const getPath = promisify(finder.getPath.bind(finder));
   return async (profileName: string): Promise<string | void> => {
     try {
       await readProfiles();

--- a/src/util/artifacts.js
+++ b/src/util/artifacts.js
@@ -1,8 +1,9 @@
 /* @flow */
+import {promisify} from 'util';
+
 import {fs} from 'mz';
 import mkdirp from 'mkdirp';
 
-import promisify from './promisify';
 import {UsageError, isErrorWithCode} from '../errors';
 import {createLogger} from './logger';
 

--- a/src/util/artifacts.js
+++ b/src/util/artifacts.js
@@ -1,8 +1,8 @@
 /* @flow */
 import {fs} from 'mz';
 import mkdirp from 'mkdirp';
-import promisify from 'es6-promisify';
 
+import promisify from './promisify';
 import {UsageError, isErrorWithCode} from '../errors';
 import {createLogger} from './logger';
 

--- a/src/util/promisify.js
+++ b/src/util/promisify.js
@@ -1,14 +1,16 @@
 /* @flow */
 
-// A small promisify helper to make it easier to customize a
-// function promisified (using the 'util' module available in
-// nodejs >= 8) to resolve to an array of results:
-//
-//    import {promisify} from 'util';
-//    import {multiArgsPromisedFn} from '../util/promisify';
-//
-//    aCallbackBasedFn[promisify.custom] = multiArgsPromisedFn(tmp.dir);
-//    ...
+/*
+ * A small promisify helper to make it easier to customize a
+ * function promisified (using the 'util' module available in
+ * nodejs >= 8) to resolve to an array of results:
+ *
+ *    import {promisify} from 'util';
+ *    import {multiArgsPromisedFn} from '../util/promisify';
+ *
+ *    aCallbackBasedFn[promisify.custom] = multiArgsPromisedFn(tmp.dir);
+ *    ...
+ */
 export function multiArgsPromisedFn(fn: Function): Function {
   return (...callerArgs: Array<any>): Promise<any> => {
     return new Promise((resolve, reject) => {

--- a/src/util/promisify.js
+++ b/src/util/promisify.js
@@ -14,17 +14,13 @@
 export function multiArgsPromisedFn(fn: Function): Function {
   return (...callerArgs: Array<any>): Promise<any> => {
     return new Promise((resolve, reject) => {
-      try {
-        fn(...callerArgs, (err, ...rest) => {
-          if (err) {
-            reject(err);
-          } else {
-            resolve(rest);
-          }
-        });
-      } catch (err) {
-        reject(err);
-      }
+      fn(...callerArgs, (err, ...rest) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(rest);
+        }
+      });
     });
   };
 }

--- a/src/util/promisify.js
+++ b/src/util/promisify.js
@@ -31,7 +31,11 @@ export default function(
         }
       }
 
-      fnWithCb(...(callerArgs.concat(cb)));
+      try {
+        fnWithCb(...(callerArgs.concat(cb)));
+      } catch (err) {
+        reject(err);
+      }
     });
   };
 }

--- a/src/util/promisify.js
+++ b/src/util/promisify.js
@@ -1,0 +1,37 @@
+/* @flow */
+
+// promisify helper types and implementation
+
+type PromisifyOptions = {|
+  multiArgs: boolean,
+|};
+
+export default function(
+  fn: Function,
+  bindObject: ?Object = null,
+  options: PromisifyOptions = {multiArgs: false}
+) {
+  let fnWithCb = fn;
+  if (bindObject != null) {
+    fnWithCb = fn.bind(bindObject);
+  }
+
+  return function(...callerArgs: Array<any>): Promise<any> {
+    return new Promise((resolve, reject) => {
+      function cb(err, ...rest) {
+        if (err) {
+          reject(err);
+          return;
+        }
+
+        if (options && options.multiArgs) {
+          resolve(rest);
+        } else {
+          resolve(rest[0]);
+        }
+      }
+
+      fnWithCb(...(callerArgs.concat(cb)));
+    });
+  };
+}

--- a/src/util/temp-dir.js
+++ b/src/util/temp-dir.js
@@ -1,13 +1,16 @@
 /* @flow */
+import {promisify} from 'util';
+
 import tmp from 'tmp';
 
 import {createLogger} from './logger';
-import promisify from './promisify';
+import {multiArgsPromisedFn} from './promisify';
 
 const log = createLogger(__filename);
 
 export type MakePromiseCallback = (tmpDir: TempDir) => any;
 
+tmp.dir[promisify.custom] = multiArgsPromisedFn(tmp.dir);
 
 /*
  * Work with a self-destructing temporary directory in a promise chain.
@@ -63,7 +66,9 @@ export class TempDir {
    * been created.
    */
   create(): Promise<TempDir> {
-    const createTempDir = promisify(tmp.dir, tmp, {multiArgs: true});
+    //const createTempDir = promisify(tmp.dir, tmp, {multiArgs: true});
+    const createTempDir = promisify(tmp.dir);
+
     return createTempDir(
       {
         prefix: 'tmp-web-ext-',

--- a/src/util/temp-dir.js
+++ b/src/util/temp-dir.js
@@ -1,8 +1,8 @@
 /* @flow */
 import tmp from 'tmp';
-import promisify from 'es6-promisify';
 
 import {createLogger} from './logger';
+import promisify from './promisify';
 
 const log = createLogger(__filename);
 
@@ -63,7 +63,7 @@ export class TempDir {
    * been created.
    */
   create(): Promise<TempDir> {
-    const createTempDir = promisify(tmp.dir, {multiArgs: true});
+    const createTempDir = promisify(tmp.dir, tmp, {multiArgs: true});
     return createTempDir(
       {
         prefix: 'tmp-web-ext-',

--- a/src/util/temp-dir.js
+++ b/src/util/temp-dir.js
@@ -74,8 +74,7 @@ export class TempDir {
         // This allows us to remove a non-empty tmp dir.
         unsafeCleanup: true,
       })
-      .then((args) => {
-        const [tmpPath, removeTempDir] = args;
+      .then(([tmpPath, removeTempDir]) => {
         this._path = tmpPath;
         this._removeTempDir = removeTempDir;
         log.debug(`Created temporary directory: ${this.path()}`);

--- a/src/util/temp-dir.js
+++ b/src/util/temp-dir.js
@@ -12,6 +12,8 @@ export type MakePromiseCallback = (tmpDir: TempDir) => any;
 
 tmp.dir[promisify.custom] = multiArgsPromisedFn(tmp.dir);
 
+const createTempDir = promisify(tmp.dir);
+
 /*
  * Work with a self-destructing temporary directory in a promise chain.
  *
@@ -66,9 +68,6 @@ export class TempDir {
    * been created.
    */
   create(): Promise<TempDir> {
-    //const createTempDir = promisify(tmp.dir, tmp, {multiArgs: true});
-    const createTempDir = promisify(tmp.dir);
-
     return createTempDir(
       {
         prefix: 'tmp-web-ext-',

--- a/src/util/zip-dir.js
+++ b/src/util/zip-dir.js
@@ -1,5 +1,6 @@
 /* @flow */
 import zipDirModule from 'zip-dir';
-import promisify from 'es6-promisify';
+
+import promisify from './promisify';
 
 export const zipDir = promisify(zipDirModule);

--- a/src/util/zip-dir.js
+++ b/src/util/zip-dir.js
@@ -1,6 +1,6 @@
 /* @flow */
-import zipDirModule from 'zip-dir';
+import {promisify} from 'util';
 
-import promisify from './promisify';
+import zipDirModule from 'zip-dir';
 
 export const zipDir = promisify(zipDirModule);

--- a/tests/functional/common.js
+++ b/tests/functional/common.js
@@ -3,10 +3,10 @@ import path from 'path';
 import {ChildProcess, spawn} from 'child_process';
 
 import copyDir from 'copy-dir';
-import promisify from 'es6-promisify';
 import prettyjson from 'prettyjson';
 
 import * as tmpDirUtils from '../../src/util/temp-dir';
+import promisify from '../../src/util/promisify';
 
 export const withTempDir = tmpDirUtils.withTempDir;
 

--- a/tests/functional/common.js
+++ b/tests/functional/common.js
@@ -1,12 +1,12 @@
 /* @flow */
 import path from 'path';
 import {ChildProcess, spawn} from 'child_process';
+import {promisify} from 'util';
 
 import copyDir from 'copy-dir';
 import prettyjson from 'prettyjson';
 
 import * as tmpDirUtils from '../../src/util/temp-dir';
-import promisify from '../../src/util/promisify';
 
 export const withTempDir = tmpDirUtils.withTempDir;
 
@@ -36,9 +36,10 @@ export type TempAddonParams = {|
 |};
 
 export type TempAddonCallback =
-  (tmpAddonDir: string, tmpDir: string) => Promise<any>
+  (tmpAddonDir: string, tmpDir: string) => Promise<any>;
 
 const copyDirAsPromised = promisify(copyDir);
+
 export function withTempAddonDir(
   {addonPath}: TempAddonParams,
   makePromise: TempAddonCallback,

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -3,6 +3,7 @@ import path from 'path';
 import EventEmitter from 'events';
 import tty from 'tty';
 import stream from 'stream';
+import {promisify} from 'util';
 
 import deepcopy from 'deepcopy';
 import sinon from 'sinon';
@@ -12,7 +13,6 @@ import ExtendableError from 'es6-error';
 import {createLogger} from '../../src/util/logger';
 import * as defaultFirefoxApp from '../../src/firefox';
 import {RemoteFirefox} from '../../src/firefox/remote';
-import promisify from '../../src/util/promisify';
 
 const log = createLogger(__filename);
 

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -4,14 +4,15 @@ import EventEmitter from 'events';
 import tty from 'tty';
 import stream from 'stream';
 
+import deepcopy from 'deepcopy';
 import sinon from 'sinon';
 import yauzl from 'yauzl';
 import ExtendableError from 'es6-error';
-import promisify from 'es6-promisify';
 
 import {createLogger} from '../../src/util/logger';
 import * as defaultFirefoxApp from '../../src/firefox';
 import {RemoteFirefox} from '../../src/firefox/remote';
+import promisify from '../../src/util/promisify';
 
 const log = createLogger(__filename);
 
@@ -280,7 +281,7 @@ export class ErrorWithCode extends Error {
 }
 
 /*
- * A basic manifest fixture using in unit tests.
+ * A basic manifest fixture used in unit tests.
  */
 export const basicManifest = {
   name: 'the extension',
@@ -291,6 +292,12 @@ export const basicManifest = {
     },
   },
 };
+
+/*
+ * A basic manifest fixture without an applications property.
+ */
+export const manifestWithoutApps = deepcopy(basicManifest);
+delete manifestWithoutApps.applications;
 
 /*
  * A class that implements an empty IExtensionRunner interface.

--- a/tests/unit/test-cmd/test.build.js
+++ b/tests/unit/test-cmd/test.build.js
@@ -18,9 +18,9 @@ import {
   basicManifest,
   fixturePath,
   makeSureItFails,
+  manifestWithoutApps,
   ZipFile,
 } from '../helpers';
-import {manifestWithoutApps} from '../test-util/test.manifest';
 import {UsageError} from '../../../src/errors';
 import {createLogger} from '../../../src/util/logger';
 

--- a/tests/unit/test-cmd/test.sign.js
+++ b/tests/unit/test-cmd/test.sign.js
@@ -1,5 +1,6 @@
 /* @flow */
 import path from 'path';
+import {promisify} from 'util';
 
 import copyDir from 'copy-dir';
 import {fs} from 'mz';
@@ -9,7 +10,6 @@ import sinon from 'sinon';
 
 import {onlyInstancesOf, UsageError, WebExtError} from '../../../src/errors';
 import {getManifestId} from '../../../src/util/manifest';
-import promisify from '../../../src/util/promisify';
 import {withTempDir} from '../../../src/util/temp-dir';
 import completeSignCommand, {
   extensionIdFile, getIdFromSourceDir, saveIdToSourceDir,

--- a/tests/unit/test-cmd/test.sign.js
+++ b/tests/unit/test-cmd/test.sign.js
@@ -6,18 +6,18 @@ import {fs} from 'mz';
 import {describe, it} from 'mocha';
 import {assert} from 'chai';
 import sinon from 'sinon';
-import promisify from 'es6-promisify';
 
 import {onlyInstancesOf, UsageError, WebExtError} from '../../../src/errors';
 import {getManifestId} from '../../../src/util/manifest';
+import promisify from '../../../src/util/promisify';
 import {withTempDir} from '../../../src/util/temp-dir';
-import {manifestWithoutApps} from '../test-util/test.manifest';
 import completeSignCommand, {
   extensionIdFile, getIdFromSourceDir, saveIdToSourceDir,
 } from '../../../src/cmd/sign';
 import {
   basicManifest,
   makeSureItFails,
+  manifestWithoutApps,
   fixturePath,
 } from '../helpers';
 // Import flow type

--- a/tests/unit/test-util/test.manifest.js
+++ b/tests/unit/test-util/test.manifest.js
@@ -9,11 +9,11 @@ import {fs} from 'mz';
 import {onlyInstancesOf, InvalidManifest} from '../../../src/errors';
 import getValidatedManifest, {getManifestId} from '../../../src/util/manifest';
 import {withTempDir} from '../../../src/util/temp-dir';
-import {basicManifest, makeSureItFails} from '../helpers';
-
-
-export const manifestWithoutApps = deepcopy(basicManifest);
-delete manifestWithoutApps.applications;
+import {
+  basicManifest,
+  makeSureItFails,
+  manifestWithoutApps,
+} from '../helpers';
 
 
 describe('util/manifest', () => {

--- a/tests/unit/test-util/test.promisify.js
+++ b/tests/unit/test-util/test.promisify.js
@@ -1,0 +1,81 @@
+/* @flow */
+import {describe, it} from 'mocha';
+import {assert} from 'chai';
+import sinon from 'sinon';
+
+import promisify from '../../../src/util/promisify';
+
+describe('util.promisify', () => {
+  it('wraps a nodejs callback-based function into a promised function',
+     async () => {
+       const expectedParam1 = 'param-value-1';
+       const expectedParam2 = 'param-value-2';
+       const expectedResult = {result: 'value'};
+       const expectedError = new Error('Fake error');
+
+       const fnCallSuccess = sinon.spy(function(param1, param2, cb) {
+         setTimeout(() => cb(undefined, expectedResult), 0);
+       });
+
+       const fnCallFailure = sinon.spy(function(param, cb) {
+         setTimeout(() => cb(expectedError), 0);
+       });
+
+       const fnCallThrow = sinon.spy(function fnCallThrow() {
+         throw expectedError;
+       });
+
+       const promisedFnSuccess = promisify(fnCallSuccess);
+       const promisedFnFailure = promisify(fnCallFailure);
+       const promisedFnThrow = promisify(fnCallThrow);
+
+       // Test successfull promised function call.
+       await assert.becomes(
+         promisedFnSuccess(expectedParam1, expectedParam2),
+         expectedResult);
+       sinon.assert.calledOnce(fnCallSuccess);
+       sinon.assert.calledWith(
+         fnCallSuccess, expectedParam1, expectedParam2, sinon.match.func);
+
+       // Test failed promised function call.
+       await assert.isRejected(
+         promisedFnFailure(expectedParam1), expectedError);
+       sinon.assert.calledOnce(fnCallFailure);
+       sinon.assert.calledWith(fnCallFailure, expectedParam1, sinon.match.func);
+
+       // Test function call that throws.
+       await assert.isRejected(promisedFnThrow(), expectedError);
+       sinon.assert.calledOnce(fnCallThrow);
+       sinon.assert.calledWith(fnCallThrow, sinon.match.func);
+     });
+
+  it('optionally bind the function to a given object', async () => {
+    const obj = {
+      method: sinon.spy(function(cb) {
+        assert.equal(this, obj, 'The method is binded on the expected object');
+        cb();
+      }),
+    };
+
+    const promisedFn = promisify(obj.method, obj);
+
+    await assert.isFulfilled(promisedFn());
+    sinon.assert.calledOnce(obj.method);
+    sinon.assert.calledWith(obj.method, sinon.match.func);
+  });
+
+  it('optionally pass multiple results to a wrapped function', async () => {
+    const expectedResults = ['result1', 'result2'];
+
+    const fnCallMultiArgs = sinon.spy(function(cb) {
+      setTimeout(() => cb(undefined, ...expectedResults));
+    });
+
+    const promisedFnMultiArgs = promisify(
+      fnCallMultiArgs, null, {multiArgs: true});
+
+    await assert.becomes(promisedFnMultiArgs(), expectedResults);
+    sinon.assert.calledOnce(fnCallMultiArgs);
+    sinon.assert.calledWith(fnCallMultiArgs, sinon.match.func);
+  });
+});


### PR DESCRIPTION
This PR replaces es6-promisify with a small util module included in-tree.

The new es6-promisify release has deprecated the multiArgs option, that is basically the only es6-promisify option that we use, and so given that we only have a small number of places where we were using es6-promisify I opted to replace it with a small module that should provide just "what we actually use" (and in the end "one less npm dependency" is nice side-effect ;-)).

This PR also unvealed some mistakes we made on some of the mocks defined in the unit test suite (same issues were also triggered by upgrading the project to the API of the last es6-promisify release, but I didn't digged too much into why with the previous version of es6-promisify they did seem to work just fine).