### PR TITLE
test: Disabled code coverage collection on Travis windows workers

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "node scripts/build",
     "start": "node scripts/develop",
     "test": "node scripts/test",
-    "test-coverage": "nyc npm run test",
+    "test-coverage": "node scripts/test --coverage",
     "test-functional": "node scripts/test-functional",
     "publish-coverage": "nyc report --reporter=text-lcov | coveralls",
     "audit-deps": "node ./scripts/audit-deps",

--- a/scripts/develop
+++ b/scripts/develop
@@ -11,6 +11,8 @@ const {flowStatus} = require('./lib/flow');
 const {mochaUnit, mochaFunctional} = require('./lib/mocha');
 const webpack = require('./lib/webpack');
 
+const COVERAGE = process.argv.includes('--coverage') || process.env.COVERAGE === 'y';
+
 console.log('Starting flow server...');
 if (!flowStatus()) {
   process.exit(1);
@@ -43,7 +45,7 @@ async function runTasks(changes) {
   }
 
   console.log('\nRunning unit tests');
-  if (!mochaUnit()) {
+  if (!mochaUnit({}, COVERAGE)) {
     notify('mocha unit tests errors');
     return;
   }

--- a/scripts/lib/mocha.js
+++ b/scripts/lib/mocha.js
@@ -4,11 +4,16 @@ const shell = require('shelljs');
 
 const config = require('./config');
 
-// Get the explicit path to mocha (needed to make it find mocha binary on travis windows workers).
-const mochaPath = String(shell.which('mocha'));
+// Get the explicit path (needed on travis windows workers).
+function which(...args) {
+  return String(shell.which(...args));
+}
 
-const runMocha = (args, execMochaOptions = {}) => {
-  const res = spawnSync(mochaPath, args, {
+const runMocha = (args, execMochaOptions = {}, coverageEnabled) => {
+  const mochaPath = which('mocha');
+  const binArgs = coverageEnabled ? [mochaPath, ...args] : args;
+  const binPath = coverageEnabled ? which('nyc') : mochaPath;
+  const res = spawnSync(binPath, binArgs, {
     ...execMochaOptions,
     stdio: 'inherit',
   });
@@ -21,8 +26,8 @@ const runMocha = (args, execMochaOptions = {}) => {
   return res.status === 0;
 };
 
-exports.mochaUnit = (execMochaOptions) => {
-  return runMocha(config.mocha.unit, execMochaOptions);
+exports.mochaUnit = (execMochaOptions, coverageEnabled) => {
+  return runMocha(config.mocha.unit, execMochaOptions, coverageEnabled);
 };
 
 exports.mochaFunctional = (execMochaOptions) => {

--- a/scripts/test
+++ b/scripts/test
@@ -1,5 +1,17 @@
 #!/usr/bin/env node
 
+let COVERAGE = process.argv.includes('--coverage') || process.env.COVERAGE === 'y';
+
+const {TRAVIS_OS_NAME} = process.env;
+if (TRAVIS_OS_NAME === 'windows') {
+  console.log(
+    'Skipping coverage collection because running on',
+    TRAVIS_OS_NAME,
+    '(See issue https://github.com/mozilla/web-ext/issues/1739)'
+  );
+  COVERAGE = false;
+}
+
 const eslint = require('./lib/eslint');
 const {flowCheck} = require('./lib/flow');
 const {mochaUnit} = require('./lib/mocha');
@@ -14,6 +26,6 @@ if (!flowCheck()) {
   process.exit(1);
 }
 
-console.log('Running mocha unit tests...');
-const ok = mochaUnit();
+console.log('Running mocha unit tests...', COVERAGE ? '(COVERAGE)' : '');
+const ok = mochaUnit({}, COVERAGE);
 process.exit(ok ? 0 : 1);


### PR DESCRIPTION
This PR workarounds the issue described in #1739 by skipping the code coverage collection on travis windows workers.