### PR TITLE
chore(audit): Add handlebars advisory to nsprc ignore list (#1750)

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,4 +1,6 @@
 {
   "exceptions": [
+    // Remove this once commitlint and babel have updated handlerbars in their dependencies.
+    "https://npmjs.com/advisories/1300"
   ]
 }


### PR DESCRIPTION
Backported #1750 into the patch-release-3.2.x branch.