### PR TITLE
fix: Detect old artifacts dirs on adb device, remove automatically using the new --adb-remove-old-artifacts cli option

### DIFF
--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -45,6 +45,7 @@ export type CmdRunParams = {|
   adbPort?: string,
   adbDevice?: string,
   adbDiscoveryTimeout?: number,
+  adbCleanArtifacts?: boolean,
   firefoxApk?: string,
   firefoxApkComponent?: string,
 
@@ -87,6 +88,7 @@ export default async function run(
     adbPort,
     adbDevice,
     adbDiscoveryTimeout,
+    adbCleanArtifacts,
     firefoxApk,
     firefoxApkComponent,
     // Chromium CLI options.
@@ -165,6 +167,7 @@ export default async function run(
       adbPort,
       adbBin,
       adbDiscoveryTimeout,
+      adbCleanArtifacts,
 
       // Injected dependencies.
       firefoxApp,

--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -45,7 +45,7 @@ export type CmdRunParams = {|
   adbPort?: string,
   adbDevice?: string,
   adbDiscoveryTimeout?: number,
-  adbCleanArtifacts?: boolean,
+  adbRemoveOldArtifacts?: boolean,
   firefoxApk?: string,
   firefoxApkComponent?: string,
 
@@ -88,7 +88,7 @@ export default async function run(
     adbPort,
     adbDevice,
     adbDiscoveryTimeout,
-    adbCleanArtifacts,
+    adbRemoveOldArtifacts,
     firefoxApk,
     firefoxApkComponent,
     // Chromium CLI options.
@@ -167,7 +167,7 @@ export default async function run(
       adbPort,
       adbBin,
       adbDiscoveryTimeout,
-      adbCleanArtifacts,
+      adbRemoveOldArtifacts,
 
       // Injected dependencies.
       firefoxApp,

--- a/src/extension-runners/firefox-android.js
+++ b/src/extension-runners/firefox-android.js
@@ -71,7 +71,7 @@ export type FirefoxAndroidExtensionRunnerParams = {|
   adbPort?: string,
   adbDevice?: string,
   adbDiscoveryTimeout?: number,
-  adbCleanArtifacts?: boolean,
+  adbRemoveOldArtifacts?: boolean,
   firefoxApk?: string,
   firefoxApkComponent?: string,
 
@@ -385,30 +385,6 @@ export class FirefoxAndroidExtensionRunner {
     await adbUtils.amForceStopAPK(selectedAdbDevice, selectedFirefoxApk);
   }
 
-  async adbOldArtifactsDir(removeArtifacts?: boolean) {
-    const {
-      adbUtils,
-      selectedAdbDevice,
-    } = this;
-
-    const foundDirectories = await adbUtils.checkOrCleanArtifacts(
-      selectedAdbDevice, removeArtifacts
-    );
-
-    if (!foundDirectories) {
-      return;
-    }
-    if (removeArtifacts) {
-      log.info('Old web-ext artifacts have been found and removed ' +
-              `from ${selectedAdbDevice} device`);
-    } else {
-      log.warn(
-        `Old artifacts directories have been found on ${selectedAdbDevice} ` +
-        'device. Use --adb-clean-artifacts to remove them automatically.'
-      );
-    }
-  }
-
   async adbCheckRuntimePermissions() {
     const {
       adbUtils,
@@ -456,6 +432,7 @@ export class FirefoxAndroidExtensionRunner {
       params: {
         customPrefs,
         firefoxApp,
+        adbRemoveOldArtifacts,
       },
     } = this;
     // Create the preferences file and the Fennec temporary profile.
@@ -466,8 +443,23 @@ export class FirefoxAndroidExtensionRunner {
       customPrefs,
     });
 
-    //Checking for older artifacts
-    await this.adbOldArtifactsDir(this.params.adbCleanArtifacts);
+    // Check if there are any artifacts dirs from previous runs and
+    // automatically remove them if adbRemoteOldArtifacts is true.
+    const foundOldArtifacts = await adbUtils.detectOrRemoveOldArtifacts(
+      selectedAdbDevice, adbRemoveOldArtifacts
+    );
+
+    if (foundOldArtifacts) {
+      if (adbRemoveOldArtifacts) {
+        log.info('Old web-ext artifacts have been found and removed ' +
+          `from ${selectedAdbDevice} device`);
+      } else {
+        log.warn(
+          `Old artifacts directories have been found on ${selectedAdbDevice} ` +
+          'device. Use --adb-remove-old-artifacts to remove them automatically.'
+        );
+      }
+    }
 
     // Choose a artifacts dir name for the assets pushed to the
     // Android device.

--- a/src/program.js
+++ b/src/program.js
@@ -663,8 +663,8 @@ Example: $0 --help run.
         type: 'number',
         requiresArg: true,
       },
-      'adb-clean-artifacts': {
-        describe: 'Remove old artifact directories from the adb device',
+      'adb-remove-old-artifacts': {
+        describe: 'Remove old artifacts directories from the adb device',
         demandOption: false,
         type: 'boolean',
       },

--- a/src/program.js
+++ b/src/program.js
@@ -663,6 +663,11 @@ Example: $0 --help run.
         type: 'number',
         requiresArg: true,
       },
+      'adb-clean-artifacts': {
+        describe: 'Remove old artifact directories from the adb device',
+        demandOption: false,
+        type: 'boolean',
+      },
       'firefox-apk': {
         describe: (
           'Run a specific Firefox for Android APK. ' +

--- a/src/util/adb.js
+++ b/src/util/adb.js
@@ -8,8 +8,9 @@ import {
 } from '../errors';
 import {createLogger} from '../util/logger';
 
-const DEVICE_DIR_BASE = '/sdcard';
-const ARTIFACTS_DIR_PREFIX = '/web-ext-artifacts';
+export const DEVICE_DIR_BASE = '/sdcard/';
+export const ARTIFACTS_DIR_PREFIX = 'web-ext-artifacts-';
+
 const log = createLogger(__filename);
 
 export type ADBUtilsParams = {|
@@ -197,7 +198,7 @@ export default class ADBUtils {
       return artifactsDir;
     }
 
-    artifactsDir = `${DEVICE_DIR_BASE}${ARTIFACTS_DIR_PREFIX}-${Date.now()}`;
+    artifactsDir = `${DEVICE_DIR_BASE}${ARTIFACTS_DIR_PREFIX}${Date.now()}`;
 
     const testDirOut = (await this.runShellCommand(
       deviceId, `test -d ${artifactsDir} ; echo $?`
@@ -217,38 +218,38 @@ export default class ADBUtils {
     return artifactsDir;
   }
 
-  async checkOrCleanArtifacts(
-    deviceId: string, remove?: boolean
+  async detectOrRemoveOldArtifacts(
+    deviceId: string, removeArtifactDirs?: boolean = false
   ): Promise<boolean> {
     const {adbClient} = this;
 
-    let found = false;
-    log.debug('Finding older artifacts');
+    log.debug('Checking adb device for existing web-ext artifacts dirs');
 
     return wrapADBCall(async () => {
       const files = await adbClient.readdir(deviceId, DEVICE_DIR_BASE);
+      let found = false;
 
       for (const file of files) {
         if (!file.isDirectory() ||
-              !file.name.startsWith('web-ext-artifacts-')) {
+            !file.name.startsWith(ARTIFACTS_DIR_PREFIX)) {
           continue;
         }
 
-        if (!remove) {
+        // Return earlier if we only need to warn the user that some
+        // existing artifacts dirs have been found on the adb device.
+        if (!removeArtifactDirs) {
           return true;
         }
 
         found = true;
 
-        const artifactsDir = `${DEVICE_DIR_BASE}/${file.name}`;
+        const artifactsDir = `${DEVICE_DIR_BASE}${file.name}`;
 
         log.debug(
-          `Removing ${artifactsDir} artifacts directory on ${deviceId} device`
+          `Removing artifacts directory ${artifactsDir} from device ${deviceId}`
         );
 
-        await this.runShellCommand(deviceId, [
-          'rm', '-rf', artifactsDir,
-        ]);
+        await this.runShellCommand(deviceId, ['rm', '-rf', artifactsDir]);
       }
 
       return found;
@@ -269,9 +270,7 @@ export default class ADBUtils {
       `Removing ${artifactsDir} artifacts directory on ${deviceId} device`
     );
 
-    await this.runShellCommand(deviceId, [
-      'rm', '-rf', artifactsDir,
-    ]);
+    await this.runShellCommand(deviceId, ['rm', '-rf', artifactsDir]);
   }
 
   async pushFile(


### PR DESCRIPTION
This pull request includes the changes from #1866 rebased on a recent tip of the web-ext main development branch with the following additions:
- renamed the new CLI option to --adb-remove-old-artifacts
- minor cleanup of the firefox-android.js module (folded the `adbOldArtifactsDir` method added in #1866 into the existing `adbPrepareProfileDir` method)
- some additional tweaks and cleanups to the new test cases