### PR TITLE
fix: custom preferences on Fennec

### DIFF
--- a/src/extension-runners/firefox-android.js
+++ b/src/extension-runners/firefox-android.js
@@ -423,13 +423,17 @@ export class FirefoxAndroidExtensionRunner {
       selectedAdbDevice,
       selectedFirefoxApk,
       params: {
+        customPrefs,
         firefoxApp,
       },
     } = this;
     // Create the preferences file and the Fennec temporary profile.
     log.debug(`Preparing a temporary profile for ${selectedFirefoxApk}...`);
 
-    const profile = await firefoxApp.createProfile({app: 'fennec'});
+    const profile = await firefoxApp.createProfile({
+      app: 'fennec',
+      customPrefs,
+    });
 
     // Choose a artifacts dir name for the assets pushed to the
     // Android device.

--- a/src/firefox/preferences.js
+++ b/src/firefox/preferences.js
@@ -59,6 +59,10 @@ const prefsCommon: FirefoxPreferences = {
 const prefsFennec: FirefoxPreferences = {
   'browser.console.showInPanel': true,
   'browser.firstrun.show.uidiscovery': false,
+  // browser.link.open_newwindow is changed from 3 to 2 in:
+  // https://github.com/saadtazi/firefox-profile-js/blob/cafc793d940a779d280103ae17d02a92de862efc/lib/firefox_profile.js#L32
+  // Restore original value to avoid https://github.com/mozilla/web-ext/issues/1592
+  'browser.link.open_newwindow': 3,
   'devtools.remote.usb.enabled': true,
 };
 

--- a/tests/unit/test-extension-runners/test.firefox-android.js
+++ b/tests/unit/test-extension-runners/test.firefox-android.js
@@ -351,6 +351,31 @@ describe('util/extension-runners/firefox-android', () => {
          );
        });
 
+    it('supports custom prefs via --pref', async () => {
+      const fakeFirefoxApp = {
+        createProfile: sinon.spy(() => {
+          return Promise.resolve({profileDir: '/path/to/fake/profile'});
+        }),
+      };
+      const {params} = prepareSelectedDeviceAndAPKParams({
+        fakeFirefoxApp,
+      });
+
+      // cmd/run.js maps --pref to customPrefs.
+      params.customPrefs = {'some.pref.name': 123};
+
+      const runnerInstance = new FirefoxAndroidExtensionRunner(params);
+      await runnerInstance.run();
+
+      sinon.assert.calledWithMatch(
+        fakeFirefoxApp.createProfile,
+        {
+          app: 'fennec',
+          customPrefs: {'some.pref.name': 123},
+        },
+      );
+    });
+
     it('builds and pushes the extension xpi to the android device',
        async () => {
          const {


### PR DESCRIPTION
This PR has two independent fixes, both of which can be used to fix #1592.

The first patch adds support for `--pref`, so that one could have used `web-ext run --target=firefox-android --android-device=emulator-5554 --pref=browser.link.open_newwindow=3` to work around #1592

The second patch restores the default value of the `browser.link.open_newwindow` preference so that bug #1592 does not occur any more.

I tested both, by launching `web-ext run` for a simple extension:

manifest.json:
```json
{
    "name": "Link to website",
    "version": "1",
    "manifest_version": 2,
    "background": {
        "scripts": ["background.js"]
    }
}
```

```javascript
// background.js
chrome.tabs.create({url: "page.html"});
```

```html
<!-- page.html -->
<meta name=viewport content="width=device-width">
<a href="https://example.com/" target="_blank">External link (blank target)</a>
```

With the following command (after building `web-ext`) (if testing the first patch, add `--pref=browser.link.open_newwindow=3` too):
```
node path/to/web-ext/bin/web-ext run --target=firefox-android --firefox-apk=org.mozilla.fennec_aurora --android-device=emulator-5554 -v
```

... and then clicking on the link. With this PR, the link opens as expected. Before the PR, Firefox broke down as explained in #1592 