### PR TITLE
fix: Cleanup old web-ext run artifacts dir when we are connecting to an android device

### DIFF
--- a/src/extension-runners/firefox-android.js
+++ b/src/extension-runners/firefox-android.js
@@ -128,6 +128,15 @@ export class FirefoxAndroidExtensionRunner {
       adbBin, adbHost, adbPort,
     });
 
+    // Call all the registered cleanup callbacks.
+    for (const fn of this.cleanupCallbacks) {
+      try {
+        fn();
+      } catch (error) {
+        log.error(error);
+      }
+    }
+
     await this.adbDevicesDiscoveryAndSelect();
     await this.apkPackagesDiscoveryAndSelect();
     await this.adbCheckRuntimePermissions();


### PR DESCRIPTION
fix: Added cleaning up old files In android
Calling cleanupCallbacks.
Also used
if (selectedArtifactsDir)
{log.debug('Cleaning up artifacts directory on the Android device...');
await adbUtils.clearArtifactsDir(selectedAdbDevice);}

But this caused in decrease of coverage.
So just this.cleanupCallbacks functions is called.

(Fixes #1591)