### PR TITLE
fix: npm release should only include production assets

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,12 +1,2 @@
-# OSX
-.DS_Store
-
-# Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
-.grunt
-.cache
-
-# Build artifacts.
-npm-debug.log
-dist/tests.js*
-artifacts/*
-coverage/*
+# The files to be included in the npm package are listed in the package.json file,
+# in the `files` property (See https://docs.npmjs.com/files/package.json#files).

--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "3.2.0",
   "description": "A command line tool to help build, run, and test web extensions",
   "main": "dist/web-ext.js",
+  "files": [
+    "CODE_OF_CONDUCT.md",
+    "dist/*.js",
+    "src/**"
+  ],
   "engines": {
     "node": ">=10.0.0",
     "npm": ">=5.6.0"

--- a/scripts/lib/config.js
+++ b/scripts/lib/config.js
@@ -1,15 +1,5 @@
 module.exports = {
   clean: ['dist/*'],
-  copy: {
-    productionModeAssets: {
-      src: [
-        'package.json',
-        'package-lock.json',
-        'dist/**',
-        'bin/**',
-      ],
-    },
-  },
   watch: {
     files: [
       'package.json',

--- a/scripts/test-functional
+++ b/scripts/test-functional
@@ -5,11 +5,12 @@ const path = require('path');
 const shell = require('shelljs');
 const tmp = require('tmp');
 
-const config = require('./lib/config');
+const pkg = require('../package.json');
 const {mochaFunctional} = require('./lib/mocha');
 
 shell.set('-e');
 
+const packageFileName = `${pkg.name}-${pkg.version}.tgz`;
 const testProductionMode = process.env.TEST_PRODUCTION_MODE === '1';
 const testLegacyBundling = process.env.TEST_LEGACY_BUNDLING === '1';
 
@@ -23,6 +24,7 @@ shell.exec('npm run build', testProductionMode ? {
 } : {});
 
 if (testProductionMode) {
+  const srcDir = process.cwd();
   const destDir = tmp.tmpNameSync();
   const packageDir = tmp.tmpNameSync();
   const npmInstallOptions = ['--production'];
@@ -42,9 +44,12 @@ if (testProductionMode) {
   shell.echo('\nPreparing web-ext production mode environment...\n');
   shell.rm('-rf', destDir, packageDir);
   shell.mkdir('-p', destDir, packageDir);
-  shell.cp('-rf', config.copy.productionModeAssets.src, packageDir);
+  shell.pushd(packageDir);
+  shell.exec(`npm pack ${srcDir}`);
+  shell.popd();
   shell.pushd(destDir);
-  shell.exec(`npm install ${npmInstallOptions.join(' ')} ${packageDir}`);
+  const pkgPath = path.join(packageDir, packageFileName);
+  shell.exec(`npm install ${npmInstallOptions.join(' ')} ${pkgPath}`);
   shell.popd();
   shell.echo('\nProduction mode environment successfully created.\n');
 }


### PR DESCRIPTION
This PR does exclude from the released npm package any asset that isn't needed in production (like we did for the sign-addon dependency in mozilla/sign-addon#402).

Besides that, this PR also change the test-functional script to use `npm pack` to run the production mode functional tests on the same package we would release on npm (without the need to keep a separate list of files to include).