### PR TITLE
fix(deps): Switch from adbkit to @devicefarmer/adbkit npm package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3547,6 +3547,40 @@
       "integrity": "sha512-VoNqai1vR5anRF5Tuh/+SWDFk7xi7oMwHrHrbm1BprYXjB2RJsWLhUrStMssDxEl5lW/z3EUdg8RvH/IUBccSQ==",
       "dev": true
     },
+    "@devicefarmer/adbkit": {
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/@devicefarmer/adbkit/-/adbkit-2.11.3.tgz",
+      "integrity": "sha512-rsgWREAvSRQjdP9/3GoAV6Tq+o97haywgbTfCgt5yUqiDpaaq3hlH9FTo9XsdG8x+Jd0VQ9nTC2IXsDu8JGRSA==",
+      "requires": {
+        "@devicefarmer/adbkit-logcat": "^1.1.0",
+        "@devicefarmer/adbkit-monkey": "~1.0.1",
+        "bluebird": "~2.9.24",
+        "commander": "^2.3.0",
+        "debug": "~2.6.3",
+        "node-forge": "^0.10.0",
+        "split": "~0.3.3"
+      },
+      "dependencies": {
+        "node-forge": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+          "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
+        }
+      }
+    },
+    "@devicefarmer/adbkit-logcat": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@devicefarmer/adbkit-logcat/-/adbkit-logcat-1.1.0.tgz",
+      "integrity": "sha512-K90P5gUXM/w+yzLvJIRQ+tJooNU6ipUPPQkljtPJ0laR66TGtpt4Gqsjm0n9dPHK1W5KGgU1R5wnCd6RTSlPNA=="
+    },
+    "@devicefarmer/adbkit-monkey": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@devicefarmer/adbkit-monkey/-/adbkit-monkey-1.0.1.tgz",
+      "integrity": "sha512-HilPrVrCosYWqSyjfpDtaaN1kJwdlBpS+IAflP3z+e7nsEgk3JGJf1Vg0NgHJooTf5HDfXSyZqMVg+5jvXCK0g==",
+      "requires": {
+        "async": "~0.2.9"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.1.3.tgz",
@@ -3985,33 +4019,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
       "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ=="
-    },
-    "adbkit": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/adbkit/-/adbkit-2.11.1.tgz",
-      "integrity": "sha512-hDTiRg9NX3HQt7WoDAPCplUpvzr4ZzQa2lq7BdTTJ/iOZ6O7YNAs6UYD8sFAiBEcYHDRIyq3cm9sZP6uZnhvXw==",
-      "requires": {
-        "adbkit-logcat": "^1.1.0",
-        "adbkit-monkey": "~1.0.1",
-        "bluebird": "~2.9.24",
-        "commander": "^2.3.0",
-        "debug": "~2.6.3",
-        "node-forge": "^0.7.1",
-        "split": "~0.3.3"
-      }
-    },
-    "adbkit-logcat": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/adbkit-logcat/-/adbkit-logcat-1.1.0.tgz",
-      "integrity": "sha1-Adf5sM75CTowvLOwB+//MBUIli8="
-    },
-    "adbkit-monkey": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/adbkit-monkey/-/adbkit-monkey-1.0.1.tgz",
-      "integrity": "sha1-8pG+cBou/FZ6Y/x6pq/N7TFDC+E=",
-      "requires": {
-        "async": "~0.2.9"
-      }
     },
     "addons-linter": {
       "version": "2.7.0",
@@ -9958,11 +9965,6 @@
         "just-extend": "^4.0.2",
         "path-to-regexp": "^1.7.0"
       }
-    },
-    "node-forge": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
-      "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
     },
     "node-libs-browser": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@babel/runtime": "7.11.2",
     "@cliqz-oss/firefox-client": "0.3.1",
     "@cliqz-oss/node-firefox-connect": "1.2.1",
-    "adbkit": "2.11.1",
+    "@devicefarmer/adbkit": "2.11.3",
     "addons-linter": "2.7.0",
     "bunyan": "1.8.14",
     "camelcase": "6.0.0",

--- a/src/util/adb.js
+++ b/src/util/adb.js
@@ -1,5 +1,5 @@
 /* @flow */
-import defaultADB from 'adbkit';
+import defaultADB from '@devicefarmer/adbkit';
 
 import {
   isErrorWithCode,


### PR DESCRIPTION
Fixes #2025

Some notes from some additional checks I did:

- The developer working on the replacement package @devicefarmer/adbkit is also part of the organization under which the adbkit package was developed, and the new @devicefarmer/adbkit seems to be actively maintained as discussed in the issue linked above.

- I also looked to the diff between the 3 adbkit/adbkit-* packages we are currently using and the 3 related package under the new devicefarmer github organization (both in their original coffeescript sources and the resulting transpiled js code) and the changes are minimal, matching what we would expect from a patch release, and nothing that should change the behavior of the code that is already using the adbkit package in web-ext.

- To be totally fair, there is some small changes around the adb connection object that at a first glance may trigger some slightly different behaviors in case of connection errors, but I do have tested `web-ext run` on a real android device and tried the behavior on unexpected disconnection of the device and the behavior seems to be the same (there is some fixes that we should apply around that, but it isn't a blocker for this pull request, I'll file it as a follow up).