### PR TITLE
chore: Added last set-value and mixed-deep advisories to the nsprc ignore list

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,4 +1,9 @@
 {
   "exceptions": [
+    // Temporarily ignore set-value and mixin-deep advisories,
+    // related to watchpak and webpack dependencies
+    // (https://github.com/mozilla/web-ext/issues/1656).
+    "https://npmjs.com/advisories/1012",
+    "https://npmjs.com/advisories/1013"
   ]
 }

--- a/scripts/audit-deps
+++ b/scripts/audit-deps
@@ -8,6 +8,7 @@
 // (See https://github.com/npm/npm/issues/20565).
 
 const shell = require('shelljs');
+const stripJsonComments = require('strip-json-comments');
 
 const npmVersion = parseInt(shell.exec('npm --version', {silent: true}).stdout.split('.')[0], 10);
 const npmCmd = npmVersion >= 6 ? 'npm' : 'npx npm@latest';
@@ -42,7 +43,8 @@ const ignoredIssues = [];
 let auditReport = getNpmAuditJSON();
 
 if (auditReport) {
-  const exceptions = JSON.parse(shell.cat('.nsprc')).exceptions;
+  const {exceptions} = JSON.parse(stripJsonComments(shell.cat('.nsprc')));
+
   if (auditReport.error) {
     if (auditReport.error.code === 'ENETUNREACH') {
       console.log('npm was not able to reach the api endpoint:', auditReport.error.summary);


### PR DESCRIPTION
This PR adds the recent advisories related to set-value and mixed-deep (which are not direct web-ext dependencies, but still required by watchpak and webpack) to the nsprc ignore list, because it is currently triggering failures in any pull request (because the CI jobs fails on the "Npm audit and lint github pr title" step, [e.g. as in this job](https://travis-ci.org/mozilla/web-ext/jobs/557924886)).

TODO:
- [x] verify that the CI job completes successfull on this PR
- [x] file a github issue to remove these two advisories from the ignore list and link it in the comment included in the .nsprc file