### PR TITLE
Allow comma as separator when checking permissions via adb

### DIFF
--- a/src/util/adb.js
+++ b/src/util/adb.js
@@ -160,7 +160,8 @@ export default class ADBUtils {
     // Set to true the required permissions that have been granted.
     for (const line of pmDumpLogs) {
       for (const perm of permissions) {
-        if (line.includes(`${perm}: granted=true`)) {
+        if (line.includes(`${perm}: granted=true`) ||
+            line.includes(`${perm}, granted=true`)) {
           permissionsMap[perm] = true;
         }
       }


### PR DESCRIPTION
The separator between permission name and "granted=true" is a comma on older Android versions. Verified on Samsung Galaxy S5 (original ROM).