### PR TITLE
fix: Changed npm dependency from opn to open

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9623,10 +9623,10 @@
         "mimic-fn": "^1.0.0"
       }
     },
-    "opn": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
-      "integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
+    "open": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
+      "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
       "requires": {
         "is-wsl": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "multimatch": "4.0.0",
     "mz": "2.7.0",
     "node-notifier": "5.4.0",
-    "opn": "5.5.0",
+    "open": "6.4.0",
     "parse-json": "4.0.0",
     "require-uncached": "2.0.0",
     "sign-addon": "0.3.1",

--- a/src/cmd/docs.js
+++ b/src/cmd/docs.js
@@ -1,5 +1,5 @@
 /* @flow */
-import opn from 'opn';
+import open from 'open';
 
 import {createLogger} from '../util/logger';
 
@@ -11,14 +11,14 @@ export type DocsParams = {
 }
 
 export type DocsOptions = {
-  openUrl?: typeof opn,
+  openUrl?: typeof open,
 }
 
 export const url = 'https://developer.mozilla.org/en-US/Add-ons' +
   '/WebExtensions/Getting_started_with_web-ext';
 
 export default function docs(
-  params: DocsParams, {openUrl = opn}: DocsOptions = {}
+  params: DocsParams, {openUrl = open}: DocsOptions = {}
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     openUrl(url, (error) => {


### PR DESCRIPTION
This pull request change the npm dependencies to switch from [opn](npmjs.com/package/opn) (now deprecated) to [open](npmjs.com/package/open) (new npm package name for the same dependency).

This PR includes and supersedes #1679 (it includes the changes from #1679 and fixes the diff applied to the package-lock.json file).