### PR TITLE
chore(deps): Removed unused stream-to-promise from the package.json dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "parse-json": "5.0.0",
     "sign-addon": "2.0.5",
     "source-map-support": "0.5.19",
-    "stream-to-promise": "2.2.0",
     "strip-bom": "4.0.0",
     "strip-json-comments": "3.1.1",
     "tmp": "0.2.1",


### PR DESCRIPTION
This PR supersedes #1914 

It looks that `stream-to-promise` has been added as part of #744 but it is unused in that pull request (and we never used anywhere in the web-ext sources in the meantime).