### PR TITLE
fix: Fixed linting error related to eslint v6

### DIFF
--- a/src/cmd/build.js
+++ b/src/cmd/build.js
@@ -146,7 +146,7 @@ export async function defaultPackageCreator(
   const extensionPath = path.join(artifactsDir, packageName);
 
   // Added 'wx' flags to avoid overwriting of existing package.
-  let stream = createWriteStream(extensionPath, {flags: 'wx'});
+  const stream = createWriteStream(extensionPath, {flags: 'wx'});
 
   stream.write(buffer, () => stream.end());
 
@@ -162,9 +162,9 @@ export async function defaultPackageCreator(
         'Use --overwrite-dest to enable overwriting.');
     }
     log.info(`Destination exists, overwriting: ${extensionPath}`);
-    stream = createWriteStream(extensionPath);
-    stream.write(buffer, () => stream.end());
-    await eventToPromise(stream, 'close');
+    const overwriteStream = createWriteStream(extensionPath);
+    overwriteStream.write(buffer, () => overwriteStream.end());
+    await eventToPromise(overwriteStream, 'close');
   }
 
   if (showReadyMessage) {

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -158,22 +158,15 @@ export function makeSureItFails(): Function {
 export function fake<T>(
   original: Object, methods: Object = {}, skipProperties: Array<string> = []
 ): T {
-  var stub = {};
+  const stub = {};
 
   // Provide stubs for all original members:
-  var props = [];
-  var obj = original;
-  while (obj) {
-    props = props.concat(Object.getOwnPropertyNames(obj));
-    obj = Object.getPrototypeOf(obj);
-  }
+  const proto = Object.getPrototypeOf(original);
+  const props = Object.getOwnPropertyNames(original)
+    .concat(Object.getOwnPropertyNames(proto))
+    .filter((key) => !skipProperties.includes(key));
 
-  var proto = Object.getPrototypeOf(original);
   for (const key of props) {
-    if (skipProperties.indexOf(key) >= 0 ||
-       (!original.hasOwnProperty(key) && !proto.hasOwnProperty(key))) {
-      continue;
-    }
     const definition = original[key] || proto[key];
     if (typeof definition === 'function') {
       stub[key] = () => {


### PR DESCRIPTION
This PR contains two fixes needed to prevent linting errors on eslint v6 (e.g. See https://travis-ci.org/mozilla/web-ext/jobs/550038386#L227).

Unfortunately these fixes are not yet enough to be able to merge #1635: 
(once these linting errors are fixed) there are test failures related to the "addons-linter not being yet adapted to run successfully on eslint 6" (even if the addons-linter has eslint 5 has its own exact dependency, the presence of eslint 6 as a web-ext dependency doesn't seem to be forcing npm to esplicitly include eslint 5 in the addons-linter node_modules dir as we would expect).