### PR TITLE
fix: Remove WEB_EXT_* env vars not supported by the selected web-ext command

### DIFF
--- a/tests/functional/test.cli.run.js
+++ b/tests/functional/test.cli.run.js
@@ -32,6 +32,14 @@ describe('web-ext run', () => {
              PATH: process.env.PATH,
              EXPECTED_MESSAGE,
              addonPath: srcDir,
+             // Add an environment var unrelated to the executed command to
+             // ensure we do clear the environment vars from them before
+             // yargs is validation the detected cli and env options.
+             // (See #793).
+             WEB_EXT_API_KEY: 'fake-api-key',
+             // Also include an environment var that misses the '_' separator
+             // between envPrefix and option name.
+             WEB_EXTAPI_SECRET: 'fake-secret',
            },
          };
 


### PR DESCRIPTION
This PR contains another possible approach to fix #793 (as an alternative to disabling the yargs strict parsing as in #1810 

- [x] add new unit tests to cover the changes (and fix coveralls failure due to decreased code coverage)
- [x] add an integration test (to make sure the fix does work as expected when the options and environment vars are actually parsed and validated by yargs).
