### PR TITLE
fix: Use local port to avoid triggering the firewall

### DIFF
--- a/src/firefox/remote.js
+++ b/src/firefox/remote.js
@@ -251,8 +251,8 @@ export async function connectWithMaxRetries(
 export function findFreeTcpPort(): Promise<number> {
   return new Promise((resolve) => {
     const srv = net.createServer();
-    // $FLOW_FIXME: flow has his own opinions on this method signature.
-    srv.listen(0, () => {
+    // $FLOW_FIXME: signature for listen() is missing - see https://github.com/facebook/flow/pull/8290
+    srv.listen(0, '127.0.0.1', () => {
       const freeTcpPort = srv.address().port;
       srv.close(() => resolve(freeTcpPort));
     });

--- a/tests/functional/fake-amo-server.js
+++ b/tests/functional/fake-amo-server.js
@@ -51,7 +51,7 @@ http.createServer(function(req, res) {
   } else {
     process.exit(1);
   }
-}).listen(8989, () => {
+}).listen(8989, '127.0.0.1', () => {
   process.stdout.write('listening');
   process.stdout.uncork();
 });

--- a/tests/functional/fake-firefox-binary.js
+++ b/tests/functional/fake-firefox-binary.js
@@ -55,4 +55,4 @@ net.createServer(function(socket) {
   });
 
   socket.write(toRDP(REPLY_INITIAL));
-}).listen(getPortFromArgs());
+}).listen(getPortFromArgs(), '127.0.0.1');

--- a/tests/unit/test-firefox/test.remote.js
+++ b/tests/unit/test-firefox/test.remote.js
@@ -390,7 +390,8 @@ describe('firefox.remote', () => {
     async function promiseServerOnPort(port): Promise<net.Server> {
       return new Promise((resolve) => {
         const srv = net.createServer();
-        srv.listen(port, () => {
+        // $FLOW_FIXME: signature for listen() is missing - see https://github.com/facebook/flow/pull/8290
+        srv.listen(port, '127.0.0.1', () => {
           resolve(srv);
         });
       });


### PR DESCRIPTION
When `web-ext run` starts, the following prompt shows briefly on macOS:

> Do you want the application "node" to
> accept incoming network connections?

This is because we use `listen(0)` to find a port, and by default, this
method listens on any network interface.

Since we are only looking for free ports and not network connections,
limit `listen()` to localhost only.