### PR TITLE
chore: Fix missing conventional-changelog script when running npm run changelog

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test-functional": "node scripts/test-functional",
     "publish-coverage": "nyc report --reporter=text-lcov | coveralls",
     "audit-deps": "node ./scripts/audit-deps",
-    "changelog": "conventional-changelog -p angular -u",
+    "changelog": "npx conventional-changelog-cli -p angular -u",
     "changelog-lint": "commitlint --from master",
     "changelog-lint-from-stdin": "commitlint",
     "travis-pr-title-lint": "node ./scripts/travis-pr-title-lint",


### PR DESCRIPTION
I did remove conventional-changelog-cli in #1902, but I did forgot that it was actually used in this npm script.

Given that I do run this script only when we are going to release a new version, I think that we can actually opt to run it using npx to avoid having it as a dev dependency for anyone would clone the repo to develop a patch.