### PR TITLE
feat: Add reference browser support to the firefox-android extension runner (#1870)

### DIFF
--- a/src/util/adb.js
+++ b/src/util/adb.js
@@ -120,7 +120,8 @@ export default class ADBUtils {
           line.startsWith('org.mozilla.fennec') ||
           line.startsWith('org.mozilla.fenix') ||
           line.startsWith('org.mozilla.geckoview') ||
-          line.startsWith('org.mozilla.firefox')
+          line.startsWith('org.mozilla.firefox') ||
+          line.startsWith('org.mozilla.reference.browser')
         );
       });
   }

--- a/tests/unit/test-extension-runners/test.firefox-android.js
+++ b/tests/unit/test-extension-runners/test.firefox-android.js
@@ -114,6 +114,7 @@ function prepareSelectedDeviceAndAPKParams(
     discoverInstalledFirefoxAPKs: sinon.spy(() => Promise.resolve([
       'org.mozilla.fennec', 'org.mozilla.firefox',
       'org.mozilla.fenix', 'org.mozilla.fenix.nightly',
+      'org.mozilla.reference.browser',
     ])),
     getAndroidVersionNumber: sinon.spy(() => Promise.resolve(20)),
     amForceStopAPK: sinon.spy(() => Promise.resolve()),


### PR DESCRIPTION
In addition to Fenix support (#1834), we'd like to add Reference Browser as well. 🙂 