### PR TITLE
fix: Added cleaning up old files In android

### DIFF
--- a/src/extension-runners/firefox-android.js
+++ b/src/extension-runners/firefox-android.js
@@ -132,7 +132,13 @@ export class FirefoxAndroidExtensionRunner {
     await this.apkPackagesDiscoveryAndSelect();
     await this.adbCheckRuntimePermissions();
     await this.adbForceStopSelectedPackage();
-
+    for (const fn of this.cleanupCallbacks) {
+      try {
+        fn();
+      } catch (error) {
+        log.error(error);
+      }
+    }
     // Create profile prefs (with enabled remote RDP server), prepare the
     // artifacts and temporary directory on the selected device, and
     // push the profile preferences to the remote profile dir.


### PR DESCRIPTION
fix: Added cleaning up old files In android
Calling cleanupCallbacks.
Also used
if (selectedArtifactsDir)
{log.debug('Cleaning up artifacts directory on the Android device...');
await adbUtils.clearArtifactsDir(selectedAdbDevice);}

But this caused in decrease of coverage.
So just this.cleanupCallbacks functions is called.