### PR TITLE
add --filename option to specify a filename template

### DIFF
--- a/src/program.js
+++ b/src/program.js
@@ -342,6 +342,15 @@ type MainParams = {
   runOptions?: Object,
 }
 
+export function throwUsageErrorIfArray(errorMessage: string): any {
+  return (value: any): any => {
+    if (Array.isArray(value)) {
+      throw new UsageError(errorMessage);
+    }
+    return value;
+  };
+}
+
 export function main(
   absolutePackageDir: string,
   {
@@ -428,6 +437,18 @@ Example: $0 --help run.
       demandOption: false,
       default: true,
       type: 'boolean',
+    },
+    'filename': {
+      alias: 'n',
+      describe: 'Name of the created extension package file.',
+      default: undefined,
+      normalize: false,
+      demandOption: false,
+      requiresArg: true,
+      type: 'string',
+      coerce: throwUsageErrorIfArray(
+        'Multiple --filename/-n option are not allowed'
+      ),
     },
   });
 

--- a/tests/functional/test.cli.build.js
+++ b/tests/functional/test.cli.build.js
@@ -1,5 +1,6 @@
 /* @flow */
 import {describe, it} from 'mocha';
+import {assert} from 'chai';
 
 import {
   minimalAddonPath, withTempAddonDir, execWebExt, reportCommandErrors,
@@ -20,6 +21,17 @@ describe('web-ext build', () => {
              stderr,
            });
          }
+       });
+     })
+  );
+
+  it('throws an error on multiple -n',
+     () => withTempAddonDir({addonPath: minimalAddonPath}, (srcDir, tmpDir) => {
+       const argv = ['build', '-n', 'foo', '-n', 'bar'];
+       const cmd = execWebExt(argv, {cwd: tmpDir});
+       return cmd.waitForExit.then(({exitCode, stderr}) => {
+         assert.notEqual(exitCode, 0);
+         assert.match(stderr, /Multiple --filename\/-n option are not allowed/);
        });
      })
   );

--- a/tests/unit/test-cmd/test.build.js
+++ b/tests/unit/test-cmd/test.build.js
@@ -10,6 +10,7 @@ import defaultEventToPromise from 'event-to-promise';
 import build, {
   safeFileName,
   getDefaultLocalizedName,
+  getStringPropertyValue,
   defaultPackageCreator,
 } from '../../../src/cmd/build';
 import {FileFilter} from '../../../src/util/file-filter';
@@ -72,6 +73,40 @@ describe('build', () => {
     });
   });
 
+  it('throws on missing manifest properties in filename template', () => {
+    return withTempDir(
+      (tmpDir) =>
+        build({
+          sourceDir: fixturePath('minimal-web-ext'),
+          artifactsDir: tmpDir.path(),
+          filename: '{missingKey}-{version}.xpi',
+        })
+          .then(makeSureItFails())
+          .catch((error) => {
+            log.info(error);
+            assert.instanceOf(error, UsageError);
+            assert.match(
+              error.message,
+              /Manifest key "missingKey" is missing/);
+          })
+    );
+  });
+
+  it('gives the correct custom name to an extension', () => {
+    return withTempDir(
+      (tmpDir) =>
+        build({
+          sourceDir: fixturePath('minimal-web-ext'),
+          artifactsDir: tmpDir.path(),
+          filename: '{applications.gecko.id}-{version}.xpi',
+        })
+          .then((buildResult) => {
+            assert.match(path.basename(buildResult.extensionPath),
+                         /minimal-example_web-ext-test-suite-1.0\.xpi$/);
+          })
+    );
+  });
+
   it('gives the correct name to a localized extension', () => {
     return withTempDir(
       (tmpDir) =>
@@ -82,6 +117,44 @@ describe('build', () => {
           .then((buildResult) => {
             assert.match(buildResult.extensionPath,
                          /name_of_the_extension-1\.0\.zip$/);
+          })
+    );
+  });
+
+  it('throws an error if the filename contains a path', () => {
+    return withTempDir(
+      (tmpDir) =>
+        build({
+          sourceDir: fixturePath('minimal-web-ext'),
+          artifactsDir: tmpDir.path(),
+          filename: 'foo/{version}.xpi',
+        })
+          .then(makeSureItFails())
+          .catch((error) => {
+            log.info(error);
+            assert.instanceOf(error, UsageError);
+            assert.match(
+              error.message,
+              /Filename "foo\/1.0.xpi" should not contain a path/);
+          })
+    );
+  });
+
+  it('throws an error if the filename doesn\'t end in .xpi or .zip', () => {
+    return withTempDir(
+      (tmpDir) =>
+        build({
+          sourceDir: fixturePath('minimal-web-ext'),
+          artifactsDir: tmpDir.path(),
+          filename: '{version}.unknown-ext',
+        })
+          .then(makeSureItFails())
+          .catch((error) => {
+            log.info(error);
+            assert.instanceOf(error, UsageError);
+            assert.match(
+              error.message,
+              /Filename "1.0.unknown-ext" should have a zip or xpi extension/);
           })
     );
   });
@@ -505,6 +578,19 @@ describe('build', () => {
               assert.match(error.message, /Unexpected error/);
             });
         });
+    });
+
+  });
+
+  describe('getStringPropertyValue', () => {
+
+    it('accepts the value 0', () => {
+      assert.equal(getStringPropertyValue('foo', {foo: 0}), '0');
+    });
+
+    it('throws an error if string value is empty', () => {
+      assert.throws(() => getStringPropertyValue('foo', {foo: ''}),
+                    UsageError, /Manifest key "foo" value is an empty string/);
     });
 
   });

--- a/tests/unit/test.program.js
+++ b/tests/unit/test.program.js
@@ -8,7 +8,12 @@ import sinon, {spy} from 'sinon';
 import {assert} from 'chai';
 
 import {applyConfigToArgv} from '../../src/config';
-import {defaultVersionGetter, main, Program} from '../../src/program';
+import {
+  defaultVersionGetter,
+  main,
+  Program,
+  throwUsageErrorIfArray,
+} from '../../src/program';
 import commands from '../../src/cmd';
 import {
   onlyInstancesOf,
@@ -856,5 +861,14 @@ describe('program.defaultVersionGetter', () => {
     const testBuildEnv = {globalEnv: 'development'};
     assert.equal(defaultVersionGetter(projectRoot, testBuildEnv),
                  commit);
+  });
+});
+
+describe('program.throwUsageErrorIfArray', () => {
+  const errorMessage = 'This is the expected error message';
+  const innerFn = throwUsageErrorIfArray(errorMessage);
+
+  it('throws UsageError on array', () => {
+    assert.throws(() => innerFn(['foo', 'bar']), UsageError, errorMessage);
   });
 });


### PR DESCRIPTION
Fixes #1335. Based off #1741 and its review comments.

Questions:

- Does `-n` make sense as a single letter filename option? (`n` for name) I'm happy to add that or keep it as-is.
- Is there a reason why we [can't specify a directory path](https://github.com/mozilla/web-ext/pull/1741/files#r348005562)? I could see dying if the path specified doesn't exist, but I'm not sure why we can't write to a different directory.
- The code, as written, changes the `@` in the name to an underscore `_` (`minimal-example_web-ext-test-suite`. Is that expected? Should we allow for people to name the file what they want, if they pass in a flag (or warn that their name doesn't follow certain conventions)?

JavaScript isn't my strong suit; please review accordingly :)