### PR TITLE
fix: Allow import of external modules without bundling

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,16 @@ Object.keys(require('./package.json').dependencies)
     nodeModules[mod] = 'commonjs ' + mod;
   });
 
+// Allow use of importing parts of an external module, without bundling them.
+function nodeModulesExternalsHandler(context, request, callback) {
+  var mod = request.split('/', 1)[0];
+  if (Object.prototype.hasOwnProperty.call(nodeModules, mod)) {
+    callback(null, 'commonjs ' + request);
+    return;
+  }
+  callback();
+}
+
 var rules = [
   {
     exclude: /(node_modules|bower_components)/,
@@ -39,7 +49,10 @@ module.exports = {
   module: {
     rules,
   },
-  externals: nodeModules,
+  externals: [
+    nodeModules,
+    nodeModulesExternalsHandler,
+  ],
   plugins: [
     new webpack.BannerPlugin({
       banner: 'require("source-map-support").install();',


### PR DESCRIPTION
This is to support use of `import ... from 'yargs/yargs'` in #1812

This would also have been the proper fix instead of #383 .