### PR TITLE
fix: Backport longer sign command timeout and bump package version for release for 3.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-ext",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "A command line tool to help build, run, and test web extensions",
   "main": "dist/web-ext.js",
   "engines": {

--- a/src/cmd/sign.js
+++ b/src/cmd/sign.js
@@ -116,7 +116,9 @@ export default function sign(
         apiSecret,
         apiUrlPrefix,
         apiProxy,
-        timeout,
+        // Backport increased sign-addon timeout (fixed on master
+        // by updating sign-addon dependency to 1.0.0).
+        timeout: typeof timeout === 'number' ? timeout : 900000,
         verbose,
         id,
         xpiPath: buildResult.extensionPath,


### PR DESCRIPTION
This PR is related to two commit to be merged on the patch-releases-3.2.x branch (and so it is not meant to be merged on master) and then released on npm as part of a new 3.2.1 patch release:

- fix: Backported longer sign command timeout from sign-addon 1.0.0
- chore: Bump package version for release 3.2.1

(As a side note, the patch-releases-3.2.x currently contains 1 commit, the fix from #1742 backported to this branch to fix the nyc-related failures in the travis windows workers).