### PR TITLE
chore: Replace custom externals with webpack-node-externals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14631,6 +14631,12 @@
         }
       }
     },
+    "webpack-node-externals": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz",
+      "integrity": "sha512-ajerHZ+BJKeCLviLUUmnyd5B4RavLF76uv3cs6KNuO8W+HuQaEs0y0L7o40NQxdPy5w0pcv8Ew7yPUAQG0UdCg==",
+      "dev": true
+    },
     "webpack-sources": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "shelljs": "0.8.3",
     "sinon": "8.1.1",
     "webpack": "4.41.6",
+    "webpack-node-externals": "1.7.2",
     "yauzl": "2.10.0"
   },
   "author": "Kumar McMillan",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,26 +2,10 @@
 var path = require('path');
 
 var webpack = require('webpack');
-
-var nodeModules = {};
-
 // Do not bundle any external module, because those are explicitly added as
 // "dependencies" in package.json. Bundling them anyway could result in bugs
 // like https://github.com/mozilla/web-ext/issues/1629
-Object.keys(require('./package.json').dependencies)
-  .forEach(function(mod) {
-    nodeModules[mod] = 'commonjs ' + mod;
-  });
-
-// Allow use of importing parts of an external module, without bundling them.
-function nodeModulesExternalsHandler(context, request, callback) {
-  var mod = request.split('/', 1)[0];
-  if (Object.prototype.hasOwnProperty.call(nodeModules, mod)) {
-    callback(null, 'commonjs ' + request);
-    return;
-  }
-  callback();
-}
+var nodeExternals = require('webpack-node-externals');
 
 var rules = [
   {
@@ -50,8 +34,11 @@ module.exports = {
     rules,
   },
   externals: [
-    nodeModules,
-    nodeModulesExternalsHandler,
+    nodeExternals({
+      modulesFromFile: {
+        include: ['dependencies'],
+      },
+    }),
   ],
   plugins: [
     new webpack.BannerPlugin({


### PR DESCRIPTION
There is already an existing npm package that does what I have implemented in #1634 and #1813 .