### PR TITLE
feat: Enabled by default visibility of extension pages and content scripts logs in the BrowserConsole

### DIFF
--- a/src/firefox/preferences.js
+++ b/src/firefox/preferences.js
@@ -28,8 +28,8 @@ const prefsCommon: FirefoxPreferences = {
   // Disable the prompt for allowing connections.
   'devtools.debugger.prompt-connection': false,
 
-  // Turn off platform logging because it is a lot of info.
-  'extensions.logging.enabled': false,
+  // Allow extensions to log messages on browser's console
+  'extensions.logging.enabled': true,
 
   // Disable extension updates and notifications.
   'extensions.checkCompatibility.nightly': false,

--- a/src/firefox/preferences.js
+++ b/src/firefox/preferences.js
@@ -27,9 +27,11 @@ const prefsCommon: FirefoxPreferences = {
   'devtools.debugger.remote-enabled': true,
   // Disable the prompt for allowing connections.
   'devtools.debugger.prompt-connection': false,
+  // Allow extensions to log messages on browser's console.
+  'devtools.browserconsole.contentMessages': true,
 
-  // Allow extensions to log messages on browser's console
-  'extensions.logging.enabled': true,
+  // Turn off platform logging because it is a lot of info.
+  'extensions.logging.enabled': false,
 
   // Disable extension updates and notifications.
   'extensions.checkCompatibility.nightly': false,


### PR DESCRIPTION
Fixes #1702 

Hey @rpl!

I hope you're doing well!

I believe this is the only change that is needed to fix this issue. Is that right?

Also, do I need to use a conditional statement to only set ```extensions.logging.enabled``` to ```true``` when ```--browser-console``` is sent as a parameter when running web-ext?

Thanks!