### PR TITLE
chore(travis): Ported deploy config to dpl v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,12 @@ jobs:
     deploy:
       provider: npm
       email: addons-dev-automation+npm@mozilla.com
+      # Travis dpl v2 (See https://docs.travis-ci.com/user/deployment-v2/providers/npm/)
+      edge: true
       # Note that cleanup runs *after* the before_deploy script.
-      skip_cleanup: true
+      cleanup: false
       # This is the API key for npm user 'addons-robot'
-      api_key:
+      api_token:
         secure: CVUpq7hp1/CvAD40vA0cm+5jI7Izlsb83mCNrAt7Qcjb4orFWTHUxE3Y0a5wGS2gAIr5l/hd/CruXdy4EfMVS6GyW5qhTeWxS0b36+t542z4Xlk9eY4UvB5DdKMJKH8RT+Sz8E/Sx6fhISgvQW48rGJCq3ePaH54mLkXLRJW7HqZxSnrAGc8XLiTJOUPKhOzo4AALXvLKDB+doTtHtSDFD+G+kpABMlJBw849V4mGVi/oUpK5Z/tnCjBBKIaU2Cw//2rE0Wo2mN4osq9eUHxNNTA4fTZoEONaDN/zeYhp3IjYc4cRVK611xnhITLW8CJwRSFJYaoPDB0S1sHOuIcl026SC36m01m7vb0RdxzxhTRBcdClSgo0VcqWHjGjZ5knR1s3ztUcOgVbkcuyQ7x03jp7DEe52sH86myzpWpymu6StRXQix4YjkDoGMFczhPmOP+fWYUex87VCsF1f3rdXJSQmtFuM4Tm11E4WoZGaLB5cgKTNZodJ5v6+UK5u3mop59fIJsIrFF+NKCJNnHvegchiLyGiOJb5wYWpnP4/O2XXNvDEtSPJBRGT/fcHVnYBr6hAl6ux/z4ND3xX77hKKnqQk+CrR28aQpURBNJMKFgtW2DcABAXTZ16ezhXsPlIp6/2GXu0VozTTnwPCRhvsl+s+dqqJu0faxSo+vB7s=
       on:
         tags: true


### PR DESCRIPTION
The travis config that we are currently use is failing to deploy a tagged release on npm:
- https://travis-ci.org/mozilla/web-ext/jobs/649392805#L283-L284

I've been looking for clues about this issue in the travis forum and bug tracker, and it looks that it is an issue that other projects are also being triggering recently, e.g. it seems the same issue reported and discussed in the following posts from the travis forum:
- https://travis-ci.community/t/build-config-validation-using-api-key-breaks-npm-deployments/
- https://travis-ci.community/t/npm-deploy-failed-missing-api-key-but-i-have-set-it/

The workaround suggested (disabling the build validation from the Travis settings ui) doesn't seem to work for our repo.

This pull request is about trying another possible approach to fix the issue:
porting it to the new configuration format.

Travis docs related to the new deploy config format: https://docs.travis-ci.com/user/deployment-v2/providers/npm/