### PR TITLE
feat: Disabled the default browser check for Chromium (#1781)

### DIFF
--- a/src/extension-runners/chromium.js
+++ b/src/extension-runners/chromium.js
@@ -48,6 +48,10 @@ const EXCLUDED_CHROME_FLAGS = [
 export const DEFAULT_CHROME_FLAGS = ChromeLauncher.defaultFlags()
   .filter((flag) => !EXCLUDED_CHROME_FLAGS.includes(flag));
 
+export const EXTRA_CHROME_FLAGS = [
+  '--no-default-browser-check',
+];
+
 /**
  * Implements an IExtensionRunner which manages a Chromium instance.
  */
@@ -119,7 +123,7 @@ export class ChromiumExtensionRunner {
       log.debug(`(chromiumBinary: ${chromiumBinary})`);
     }
 
-    const chromeFlags = [...DEFAULT_CHROME_FLAGS];
+    const chromeFlags = [...DEFAULT_CHROME_FLAGS, ...EXTRA_CHROME_FLAGS];
 
     chromeFlags.push(`--load-extension=${extensions}`);
 

--- a/tests/unit/test-extension-runners/test.chromium.js
+++ b/tests/unit/test-extension-runners/test.chromium.js
@@ -17,6 +17,7 @@ import {
 import {
   ChromiumExtensionRunner,
   DEFAULT_CHROME_FLAGS,
+  EXTRA_CHROME_FLAGS,
 } from '../../../src/extension-runners/chromium';
 import type {
   ChromiumExtensionRunnerParams,
@@ -62,6 +63,10 @@ describe('util/extension-runners/chromium', async () => {
     assert.deepEqual(DEFAULT_CHROME_FLAGS, expectedFlags);
   });
 
+  it('disables the default browser check', () => {
+    assert.include(EXTRA_CHROME_FLAGS, '--no-default-browser-check');
+  });
+
   it('installs and runs the extension', async () => {
     const {params, fakeChromeInstance} = prepareExtensionRunnerParams();
     const runnerInstance = new ChromiumExtensionRunner(params);
@@ -78,6 +83,7 @@ describe('util/extension-runners/chromium', async () => {
       chromePath: undefined,
       chromeFlags: [
         ...DEFAULT_CHROME_FLAGS,
+        ...EXTRA_CHROME_FLAGS,
         `--load-extension=${reloadManagerExtension},/fake/sourceDir`,
       ],
       startingUrl: undefined,
@@ -271,6 +277,7 @@ describe('util/extension-runners/chromium', async () => {
       chromePath: '/my/custom/chrome-bin',
       chromeFlags: [
         ...DEFAULT_CHROME_FLAGS,
+        ...EXTRA_CHROME_FLAGS,
         `--load-extension=${reloadManagerExtension},/fake/sourceDir`,
       ],
       startingUrl: undefined,
@@ -296,6 +303,7 @@ describe('util/extension-runners/chromium', async () => {
       chromePath: undefined,
       chromeFlags: [
         ...DEFAULT_CHROME_FLAGS,
+        ...EXTRA_CHROME_FLAGS,
         `--load-extension=${reloadManagerExtension},/fake/sourceDir`,
         'url2',
         'url3',
@@ -326,6 +334,7 @@ describe('util/extension-runners/chromium', async () => {
       chromePath: undefined,
       chromeFlags: [
         ...DEFAULT_CHROME_FLAGS,
+        ...EXTRA_CHROME_FLAGS,
         `--load-extension=${reloadManagerExtension},/fake/sourceDir`,
         '--arg1',
         'arg2',
@@ -358,6 +367,7 @@ describe('util/extension-runners/chromium', async () => {
       chromePath: undefined,
       chromeFlags: [
         ...DEFAULT_CHROME_FLAGS,
+        ...EXTRA_CHROME_FLAGS,
         `--load-extension=${reloadManagerExtension},/fake/sourceDir`,
         '--user-data-dir=/fake/chrome/profile',
       ],


### PR DESCRIPTION
Essentially closes #1781.

I didn't want to touch _DEFAULT\_CHROME\_FLAGS_, as it only contains the default flags of `chromium-launcher`, so that's why I added _EXTRA\_CHROME\_FLAGS_. The new list can also be used to add more command line flags in the future, there's plenty to pick from: https://peter.sh/experiments/chromium-command-line-switches/.
The thing I'm not sure about is the correctness of my test.