### PR TITLE
fix(deps): update dependency chrome-launcher to v0.13.3 and adapt chromium extension-runner and defaultFlags test case

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3806,21 +3806,30 @@
       "dev": true
     },
     "chrome-launcher": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.13.1.tgz",
-      "integrity": "sha512-q8UiCNAknw6kCUvCVBTAEw1BwT0vaxabCrSjN3B/NWohp12YBD9+DalymYElSoKRD4KpVSu4CCl0us4v/J81Sg==",
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.13.3.tgz",
+      "integrity": "sha512-ovrDuFXgXS96lzeDqFPQRsczkxla+6QMvzsF+1u0mKlD1KE8EuhjdLwiDfIFedb0FSLz18RK3y6IbKu8oqA0qw==",
       "requires": {
         "@types/node": "*",
-        "is-wsl": "^2.1.0",
+        "escape-string-regexp": "^1.0.5",
+        "is-wsl": "^2.2.0",
         "lighthouse-logger": "^1.0.0",
         "mkdirp": "^0.5.3",
         "rimraf": "^3.0.2"
       },
       "dependencies": {
+        "is-wsl": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+          "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+          "requires": {
+            "is-docker": "^2.0.0"
+          }
+        },
         "mkdirp": {
-          "version": "0.5.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
-          "integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -7751,6 +7760,11 @@
       "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
       "dev": true
+    },
+    "is-docker": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
+      "integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ=="
     },
     "is-extendable": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "addons-linter": "1.23.0",
     "bunyan": "1.8.12",
     "camelcase": "5.3.1",
-    "chrome-launcher": "0.13.1",
+    "chrome-launcher": "0.13.3",
     "debounce": "1.2.0",
     "decamelize": "3.2.0",
     "es6-error": "4.1.1",

--- a/src/extension-runners/chromium.js
+++ b/src/extension-runners/chromium.js
@@ -10,9 +10,8 @@ import path from 'path';
 import {fs} from 'mz';
 import asyncMkdirp from 'mkdirp';
 import {
-  LaunchedChrome,
+  Launcher as ChromeLauncher,
   launch as defaultChromiumLaunch,
-  default as ChromeLauncher,
 } from 'chrome-launcher';
 import WebSocket from 'ws';
 
@@ -51,7 +50,7 @@ export const DEFAULT_CHROME_FLAGS = ChromeLauncher.defaultFlags()
 export class ChromiumExtensionRunner {
   cleanupCallbacks: Set<Function>;
   params: ChromiumExtensionRunnerParams;
-  chromiumInstance: LaunchedChrome;
+  chromiumInstance: ChromeLauncher;
   chromiumLaunch: typeof defaultChromiumLaunch;
   reloadManagerExtension: string;
   wss: WebSocket.Server;

--- a/tests/unit/test-extension-runners/test.chromium.js
+++ b/tests/unit/test-extension-runners/test.chromium.js
@@ -63,6 +63,7 @@ describe('util/extension-runners/chromium', async () => {
       '--disable-backgrounding-occluded-windows',
       '--disable-renderer-backgrounding',
       '--disable-background-timer-throttling',
+      '--force-fieldtrials=*BackgroundTracing/default/',
     ];
 
     assert.deepEqual(DEFAULT_CHROME_FLAGS, expectedFlags);


### PR DESCRIPTION
This pull request does supersede #1904.

Besides including the renovatebot changes from #1904 it is also:
- fixing incompatibilities between the properties exported in chrome-launcher v.0.13.3 and what extension-runners/chromium.js is using internally
- adding a new default flag included in v.0.13.3 into the test.chromium.js unit test  