### PR TITLE
Temporary work-around to #793 by turning off strict argument checking

### DIFF
--- a/src/program.js
+++ b/src/program.js
@@ -83,7 +83,8 @@ export class Program {
     this.yargs.parserConfiguration({
       'boolean-negation': true,
     });
-    this.yargs.strict();
+    // TODO: remove false when https://github.com/yargs/yargs/issues/873 is fixed
+    this.yargs.strict(false);
 
     this.commands = {};
     this.options = {};
@@ -105,7 +106,8 @@ export class Program {
         // web-ext lint ./src/path/to/file.js
         .demandCommand(0, 0, undefined,
                        'This command does not take any arguments')
-        .strict()
+        // TODO: remove false when https://github.com/yargs/yargs/issues/873 is fixed
+        .strict(false)
         .exitProcess(this.shouldExitProgram)
         // Calling env() will be unnecessary after
         // https://github.com/yargs/yargs/issues/486 is fixed
@@ -340,7 +342,8 @@ Example: $0 --help run.
     .env(envPrefix)
     .version(version)
     .demandCommand(1, 'You must specify a command')
-    .strict()
+    // TODO: remove false when https://github.com/yargs/yargs/issues/873 is fixed
+    .strict(false)
     .recommendCommands();
 
   program.setGlobalOptions({

--- a/tests/unit/test.program.js
+++ b/tests/unit/test.program.js
@@ -255,7 +255,8 @@ describe('program.Program', () => {
       }));
   });
 
-  it('throws an error about unknown commands', () => {
+  // TODO: remove skip when https://github.com/yargs/yargs/issues/873 is fixed
+  it.skip('throws an error about unknown commands', () => {
     return execProgram(new Program(['nope']))
       .then(makeSureItFails())
       .catch((error) => {
@@ -263,7 +264,8 @@ describe('program.Program', () => {
       });
   });
 
-  it('throws an error about unknown options', () => {
+  // TODO: remove skip when https://github.com/yargs/yargs/issues/873 is fixed
+  it.skip('throws an error about unknown options', () => {
     return execProgram(new Program(['--nope']))
       .then(makeSureItFails())
       .catch((error) => {
@@ -273,7 +275,8 @@ describe('program.Program', () => {
       });
   });
 
-  it('throws an error about unknown sub-command options', () => {
+  // TODO: remove skip when https://github.com/yargs/yargs/issues/873 is fixed
+  it.skip('throws an error about unknown sub-command options', () => {
     const program = new Program(['thing', '--nope'])
       .command('thing', '', () => {});
     return execProgram(program)


### PR DESCRIPTION
Marked all failing tests as 'pending'.  Put TODOs on each change, so that when the upstream bug is resolved, this can be backed out easily.

Note to maintainers: this is a *suggestion* with my developer hat on.  Please treat this as a normal request from an external user, with no special authority.