### PR TITLE
feat: Added fenix support to the firefox-android extension runner

### DIFF
--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -47,7 +47,6 @@ export type CmdRunParams = {|
   adbDiscoveryTimeout?: number,
   firefoxApk?: string,
   firefoxApkComponent?: string,
-  fennecMode?: boolean,
 
   // Chromium Desktop CLI options.
   chromiumBinary?: string,
@@ -90,7 +89,6 @@ export default async function run(
     adbDiscoveryTimeout,
     firefoxApk,
     firefoxApkComponent,
-    fennecMode,
     // Chromium CLI options.
     chromiumBinary,
     chromiumProfile,
@@ -167,7 +165,6 @@ export default async function run(
       adbPort,
       adbBin,
       adbDiscoveryTimeout,
-      fennecMode,
 
       // Injected dependencies.
       firefoxApp,

--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -46,6 +46,7 @@ export type CmdRunParams = {|
   adbDevice?: string,
   adbDiscoveryTimeout?: number,
   firefoxApk?: string,
+  firefoxApkComponent?: string,
   fennecMode?: boolean,
 
   // Chromium Desktop CLI options.
@@ -88,6 +89,7 @@ export default async function run(
     adbDevice,
     adbDiscoveryTimeout,
     firefoxApk,
+    firefoxApkComponent,
     fennecMode,
     // Chromium CLI options.
     chromiumBinary,
@@ -159,6 +161,7 @@ export default async function run(
       browserConsole,
       preInstall,
       firefoxApk,
+      firefoxApkComponent,
       adbDevice,
       adbHost,
       adbPort,

--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -44,7 +44,9 @@ export type CmdRunParams = {|
   adbHost?: string,
   adbPort?: string,
   adbDevice?: string,
+  adbDiscoveryTimeout?: number,
   firefoxApk?: string,
+  fennecMode?: boolean,
 
   // Chromium Desktop CLI options.
   chromiumBinary?: string,
@@ -84,7 +86,9 @@ export default async function run(
     adbHost,
     adbPort,
     adbDevice,
+    adbDiscoveryTimeout,
     firefoxApk,
+    fennecMode,
     // Chromium CLI options.
     chromiumBinary,
     chromiumProfile,
@@ -159,6 +163,8 @@ export default async function run(
       adbHost,
       adbPort,
       adbBin,
+      adbDiscoveryTimeout,
+      fennecMode,
 
       // Injected dependencies.
       firefoxApp,

--- a/src/extension-runners/firefox-android.js
+++ b/src/extension-runners/firefox-android.js
@@ -72,6 +72,7 @@ export type FirefoxAndroidExtensionRunnerParams = {|
   adbDevice?: string,
   adbDiscoveryTimeout?: number,
   firefoxApk?: string,
+  firefoxApkComponent?: string,
   fennecMode?: boolean,
 
   // Injected Dependencies.
@@ -281,7 +282,8 @@ export class FirefoxAndroidExtensionRunner {
     const firefoxApk =
       this.selectedFirefoxApk || this.params.firefoxApk;
 
-    if (firefoxApk && firefoxApk.includes('.fenix')) {
+    if (firefoxApk && (firefoxApk.includes('.fenix') ||
+        firefoxApk.includes('.geckoview'))) {
       return false;
     }
 
@@ -430,18 +432,9 @@ export class FirefoxAndroidExtensionRunner {
     // these permissions are optional and have to be granted explicitly).
     const requiredPermissions = [
       'android.permission.READ_EXTERNAL_STORAGE',
+      'android.permission.WRITE_EXTERNAL_STORAGE',
     ];
 
-    if (this.fennecCompatibilityMode) {
-      // For Fennec, also require the WRITE_EXTERNAL_STORAGE permission,
-      // needed to allow Fennec to use the temporary profile created
-      // on the sdcard (on the contrary we do not use a temporary profile
-      // for Fenix, and so the READ_EXTERNAL_STORAGE is enough to be able
-      // to access the xpi file uploaded on the android device).
-      requiredPermissions.push(
-        'android.permission.WRITE_EXTERNAL_STORAGE',
-      );
-    }
     await adbUtils.ensureRequiredAPKRuntimePermissions(
       selectedAdbDevice, selectedFirefoxApk, requiredPermissions
     );
@@ -488,6 +481,9 @@ export class FirefoxAndroidExtensionRunner {
       adbUtils,
       selectedFirefoxApk,
       selectedAdbDevice,
+      params: {
+        firefoxApkComponent,
+      },
     } = this;
 
     const deviceProfileDir = this.getDeviceProfileDir();
@@ -499,7 +495,11 @@ export class FirefoxAndroidExtensionRunner {
     }
 
     await adbUtils.startFirefoxAPK(
-      selectedAdbDevice, selectedFirefoxApk, deviceProfileDir
+      selectedAdbDevice,
+      selectedFirefoxApk,
+      firefoxApkComponent,
+      this.fennecCompatibilityMode,
+      deviceProfileDir,
     );
   }
 

--- a/src/extension-runners/firefox-android.js
+++ b/src/extension-runners/firefox-android.js
@@ -73,7 +73,6 @@ export type FirefoxAndroidExtensionRunnerParams = {|
   adbDiscoveryTimeout?: number,
   firefoxApk?: string,
   firefoxApkComponent?: string,
-  fennecMode?: boolean,
 
   // Injected Dependencies.
   firefoxApp: typeof defaultFirefoxApp,
@@ -273,22 +272,6 @@ export class FirefoxAndroidExtensionRunner {
   }
 
   // Private helper methods.
-
-  get fennecCompatibilityMode() {
-    if (this.params.fennecMode != null) {
-      return this.params.fennecMode;
-    }
-
-    const firefoxApk =
-      this.selectedFirefoxApk || this.params.firefoxApk;
-
-    if (firefoxApk && (firefoxApk.includes('.fenix') ||
-        firefoxApk.includes('.geckoview'))) {
-      return false;
-    }
-
-    return true;
-  }
 
   getDeviceProfileDir(): string {
     return `${this.selectedArtifactsDir}/profile`;
@@ -490,15 +473,12 @@ export class FirefoxAndroidExtensionRunner {
 
     log.info(`Starting ${selectedFirefoxApk}...`);
 
-    if (this.fennecCompatibilityMode) {
-      log.debug(`Using profile ${deviceProfileDir}`);
-    }
+    log.debug(`Using profile ${deviceProfileDir} (ignored by Fenix)`);
 
     await adbUtils.startFirefoxAPK(
       selectedAdbDevice,
       selectedFirefoxApk,
       firefoxApkComponent,
-      this.fennecCompatibilityMode,
       deviceProfileDir,
     );
   }
@@ -582,13 +562,11 @@ export class FirefoxAndroidExtensionRunner {
     }
 
     try {
-      let msg = `Waiting for ${selectedFirefoxApk} Remote Debugging Server...`;
-      if (!this.fennecCompatibilityMode) {
-        msg += (
-          '\nMake sure to enable "Remote Debugging via USB" ' +
-          'from Settings -> Developer Tools if it is not yet enabled.'
-        );
-      }
+      const msg = (
+        `Waiting for ${selectedFirefoxApk} Remote Debugging Server...` +
+        '\nMake sure to enable "Remote Debugging via USB" ' +
+        'from Settings -> Developer Tools if it is not yet enabled.'
+      );
 
       log.info(`\n${msg}\n`);
 

--- a/src/program.js
+++ b/src/program.js
@@ -612,6 +612,12 @@ Example: $0 --help run.
         type: 'string',
         requiresArg: true,
       },
+      'adb-discovery-timeout': {
+        describe: 'Number of milliseconds to wait before giving up',
+        demandOption: false,
+        type: 'number',
+        requiresArg: true,
+      },
       'firefox-apk': {
         describe: (
           'Run a specific Firefox for Android APK. ' +
@@ -620,6 +626,14 @@ Example: $0 --help run.
         demandOption: false,
         type: 'string',
         requiresArg: true,
+      },
+      'fennec-mode': {
+        describe: (
+          'Control the APK as a Fennec-based browser (defaults to true, ' +
+          'set to false if the APK is a geckoview-based browser)'
+        ),
+        demandOption: false,
+        type: 'boolean',
       },
     })
     .command('lint', 'Validate the extension source', commands.lint, {

--- a/src/program.js
+++ b/src/program.js
@@ -627,10 +627,17 @@ Example: $0 --help run.
         type: 'string',
         requiresArg: true,
       },
+      'firefox-apk-component': {
+        describe:
+          'Run a specific Android Component (defaults to <firefox-apk>/.App)',
+        demandOption: false,
+        type: 'string',
+        requiresArg: true,
+      },
       'fennec-mode': {
         describe: (
           'Control the APK as a Fennec-based browser (defaults to true, ' +
-          'set to false if the APK is a geckoview-based browser)'
+          'set to false if the APK is a GeckoView-based browser)'
         ),
         demandOption: false,
         type: 'boolean',

--- a/src/program.js
+++ b/src/program.js
@@ -634,14 +634,6 @@ Example: $0 --help run.
         type: 'string',
         requiresArg: true,
       },
-      'fennec-mode': {
-        describe: (
-          'Control the APK as a Fennec-based browser (defaults to true, ' +
-          'set to false if the APK is a GeckoView-based browser)'
-        ),
-        demandOption: false,
-        type: 'boolean',
-      },
     })
     .command('lint', 'Validate the extension source', commands.lint, {
       'output': {

--- a/src/util/adb.js
+++ b/src/util/adb.js
@@ -254,23 +254,21 @@ export default class ADBUtils {
     deviceId: string,
     apk: string,
     apkComponent: ?string,
-    fennecCompatibilityMode: boolean,
     deviceProfileDir: string,
   ): Promise<void> {
     const {adbClient} = this;
 
     log.debug(
-      `Starting ${apk} with profile ${deviceProfileDir} on ${deviceId}`
+      `Starting ${apk} on ${deviceId}`
     );
 
-    const extras = [];
-
-    if (fennecCompatibilityMode) {
-      extras.push({
-        key: 'args',
-        value: `-profile ${deviceProfileDir}`,
-      });
-    }
+    // Fenix does ignore the -profile parameter, on the contrary Fennec
+    // would run using the given path as the profile to be used during
+    // this execution.
+    const extras = [{
+      key: 'args',
+      value: `-profile ${deviceProfileDir}`,
+    }];
 
     const component = apkComponent ?
       `${apk}/.${apkComponent}` : `${apk}/.App`;

--- a/src/util/adb.js
+++ b/src/util/adb.js
@@ -118,7 +118,8 @@ export default class ADBUtils {
         // Match any package name that starts with the package name of a Firefox for Android browser.
         return (
           line.startsWith('org.mozilla.fennec') ||
-            line.startsWith('org.mozilla.firefox')
+          line.startsWith('org.mozilla.fenix') ||
+          line.startsWith('org.mozilla.firefox')
         );
       });
   }

--- a/src/util/adb.js
+++ b/src/util/adb.js
@@ -119,6 +119,7 @@ export default class ADBUtils {
         return (
           line.startsWith('org.mozilla.fennec') ||
           line.startsWith('org.mozilla.fenix') ||
+          line.startsWith('org.mozilla.geckoview') ||
           line.startsWith('org.mozilla.firefox')
         );
       });
@@ -250,7 +251,11 @@ export default class ADBUtils {
   }
 
   async startFirefoxAPK(
-    deviceId: string, apk: string, deviceProfileDir: string
+    deviceId: string,
+    apk: string,
+    apkComponent: ?string,
+    fennecCompatibilityMode: boolean,
+    deviceProfileDir: string,
   ): Promise<void> {
     const {adbClient} = this;
 
@@ -258,17 +263,24 @@ export default class ADBUtils {
       `Starting ${apk} with profile ${deviceProfileDir} on ${deviceId}`
     );
 
+    const extras = [];
+
+    if (fennecCompatibilityMode) {
+      extras.push({
+        key: 'args',
+        value: `-profile ${deviceProfileDir}`,
+      });
+    }
+
+    const component = apkComponent ?
+      `${apk}/.${apkComponent}` : `${apk}/.App`;
+
     await wrapADBCall(async () => {
       await adbClient.startActivity(deviceId, {
         wait: true,
         action: 'android.activity.MAIN',
-        component: `${apk}/.App`,
-        extras: [
-          {
-            key: 'args',
-            value: `-profile ${deviceProfileDir}`,
-          },
-        ],
+        component,
+        extras,
       });
     });
   }

--- a/tests/unit/test-cmd/test.run.js
+++ b/tests/unit/test-cmd/test.run.js
@@ -231,13 +231,16 @@ describe('run', () => {
   it('creates a Firefox Android runner if "firefox-android" is in target',
      async () => {
        const cmd = prepareRun();
-       await cmd.run({target: ['firefox-android'], fennecMode: false});
+       await cmd.run({
+         target: ['firefox-android'],
+         fennecMode: false,
+         firefoxApkComponent: 'CustomView',
+       });
 
        sinon.assert.calledOnce(androidRunnerStub);
-       assert.equal(
-         androidRunnerStub.firstCall.args[0].fennecMode,
-         false,
-       );
+       const options = androidRunnerStub.firstCall.args[0];
+       assert.equal(options.fennecMode, false);
+       assert.equal(options.firefoxApkComponent, 'CustomView');
        sinon.assert.notCalled(desktopRunnerStub);
      });
 

--- a/tests/unit/test-cmd/test.run.js
+++ b/tests/unit/test-cmd/test.run.js
@@ -231,9 +231,13 @@ describe('run', () => {
   it('creates a Firefox Android runner if "firefox-android" is in target',
      async () => {
        const cmd = prepareRun();
-       await cmd.run({target: ['firefox-android']});
+       await cmd.run({target: ['firefox-android'], fennecMode: false});
 
        sinon.assert.calledOnce(androidRunnerStub);
+       assert.equal(
+         androidRunnerStub.firstCall.args[0].fennecMode,
+         false,
+       );
        sinon.assert.notCalled(desktopRunnerStub);
      });
 

--- a/tests/unit/test-cmd/test.run.js
+++ b/tests/unit/test-cmd/test.run.js
@@ -233,13 +233,11 @@ describe('run', () => {
        const cmd = prepareRun();
        await cmd.run({
          target: ['firefox-android'],
-         fennecMode: false,
          firefoxApkComponent: 'CustomView',
        });
 
        sinon.assert.calledOnce(androidRunnerStub);
        const options = androidRunnerStub.firstCall.args[0];
-       assert.equal(options.fennecMode, false);
        assert.equal(options.firefoxApkComponent, 'CustomView');
        sinon.assert.notCalled(desktopRunnerStub);
      });

--- a/tests/unit/test-extension-runners/test.firefox-android.js
+++ b/tests/unit/test-extension-runners/test.firefox-android.js
@@ -337,13 +337,15 @@ describe('util/extension-runners/firefox-android', () => {
 
          sinon.assert.calledWithMatch(
            fakeADBUtils.amForceStopAPK,
-           'emulator-1', 'org.mozilla.firefox'
+           'emulator-1',
+           'org.mozilla.firefox'
          );
 
          sinon.assert.calledWithMatch(
            fakeADBUtils.startFirefoxAPK,
-           'emulator-1', 'org.mozilla.firefox',
-           undefined, true,
+           'emulator-1',
+           'org.mozilla.firefox',
+           undefined,
            runnerInstance.getDeviceProfileDir()
          );
 
@@ -360,14 +362,14 @@ describe('util/extension-runners/firefox-android', () => {
 
       const runnerInstance = new FirefoxAndroidExtensionRunner({
         ...params,
-        fennecMode: false,
         firefoxApkComponent: 'CustomView',
       });
       await runnerInstance.run();
       sinon.assert.calledWithMatch(
         fakeADBUtils.startFirefoxAPK,
-        'emulator-1', 'org.mozilla.firefox',
-        'CustomView', false,
+        'emulator-1',
+        'org.mozilla.firefox',
+        'CustomView',
         runnerInstance.getDeviceProfileDir()
       );
     });
@@ -943,54 +945,6 @@ describe('util/extension-runners/firefox-android', () => {
 
       consoleStream.stopCapturing();
     });
-
-    it(
-      'does disable fennec compatibility mode if apk name includes .fenix',
-      async () => {
-        const {params} = prepareSelectedDeviceAndAPKParams();
-        const testCases = [
-          {
-            params: {firefoxApk: 'org.mozilla.firefox'},
-            fennecCompatibilityMode: true,
-          },
-          {
-            params: {firefoxApk: 'org.mozilla.fenix'},
-            fennecCompatibilityMode: false,
-          },
-          {
-            params: {firefoxApk: 'org.mozilla.fenix.nightly'},
-            fennecCompatibilityMode: false,
-          },
-          {
-            params: {
-              firefoxApk: 'org.mozilla.fenix',
-              fennecMode: true,
-            },
-            fennecCompatibilityMode: true,
-          },
-          {
-            params: {
-              firefoxApk: 'org.mozilla.fennec',
-              fennecMode: false,
-            },
-            fennecCompatibilityMode: false,
-          },
-        ];
-        for (const testCase of testCases) {
-          const runner = new FirefoxAndroidExtensionRunner({
-            ...params,
-            ...testCase.params,
-          });
-          assert.equal(
-            runner.fennecCompatibilityMode,
-            testCase.fennecCompatibilityMode,
-            `Got expected fennecCompatibilityMode for ${
-              JSON.stringify(testCase)
-            }`
-          );
-        }
-      }
-    );
 
     it(
       'does tell user to enable Remote Debugging when running Fenix',

--- a/tests/unit/test-extension-runners/test.firefox-android.js
+++ b/tests/unit/test-extension-runners/test.firefox-android.js
@@ -343,6 +343,7 @@ describe('util/extension-runners/firefox-android', () => {
          sinon.assert.calledWithMatch(
            fakeADBUtils.startFirefoxAPK,
            'emulator-1', 'org.mozilla.firefox',
+           undefined, true,
            runnerInstance.getDeviceProfileDir()
          );
 
@@ -351,6 +352,25 @@ describe('util/extension-runners/firefox-android', () => {
            fakeADBUtils.startFirefoxAPK
          );
        });
+
+    it('does run a specific apk component if specific', async () => {
+      const {
+        params, fakeADBUtils,
+      } = prepareSelectedDeviceAndAPKParams();
+
+      const runnerInstance = new FirefoxAndroidExtensionRunner({
+        ...params,
+        fennecMode: false,
+        firefoxApkComponent: 'CustomView',
+      });
+      await runnerInstance.run();
+      sinon.assert.calledWithMatch(
+        fakeADBUtils.startFirefoxAPK,
+        'emulator-1', 'org.mozilla.firefox',
+        'CustomView', false,
+        runnerInstance.getDeviceProfileDir()
+      );
+    });
 
     it('supports custom prefs via --pref', async () => {
       const fakeFirefoxApp = {
@@ -969,24 +989,6 @@ describe('util/extension-runners/firefox-android', () => {
             }`
           );
         }
-      }
-    );
-
-    it(
-      'does only require READ_EXTERNAL_STORAGE on fennec mode disabled',
-      async () => {
-        const {params, fakeADBUtils} = prepareSelectedDeviceAndAPKParams();
-        params.firefoxApk = 'org.mozilla.fenix';
-        fakeADBUtils.getAndroidVersionNumber = async () => 23;
-
-        const runner = new FirefoxAndroidExtensionRunner(params);
-        await runner.run();
-        sinon.assert.calledWithMatch(
-          fakeADBUtils.ensureRequiredAPKRuntimePermissions,
-          'emulator-1', 'org.mozilla.fenix', [
-            'android.permission.READ_EXTERNAL_STORAGE',
-          ]
-        );
       }
     );
 

--- a/tests/unit/test-util/test.adb.js
+++ b/tests/unit/test-util/test.adb.js
@@ -676,7 +676,10 @@ describe('utils/adb', () => {
         testFn: (adbUtils) => {
           return adbUtils.startFirefoxAPK(
             'device1',
-            'org.mozilla.firefox_mybuild', '/fake/custom/profile/path'
+            'org.mozilla.firefox_mybuild',
+            undefined, // firefoxApkComponent
+            true, // fennecCompatibilityMode
+            '/fake/custom/profile/path'
           );
         },
       });
@@ -695,7 +698,65 @@ describe('utils/adb', () => {
       );
     });
 
-    it('starts the given Firefox APK on a custom profile', async () => {
+    it('starts Firefox APK on a custom profile on fennecCompatibilityMode',
+       async () => {
+         const adb = getFakeADBKit({
+           adbClient: {
+             startActivity: sinon.spy(() => Promise.resolve()),
+           },
+           adbkitUtil: {
+             readAll: sinon.spy(() => Promise.resolve(Buffer.from('\n'))),
+           },
+         });
+         const adbUtils = new ADBUtils({adb});
+
+         const promiseCompatibilityMode = adbUtils.startFirefoxAPK(
+           'device1',
+           'org.mozilla.firefox_mybuild',
+           undefined, // firefoxApkComponent
+           true, // fennecCompatibilityMode
+           '/fake/custom/profile/path',
+         );
+
+         await assert.isFulfilled(promiseCompatibilityMode);
+
+         const expectedAdbParams = {
+           action: 'android.activity.MAIN',
+           component: 'org.mozilla.firefox_mybuild/.App',
+           extras: [{
+             key: 'args',
+             value: '-profile /fake/custom/profile/path',
+           }],
+           wait: true,
+         };
+
+         sinon.assert.calledOnce(adb.fakeADBClient.startActivity);
+         sinon.assert.calledWithMatch(
+           adb.fakeADBClient.startActivity, 'device1', expectedAdbParams);
+
+         adb.fakeADBClient.startActivity.resetHistory();
+
+         const promise = adbUtils.startFirefoxAPK(
+           'device1',
+           'org.mozilla.firefox_mybuild',
+           undefined, // firefoxApkComponent
+           false, // fennecCompatibilityMode
+           '/fake/custom/profile/path',
+         );
+
+         await assert.isFulfilled(promise);
+
+         sinon.assert.calledOnce(adb.fakeADBClient.startActivity);
+         sinon.assert.calledWithMatch(
+           adb.fakeADBClient.startActivity, 'device1', {
+             ...expectedAdbParams,
+             extras: [],
+           }
+         );
+
+       });
+
+    it('starts a given APK component', async () => {
       const adb = getFakeADBKit({
         adbClient: {
           startActivity: sinon.spy(() => Promise.resolve()),
@@ -707,7 +768,11 @@ describe('utils/adb', () => {
       const adbUtils = new ADBUtils({adb});
 
       const promise = adbUtils.startFirefoxAPK(
-        'device1', 'org.mozilla.firefox_mybuild', '/fake/custom/profile/path'
+        'device1',
+        'org.mozilla.geckoview_example',
+        'GeckoViewActivity', // firefoxApkComponent
+        false, // fennecCompatibilityMode
+        '/fake/custom/profile/path',
       );
 
       await assert.isFulfilled(promise);
@@ -716,14 +781,12 @@ describe('utils/adb', () => {
       sinon.assert.calledWithMatch(
         adb.fakeADBClient.startActivity, 'device1', {
           action: 'android.activity.MAIN',
-          component: 'org.mozilla.firefox_mybuild/.App',
-          extras: [{
-            key: 'args',
-            value: '-profile /fake/custom/profile/path',
-          }],
+          component: 'org.mozilla.geckoview_example/.GeckoViewActivity',
+          extras: [],
           wait: true,
         }
       );
+
     });
   });
 

--- a/tests/unit/test-util/test.adb.js
+++ b/tests/unit/test-util/test.adb.js
@@ -678,7 +678,6 @@ describe('utils/adb', () => {
             'device1',
             'org.mozilla.firefox_mybuild',
             undefined, // firefoxApkComponent
-            true, // fennecCompatibilityMode
             '/fake/custom/profile/path'
           );
         },
@@ -698,7 +697,7 @@ describe('utils/adb', () => {
       );
     });
 
-    it('starts Firefox APK on a custom profile on fennecCompatibilityMode',
+    it('starts Firefox APK on a custom profile (only used by Fennec)',
        async () => {
          const adb = getFakeADBKit({
            adbClient: {
@@ -714,7 +713,6 @@ describe('utils/adb', () => {
            'device1',
            'org.mozilla.firefox_mybuild',
            undefined, // firefoxApkComponent
-           true, // fennecCompatibilityMode
            '/fake/custom/profile/path',
          );
 
@@ -733,27 +731,6 @@ describe('utils/adb', () => {
          sinon.assert.calledOnce(adb.fakeADBClient.startActivity);
          sinon.assert.calledWithMatch(
            adb.fakeADBClient.startActivity, 'device1', expectedAdbParams);
-
-         adb.fakeADBClient.startActivity.resetHistory();
-
-         const promise = adbUtils.startFirefoxAPK(
-           'device1',
-           'org.mozilla.firefox_mybuild',
-           undefined, // firefoxApkComponent
-           false, // fennecCompatibilityMode
-           '/fake/custom/profile/path',
-         );
-
-         await assert.isFulfilled(promise);
-
-         sinon.assert.calledOnce(adb.fakeADBClient.startActivity);
-         sinon.assert.calledWithMatch(
-           adb.fakeADBClient.startActivity, 'device1', {
-             ...expectedAdbParams,
-             extras: [],
-           }
-         );
-
        });
 
     it('starts a given APK component', async () => {
@@ -771,7 +748,6 @@ describe('utils/adb', () => {
         'device1',
         'org.mozilla.geckoview_example',
         'GeckoViewActivity', // firefoxApkComponent
-        false, // fennecCompatibilityMode
         '/fake/custom/profile/path',
       );
 
@@ -782,7 +758,10 @@ describe('utils/adb', () => {
         adb.fakeADBClient.startActivity, 'device1', {
           action: 'android.activity.MAIN',
           component: 'org.mozilla.geckoview_example/.GeckoViewActivity',
-          extras: [],
+          extras: [{
+            key: 'args',
+            value: '-profile /fake/custom/profile/path',
+          }],
           wait: true,
         }
       );

--- a/tests/unit/test.program.js
+++ b/tests/unit/test.program.js
@@ -831,6 +831,26 @@ describe('program.main', () => {
       assert.equal(options.fennecMode, false);
     }
   );
+
+  it(
+    'does pass a custom apk component with --firefox-apk-component',
+    async () => {
+      const fakeCommands = fake(commands, {
+        build: () => Promise.resolve(),
+      });
+      await execProgram(
+        [
+          'run',
+          '--firefox-apk-component', 'CustomView',
+          '-t', 'firefox-android',
+        ],
+        {commands: fakeCommands}
+      );
+      const options = fakeCommands.run.firstCall.args[0];
+      assert.equal(options.firefoxApkComponent, 'CustomView');
+    }
+  );
+
 });
 
 describe('program.defaultVersionGetter', () => {

--- a/tests/unit/test.program.js
+++ b/tests/unit/test.program.js
@@ -816,6 +816,21 @@ describe('program.main', () => {
         assert.equal(options.artifactsDir, 'xxx');
       });
   });
+
+  it(
+    'does disable fennec compatibility mode with --fennec-mode=false',
+    async () => {
+      const fakeCommands = fake(commands, {
+        build: () => Promise.resolve(),
+      });
+      await execProgram(
+        ['run', '--fennec-mode', 'false', '-t', 'firefox-android'],
+        {commands: fakeCommands}
+      );
+      const options = fakeCommands.run.firstCall.args[0];
+      assert.equal(options.fennecMode, false);
+    }
+  );
 });
 
 describe('program.defaultVersionGetter', () => {

--- a/tests/unit/test.program.js
+++ b/tests/unit/test.program.js
@@ -818,21 +818,6 @@ describe('program.main', () => {
   });
 
   it(
-    'does disable fennec compatibility mode with --fennec-mode=false',
-    async () => {
-      const fakeCommands = fake(commands, {
-        build: () => Promise.resolve(),
-      });
-      await execProgram(
-        ['run', '--fennec-mode', 'false', '-t', 'firefox-android'],
-        {commands: fakeCommands}
-      );
-      const options = fakeCommands.run.firstCall.args[0];
-      assert.equal(options.fennecMode, false);
-    }
-  );
-
-  it(
     'does pass a custom apk component with --firefox-apk-component',
     async () => {
       const fakeCommands = fake(commands, {


### PR DESCRIPTION
This pull request applies the following tweaks to make it easier to test a webextensions on a GeckoView-based browsers:

- Added Fenix and GeckoView to the auto-detected APK names (so that the user doesn't need to explicitly select the APK if Fenix is the only installed one)
- Exposed the `--adb-discovery-timeout` parameter (already supported internally but never exposed to as a cli option, it can be used to change the maximum time to wait for the remote debugging server discovery)
- Added a new `--firefox-apk-component` cli option (needed to make it easier to use `web-ext run` with other custom GeckoView-based apps, e.g. a user may add `--firefox-apk-component GeckoViewActivity` to run an extension on the geckoview_example)
- ~~Added a new --fennec-mode boolean parameter (which the user can set to "force disable" the "Fennec compatibility mode")~~ (removed as not strictly needed, we may add it in the future if it may actually help the transition from Fennec to Fenix)
- ~~Only require the READ_EXTERNAL_STORAGE permission for non-Fennec Firefox for Android browsers (required to be able to access the XPI file from the path where web-ext run has uploaded it on the device, the WRITE_EXTERNAL_STORAGE is only required on Fennec because it is executed on a separate Firefox profile created on the sdcard)~~ (geckoview_example doesn't seem to work without the WRITE_EXTERNAL_STORAGE, this PR keeps the requirement unmodified for now, we may re-evaluate later)

The version of the firefox-android extension runner in this pull request still defaults to use the "Fennec Compatibility mode" for APK files without ".fenix" in their name, the `--fennec-mode` CLI option is meant to allow the user to explicitly set the "Fennec Compatibility mode" if needed.
[Once Fenix would completely replace Fennec in the release channel](https://arewefenixyet.com/), the "Fennec Compatibility mode" should be changed to default to `false`.

[![web-ext run on Fenix - Screencast](https://img.youtube.com/vi/3V09P6CPsfY/0.jpg)](https://youtu.be/3V09P6CPsfY)

Follow ups on the GeckoView / Fenix side:
- [Bug 1596867 - [remote-dbg-next] Temporary extensions should be listed on remote devices](https://bugzilla.mozilla.org/show_bug.cgi?id=1596867)
  - to make it easier to debug the installed extensions (by making it visible from about:debugging for connected remote targets)
- [Bug 1614295 - Notify GeckoView embedder apps of new temporary extensions installed through the Remote Debugging Server](https://bugzilla.mozilla.org/show_bug.cgi?id=1614295)
  - otherwise the parts of the extensions that require a native UI (e.g. browserAction/pageAction, 
    options pages) wouldn't be available when the extension installation flow isn't started by the
    GeckoView app itself
- [ ] issue #NNN - Fennec Addon Manager view should list the extension temporarily installed through the Remote Debugging Server
  - otherwise the developer may not be sure if the extension has been successfully installed,
    and there wouldn't be an easy way to reach and test an extension options ui page.
  -  (TODO this depends from Bug 1614195, file on github after initial feedback on Bug 1614195) 