### PR TITLE
fix: defaultReloadStrategy should catch extension reloading errors

### DIFF
--- a/src/extension-runners/index.js
+++ b/src/extension-runners/index.js
@@ -359,7 +359,10 @@ export function defaultReloadStrategy(
           setRawMode(stdin, true);
         } else if (keyPressed.name === 'r') {
           log.debug('Reloading installed extensions on user request');
-          extensionRunner.reloadAllExtensions();
+          await extensionRunner.reloadAllExtensions().catch((err) => {
+            log.warn(`\nError reloading extension: ${err}`);
+            log.debug(`Reloading extension error stack: ${err.stack}`);
+          });
         }
       }
 

--- a/tests/unit/test-extension-runners/test.extension-runners.js
+++ b/tests/unit/test-extension-runners/test.extension-runners.js
@@ -549,16 +549,17 @@ describe('util/extension-runners', () => {
          // did call `stdin.once('keypress', ...)`.
          const fakeStdinOnce = fakeStdin.once;
          sinon.stub(fakeStdin, 'once');
-         fakeStdin.once.callsFake((...args) => {
-           if (args[0] === 'keypress') {
-             fakeStdin.emit('once-keypress-called');
-           }
-           return fakeStdinOnce.apply(fakeStdin, args);
-         });
 
-         const promiseWaitKeypress = () => new Promise((resolve) => {
-           fakeStdin.once('once-keypress-called', resolve);
-         });
+         function promiseWaitKeypress() {
+           return new Promise((resolve) => {
+             fakeStdin.once.callsFake((...args) => {
+               if (args[0] === 'keypress') {
+                 resolve();
+               }
+               return fakeStdinOnce.apply(fakeStdin, args);
+             });
+           });
+         }
 
          try {
            let onceWaitKeypress = promiseWaitKeypress();


### PR DESCRIPTION
This PR does apply a small change to the `defaultReloadStrategy` helper function to make sure that we do catch the rejection that `extensionRunner.reloadAllExtensions may have triggered (and then log the error as a warning, and the error stack as an additional debug level log).

The new behavior is going to:
- fix the new failures triggered by the related test case on mocha 8.2.0 (and unblock #2052 for merging, currently this issue triggers failures on the CI)
- prevent newer nodejs version from exiting the process because of an unhandled rejection (which in the current nodejs versions is just logged on the console, but in future nodejs version this is meant to make the entire nodejs process to exit with error)   