### PR TITLE
docs: Fixed link to signing addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Here is a partial list of examples:
 * Integrating with services.
   * Mozilla offers some useful services such as
     [linting](https://github.com/mozilla/addons-linter) and
-    [signing](https://github.com/mozilla/sign-addon)
+    [signing](https://addons-server.readthedocs.io/en/latest/topics/api/signing.html)
     extensions.
 
 [web-ext-user-docs]: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Getting_started_with_web-ext

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Here is a partial list of examples:
 * Integrating with services.
   * Mozilla offers some useful services such as
     [linting](https://github.com/mozilla/addons-linter) and
-    [signing](http://olympia.readthedocs.org/en/latest/topics/api/signing.html)
+    [signing](https://github.com/mozilla/sign-addon)
     extensions.
 
 [web-ext-user-docs]: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Getting_started_with_web-ext


### PR DESCRIPTION
While going through the README I discovered that the link `http://olympia.readthedocs.org/en/latest/topics/api/signing.html` was not working. I figured similiar to the `linting`, the addon should be linked here. 

If this is not the case please feel free to close the PR.