### PR TITLE
fix: Enable extensions to load on android build variants

### DIFF
--- a/src/util/adb.js
+++ b/src/util/adb.js
@@ -277,10 +277,8 @@ export default class ADBUtils {
       component = `${apk}/.App`;
     } else if (apkComponent.includes('.')) {
       component = `${apk}/${apkComponent}`;
-    } else if (apkComponent) {
-      component = `${apk}/.${apkComponent}`;
     } else {
-      component = `${apk}/.App`;
+      component = `${apk}/.${apkComponent}`;
     }
 
     await wrapADBCall(async () => {

--- a/src/util/adb.js
+++ b/src/util/adb.js
@@ -271,15 +271,14 @@ export default class ADBUtils {
       value: `-profile ${deviceProfileDir}`,
     }];
 
-    let component;
-
     if (!apkComponent) {
-      component = `${apk}/.App`;
-    } else if (apkComponent.includes('.')) {
-      component = `${apk}/${apkComponent}`;
-    } else {
-      component = `${apk}/.${apkComponent}`;
+      apkComponent = '.App';
+    } else if (!apkComponent.includes('.')) {
+      apkComponent = `.${apkComponent}`;
     }
+    // if `apkComponent` starts with a '.', then adb will expand
+    // the following to: `${apk}/${apk}.${apkComponent}`
+    const component = `${apk}/${apkComponent}`;
 
     await wrapADBCall(async () => {
       await adbClient.startActivity(deviceId, {

--- a/src/util/adb.js
+++ b/src/util/adb.js
@@ -271,8 +271,17 @@ export default class ADBUtils {
       value: `-profile ${deviceProfileDir}`,
     }];
 
-    const component = apkComponent ?
-      `${apk}/.${apkComponent}` : `${apk}/.App`;
+    let component;
+
+    if (!apkComponent) {
+      component = `${apk}/.App`;
+    } else if (apkComponent.includes(".")) {
+      component = `${apk}/${apkComponent}`;
+    } else if (apkComponent) {
+      component = `${apk}/.${apkComponent}`;
+    } else {
+      component = `${apk}/.App`;
+    }
 
     await wrapADBCall(async () => {
       await adbClient.startActivity(deviceId, {

--- a/src/util/adb.js
+++ b/src/util/adb.js
@@ -275,7 +275,7 @@ export default class ADBUtils {
 
     if (!apkComponent) {
       component = `${apk}/.App`;
-    } else if (apkComponent.includes(".")) {
+    } else if (apkComponent.includes('.')) {
       component = `${apk}/${apkComponent}`;
     } else if (apkComponent) {
       component = `${apk}/.${apkComponent}`;

--- a/tests/unit/test-util/test.adb.js
+++ b/tests/unit/test-util/test.adb.js
@@ -733,7 +733,7 @@ describe('utils/adb', () => {
            adb.fakeADBClient.startActivity, 'device1', expectedAdbParams);
        });
 
-    it('starts a given APK component', async () => {
+    it('starts a given APK component without a period', async () => {
       const adb = getFakeADBKit({
         adbClient: {
           startActivity: sinon.spy(() => Promise.resolve()),
@@ -765,7 +765,41 @@ describe('utils/adb', () => {
           wait: true,
         }
       );
+    });
 
+    it('starts a given APK component with a period', async () => {
+      const adb = getFakeADBKit({
+        adbClient: {
+          startActivity: sinon.spy(() => Promise.resolve()),
+        },
+        adbkitUtil: {
+          readAll: sinon.spy(() => Promise.resolve(Buffer.from('\n'))),
+        },
+      });
+      const adbUtils = new ADBUtils({adb});
+
+      const promise = adbUtils.startFirefoxAPK(
+        'device1',
+        'org.mozilla.geckoview_example',
+        'org.mozilla.geckoview_example.GeckoViewActivity', // firefoxApkComponent
+        '/fake/custom/profile/path',
+      );
+
+      await assert.isFulfilled(promise);
+
+      sinon.assert.calledOnce(adb.fakeADBClient.startActivity);
+      sinon.assert.calledWithMatch(
+        adb.fakeADBClient.startActivity, 'device1', {
+          action: 'android.activity.MAIN',
+          component: 'org.mozilla.geckoview_example/' +
+            'org.mozilla.geckoview_example.GeckoViewActivity',
+          extras: [{
+            key: 'args',
+            value: '-profile /fake/custom/profile/path',
+          }],
+          wait: true,
+        }
+      );
     });
   });
 


### PR DESCRIPTION
This PR fixes https://github.com/mozilla/web-ext/issues/1891 to add support for extensions loaded on android build variants.

Tested using:

```
web-ext run -t firefox-android --android-device=<device ID here> --firefox-apk=org.mozilla.reference.browser.debug --firefox-apk-component=org.mozilla.reference.browser.BrowserActivity

web-ext run -t firefox-android --android-device=<device ID here> --firefox-apk=org.mozilla.fenix.performancetest --firefox-apk-component=org.mozilla.fenix.HomeActivity
```

