### PR TITLE
fix: web-ext should look for the extension id in browser_specific_settings and fallback to applications

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -4,6 +4,7 @@
 
 [options]
 module.system=node
+esproposal.optional_chaining=enable
 log.file=./artifacts/flow.log
 
 [ignore]

--- a/src/util/manifest.js
+++ b/src/util/manifest.js
@@ -15,7 +15,7 @@ const log = createLogger(__filename);
 // getValidatedManifest helper types and implementation
 
 export type ExtensionManifestApplications = {|
-  gecko: {|
+  gecko?: {|
     id?: string,
     strict_min_version?: string,
     strict_max_version?: string,
@@ -28,6 +28,7 @@ export type ExtensionManifest = {|
   version: string,
   default_locale?: string,
   applications?: ExtensionManifestApplications,
+  browser_specific_settings?: ExtensionManifestApplications,
   permissions?: Array<string>,
 |};
 
@@ -85,6 +86,15 @@ export default async function getValidatedManifest(
 
 
 export function getManifestId(manifestData: ExtensionManifest): string | void {
-  return manifestData.applications ?
-    manifestData.applications.gecko.id : undefined;
+  const manifestApps = [
+    manifestData.browser_specific_settings,
+    manifestData.applications,
+  ];
+  for (const apps of manifestApps) {
+    if (apps && apps.gecko && apps.gecko.id) {
+      return apps.gecko.id;
+    }
+  }
+
+  return undefined;
 }

--- a/src/util/manifest.js
+++ b/src/util/manifest.js
@@ -91,7 +91,11 @@ export function getManifestId(manifestData: ExtensionManifest): string | void {
     manifestData.applications,
   ];
   for (const apps of manifestApps) {
-    if (apps && apps.gecko && apps.gecko.id) {
+    // If both bss and applicants contains a defined gecko property,
+    // we prefer bss even if the id property isn't available.
+    // This match what Firefox does in this particular scenario, see
+    // https://searchfox.org/mozilla-central/rev/828f2319c0195d7f561ed35533aef6fe183e68e3/toolkit/mozapps/extensions/internal/XPIInstall.jsm#470-474,488
+    if (apps?.gecko) {
       return apps.gecko.id;
     }
   }

--- a/tests/unit/test-cmd/test.sign.js
+++ b/tests/unit/test-cmd/test.sign.js
@@ -279,7 +279,7 @@ describe('sign', () => {
             apiSecret: stubs.signingConfig.apiSecret,
             apiUrlPrefix: stubs.signingConfig.apiUrlPrefix,
             downloadDir: artifactsDir,
-            id: applications.gecko.id,
+            id: applications.gecko && applications.gecko.id,
             timeout: stubs.signingConfig.timeout,
             version: stubs.preValidatedManifest.version,
             xpiPath: stubs.buildResult.extensionPath,

--- a/tests/unit/test-cmd/test.sign.js
+++ b/tests/unit/test-cmd/test.sign.js
@@ -279,7 +279,7 @@ describe('sign', () => {
             apiSecret: stubs.signingConfig.apiSecret,
             apiUrlPrefix: stubs.signingConfig.apiUrlPrefix,
             downloadDir: artifactsDir,
-            id: applications.gecko && applications.gecko.id,
+            id: applications.gecko?.id,
             timeout: stubs.signingConfig.timeout,
             version: stubs.preValidatedManifest.version,
             xpiPath: stubs.buildResult.extensionPath,

--- a/tests/unit/test-extension-runners/test.firefox-desktop.js
+++ b/tests/unit/test-extension-runners/test.firefox-desktop.js
@@ -284,9 +284,7 @@ describe('util/extension-runners/firefox-desktop', () => {
 
     assert.equal(install.asProxy, true);
     assert.equal(install.manifestData.applications.gecko.id,
-                 manifestData.applications &&
-                 manifestData.applications.gecko &&
-                 manifestData.applications.gecko.id);
+                 manifestData.applications?.gecko?.id);
     assert.deepEqual(install.profile, fakeProfile);
     // This needs to be the source of the extension.
     assert.equal(install.extensionPath, sourceDir);

--- a/tests/unit/test-extension-runners/test.firefox-desktop.js
+++ b/tests/unit/test-extension-runners/test.firefox-desktop.js
@@ -285,6 +285,7 @@ describe('util/extension-runners/firefox-desktop', () => {
     assert.equal(install.asProxy, true);
     assert.equal(install.manifestData.applications.gecko.id,
                  manifestData.applications &&
+                 manifestData.applications.gecko &&
                  manifestData.applications.gecko.id);
     assert.deepEqual(install.profile, fakeProfile);
     // This needs to be the source of the extension.

--- a/tests/unit/test-util/test.manifest.js
+++ b/tests/unit/test-util/test.manifest.js
@@ -213,7 +213,7 @@ describe('util/manifest', () => {
   describe('getManifestId', () => {
     const id = 'basic-manifest@web-ext-test-suite';
 
-    ['applications', 'browser_specific_settings'].forEach((key) => {
+    ['applications', 'browser_specific_settings'].forEach((key: string) => {
 
       describe(`with ${key}`, () => {
 
@@ -234,6 +234,35 @@ describe('util/manifest', () => {
           );
         });
 
+      });
+
+    });
+
+    describe('with both applications and browser_specific_settings', () => {
+      const bssId = 'id@from-bss-prop';
+      const appId = 'id@from-app-prop';
+
+      it('does prefer bss if it includes a gecko object', () => {
+        assert.equal(getManifestId({
+          ...manifestWithoutApps,
+          browser_specific_settings: {gecko: {id: bssId}},
+          applications: {gecko: {id: appId}},
+        }), bssId);
+
+        // This test that we are matching what Firefox does in this scenario.
+        assert.equal(getManifestId({
+          ...manifestWithoutApps,
+          browser_specific_settings: {gecko: {}},
+          applications: {gecko: {id: appId}},
+        }), undefined);
+      });
+
+      it('does fallback to applications if bss.gecko is undefined', () => {
+        assert.equal(getManifestId({
+          ...manifestWithoutApps,
+          browser_specific_settings: {},
+          applications: {gecko: {id: appId}},
+        }), appId);
       });
 
     });

--- a/tests/unit/test-util/test.manifest.js
+++ b/tests/unit/test-util/test.manifest.js
@@ -211,14 +211,39 @@ describe('util/manifest', () => {
   });
 
   describe('getManifestId', () => {
+    const id = 'basic-manifest@web-ext-test-suite';
 
-    it('returns a gecko ID', () => {
-      assert.equal(getManifestId(basicManifest),
-                   'basic-manifest@web-ext-test-suite');
+    ['applications', 'browser_specific_settings'].forEach((key) => {
+
+      describe(`with ${key}`, () => {
+
+        it('returns gecko.id if present', () => {
+          assert.equal(getManifestId({
+            ...manifestWithoutApps,
+            [key]: basicManifest.applications,
+          }), id);
+        });
+
+        it('returns undefined when gecko does not exist', () => {
+          assert.equal(
+            getManifestId({
+              ...manifestWithoutApps,
+              [key]: {},
+            }),
+            undefined
+          );
+        });
+
+      });
+
     });
 
-    it('returns undefined when ID is not specified', () => {
-      assert.strictEqual(getManifestId(manifestWithoutApps), undefined);
+    describe('without applications and browser_specific_settings', () => {
+
+      it('returns undefined when ID is not specified', () => {
+        assert.strictEqual(getManifestId(manifestWithoutApps), undefined);
+      });
+
     });
 
   });


### PR DESCRIPTION
Fixes #1901 

This PR includes and supersedes #1944 
- the first patch contains a squashed version of #1944 as submitted by the author (I did preserve Lusito as the author of that patch because it did change enough from the PR it was originally based on), 
- the second patch applies some small tweaks to:
  - better match Firefox behavior (and some additional test case to cover the expected behaviors)
  - fix some new flow typecheck errors (due to the updated flow version)
  - small tweaks suggested in the last round of review comments

This PR also enable the optional chaining support in the flow config file.