### PR TITLE
fix: Strip UTF-8 BOM before parsing manifest.json/messages.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "sign-addon": "0.3.1",
     "source-map-support": "0.5.13",
     "stream-to-promise": "2.2.0",
+    "strip-bom": "3.0.0",
     "strip-json-comments": "3.0.1",
     "tmp": "0.1.0",
     "update-notifier": "3.0.1",

--- a/src/cmd/build.js
+++ b/src/cmd/build.js
@@ -4,6 +4,7 @@ import {createWriteStream} from 'fs';
 
 import {fs} from 'mz';
 import parseJSON from 'parse-json';
+import stripBom from 'strip-bom';
 import stripJsonComments from 'strip-json-comments';
 import defaultEventToPromise from 'event-to-promise';
 
@@ -77,6 +78,8 @@ export async function getDefaultLocalizedName(
     throw new UsageError(
       `Error reading messages.json file at ${messageFile}: ${error}`);
   }
+
+  messageContents = stripBom(messageContents);
 
   try {
     messageData = parseJSON(stripJsonComments(messageContents), messageFile);

--- a/src/util/manifest.js
+++ b/src/util/manifest.js
@@ -3,6 +3,7 @@ import path from 'path';
 
 import {fs} from 'mz';
 import parseJSON from 'parse-json';
+import stripBom from 'strip-bom';
 import stripJsonComments from 'strip-json-comments';
 
 import {InvalidManifest} from '../errors';
@@ -44,6 +45,8 @@ export default async function getValidatedManifest(
     throw new InvalidManifest(
       `Could not read manifest.json file at ${manifestFile}: ${error}`);
   }
+
+  manifestContents = stripBom(manifestContents);
 
   let manifestData;
 

--- a/tests/unit/test-cmd/test.build.js
+++ b/tests/unit/test-cmd/test.build.js
@@ -129,6 +129,22 @@ describe('build', () => {
     );
   });
 
+  it('handles UTF-8 BOM in messages.json', () => withTempDir(
+    async (tmpDir) => {
+      const manifestDataWithBOM = '\uFEFF{"name":{"message":"BOM = \uFEFF!"}}';
+      const messageFileName = path.join(tmpDir.path(), 'messages.json');
+      await fs.writeFile(messageFileName, manifestDataWithBOM);
+      const result = await getDefaultLocalizedName({
+        messageFile: messageFileName,
+        manifestData: {
+          name: '__MSG_name__',
+          version: '0.0.1',
+        },
+      });
+      assert.equal(result, 'BOM = \uFEFF!');
+    }
+  ));
+
   it('handles comments in messages.json', () => {
     return withTempDir(
       (tmpDir) => {

--- a/tests/unit/test-util/test.manifest.js
+++ b/tests/unit/test-util/test.manifest.js
@@ -158,6 +158,17 @@ describe('util/manifest', () => {
       }
     ));
 
+    it('ignore UTF-8 BOM in manifest JSON', () => withTempDir(
+      async (tmpDir) => {
+        const manifestDataWithBOM = `\uFEFF${JSON.stringify(basicManifest)}`;
+        const manifestFile = path.join(tmpDir.path(), 'manifest.json');
+        await fs.writeFile(manifestFile, manifestDataWithBOM);
+        const manifestData = await getValidatedManifest(tmpDir.path());
+
+        assert.deepEqual(manifestData, basicManifest);
+      }
+    ));
+
     it('allows comments in manifest JSON', () =>
       withTempDir(async (tmpDir) => {
         const manifestWithComments = `{


### PR DESCRIPTION
Fixes #1013.

This PR doesn't require a change in package-lock.json, because I purposefully selected a version of strip-bom that was already depended upon via other dependencies. The latest version (4.0.0) does not differ in functionality compared to the chosen version (3.0.0).