### PR TITLE
fix: chromium runner async setup should wait for the WebSocketServer to be listening

### DIFF
--- a/src/extension-runners/chromium.js
+++ b/src/extension-runners/chromium.js
@@ -90,9 +90,12 @@ export class ChromiumExtensionRunner {
    */
   async setupInstance(): Promise<void> {
     // Start a websocket server on a free localhost TCP port.
-    this.wss = new WebSocket.Server({
-      port: 0,
-      host: 'localhost',
+    this.wss = await new Promise((resolve) => {
+      const server = new WebSocket.Server(
+        {port: 0, host: 'localhost'},
+        // Wait the server to be listening (so that the extension
+        // runner can successfully retrieve server address and port).
+        () => resolve(server));
     });
 
     // Prevent unhandled socket error (e.g. when chrome


### PR DESCRIPTION
Fixes #1779 

The underlying issue is (unsurprisingly) a race, between the WebSocketServer starting up and the chromium extension runner setup moving on to generate the extension used to control the chromium instance (which needs to retrieve the WebSocketServer address and port to interpolate them into the extension sources).

If the WebsocketServer is not yet listening, calling `wss.address()` would return `undefined`, and the rest of the chromium runner setup fails. 