### PR TITLE
chore: Fix on flow type signature to pass type checking on flow >= v0.132.0

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 dist/
 coverage/
 artifacts/
+flow-typed/
 commitlint.config.js

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,7 @@
 [include]
 
 [libs]
+flow-typed/
 
 [options]
 module.system=node

--- a/flow-typed/README.md
+++ b/flow-typed/README.md
@@ -1,0 +1,6 @@
+This directory contains flowtyped declarations for the npm modules that do need
+valid flow signatures to be able to flow check the modules part of this project.
+
+The declarations in this directory are not complete definitions of the type defined
+in the related modules source code, this declaration files define just as much as
+needed for the purpose of flow checking this project source code.

--- a/flow-typed/chrome-launcher.decl.js
+++ b/flow-typed/chrome-launcher.decl.js
@@ -1,0 +1,23 @@
+// flow-typed signatures for 'chrome-launcher' module.
+
+declare module "chrome-launcher" {
+  declare type LaunchOptions = {
+    enableExtensions: boolean,
+    chromePath: ?string,
+    chromeFlags: Array<string>,
+    startingUrl: ?string,
+    userDataDir: ?string,
+    ignoreDefaultFlags: boolean,
+  };
+
+  declare class Launcher {
+    static defaultFlags: () => Array<string>,
+    process: child_process$ChildProcess,
+    kill(): Promise<void>,
+  }
+
+  declare module.exports: {
+    Launcher: Class<Launcher>,
+    launch(options?: LaunchOptions): Promise<Launcher>,
+  }
+}

--- a/flow-typed/firefox-client.decl.js
+++ b/flow-typed/firefox-client.decl.js
@@ -1,0 +1,6 @@
+// flow-typed signatures for 'firefox-client' module.
+
+declare module "@cliqz-oss/firefox-client" {
+  declare class FirefoxClient extends event$EventEmitter {}
+  declare module.exports: Class<FirefoxClient>;
+}

--- a/flow-typed/firefox-profile.decl.js
+++ b/flow-typed/firefox-profile.decl.js
@@ -1,0 +1,39 @@
+// flow-typed signatures for 'firefox-profile' module.
+
+declare module "firefox-profile" {
+  declare type ProfileOptions = {
+    destinationDirectory: string,
+  }
+
+  declare type ProfileCallback = 
+    (err: ?Error, profile: Profile) => void;
+
+  declare class Finder {
+    constructor(baseDir: ?string): Finder,
+    readProfiles(cb: Function): void,
+    getPath(name: string, cb: (err: ?Error, profilePath: string) => void): void,
+
+    profiles: Array<{ [key:string]: string }>, 
+
+    static locateUserDirectory(): string,
+  }
+
+  declare class FirefoxProfile {
+    constructor(opts: ?ProfileOptions): FirefoxProfile,
+
+    extensionsDir: string,
+    profileDir: string,
+    userPrefs: string,
+    defaultPreferences: { [key: string]: any },
+
+    path(): string,
+    setPreference(pref: string, value: any): void,
+    updatePreferences(): void,
+    
+    static copy({profileDirectory: string}, cb: ProfileCallback): void,
+    static copyFromUserProfile({name: string}, cb: ProfileCallback): void,
+    static Finder: Class<Finder>,
+  }
+
+  declare module.exports: Class<FirefoxProfile>;
+}

--- a/flow-typed/watchpack.decl.js
+++ b/flow-typed/watchpack.decl.js
@@ -1,0 +1,9 @@
+// flow-typed signatures for 'watchpack' module.
+
+declare module "watchpack" {
+  declare class Watchpack extends event$EventEmitter {
+    close(): void,
+  }
+
+  declare module.exports: Class<Watchpack>;
+}

--- a/flow-typed/ws.decl.js
+++ b/flow-typed/ws.decl.js
@@ -1,0 +1,36 @@
+// flow-typed signatures for 'ws' module.
+
+declare module "ws" {
+  declare type ServerOptions = {
+    host: string,
+    port: number,
+  }
+
+  declare type ServerAddressInfo = {
+    address: string,
+    port: number,
+  }
+
+  declare class WebSocket extends events$EventEmitter {
+    constructor(url: string): WebSocket,
+    removeEventListener(eventName: string, cb: Function): void,
+    readyState: "CONNECTING" | "OPEN" | "CLOSING" | "CLOSED",
+    send(msg: string): void,
+    close(): void,
+      
+    static OPEN: "OPEN",
+    static CLOSED: "CLOSED",
+    static CONNECTING: "CONNECTING",
+    static CLOSING: "CLOSING",
+    static Server: Class<Server>,
+  }
+
+  declare class Server extends net$Server {
+    constructor(opts?: ServerOptions, listenCb: Function): Server,
+    address(): ServerAddressInfo,
+    clients: Set<WebSocket>,
+    close(closedCb: Function): void,
+  }
+
+  declare module.exports: Class<WebSocket>;
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "README.md",
     "dist/*.js",
     "src/**",
-    "index.mjs"
+    "index.mjs",
+    "flow-typed/*.js"
   ],
   "engines": {
     "node": ">=10.0.0",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "README.md",
     "dist/*.js",
     "src/**",
-    "index.mjs",
-    "flow-typed/*.js"
+    "index.mjs"
   ],
   "engines": {
     "node": ">=10.0.0",

--- a/src/cmd/build.js
+++ b/src/cmd/build.js
@@ -209,7 +209,9 @@ export async function defaultPackageCreator(
   // Added 'wx' flags to avoid overwriting of existing package.
   const stream = createWriteStream(extensionPath, {flags: 'wx'});
 
-  stream.write(buffer, () => stream.end());
+  stream.write(buffer, () => {
+    stream.end();
+  });
 
   try {
     await eventToPromise(stream, 'close');
@@ -224,7 +226,9 @@ export async function defaultPackageCreator(
     }
     log.info(`Destination exists, overwriting: ${extensionPath}`);
     const overwriteStream = createWriteStream(extensionPath);
-    overwriteStream.write(buffer, () => overwriteStream.end());
+    overwriteStream.write(buffer, () => {
+      overwriteStream.end();
+    });
     await eventToPromise(overwriteStream, 'close');
   }
 

--- a/src/cmd/docs.js
+++ b/src/cmd/docs.js
@@ -14,8 +14,8 @@ export type DocsOptions = {
   openUrl?: typeof open,
 }
 
-export const url = 'https://developer.mozilla.org/en-US/Add-ons' +
-  '/WebExtensions/Getting_started_with_web-ext';
+// eslint-disable-next-line max-len
+export const url = 'https://extensionworkshop.com/documentation/develop/getting-started-with-web-ext/';
 
 export default function docs(
   params: DocsParams, {openUrl = open}: DocsOptions = {}

--- a/src/cmd/sign.js
+++ b/src/cmd/sign.js
@@ -15,7 +15,8 @@ import type {ExtensionManifest} from '../util/manifest';
 
 const log = createLogger(__filename);
 
-const defaultAsyncFsReadFile = fs.readFile.bind(fs);
+const defaultAsyncFsReadFile: (string) => Promise<Buffer> =
+  fs.readFile.bind(fs);
 
 export const extensionIdFile = '.web-extension-id';
 

--- a/src/extension-runners/chromium.js
+++ b/src/extension-runners/chromium.js
@@ -43,7 +43,7 @@ const EXCLUDED_CHROME_FLAGS = [
   '--mute-audio',
 ];
 
-export const DEFAULT_CHROME_FLAGS = ChromeLauncher.defaultFlags()
+export const DEFAULT_CHROME_FLAGS: Array<string> = ChromeLauncher.defaultFlags()
   .filter((flag) => !EXCLUDED_CHROME_FLAGS.includes(flag));
 
 /**
@@ -52,10 +52,10 @@ export const DEFAULT_CHROME_FLAGS = ChromeLauncher.defaultFlags()
 export class ChromiumExtensionRunner {
   cleanupCallbacks: Set<Function>;
   params: ChromiumExtensionRunnerParams;
-  chromiumInstance: ChromeLauncher;
+  chromiumInstance: ?ChromeLauncher;
   chromiumLaunch: typeof defaultChromiumLaunch;
   reloadManagerExtension: string;
-  wss: WebSocket.Server;
+  wss: ?WebSocket.Server;
   exiting: boolean;
   _promiseSetupDone: ?Promise<void>;
 
@@ -73,7 +73,7 @@ export class ChromiumExtensionRunner {
   /**
    * Returns the runner name.
    */
-  getName() {
+  getName(): string {
     return 'Chromium';
   }
 
@@ -241,7 +241,7 @@ export class ChromiumExtensionRunner {
     });
   }
 
-  async wssBroadcast(data: Object) {
+  async wssBroadcast(data: Object): Promise<void> {
     return new Promise((resolve) => {
       const clients = this.wss ? new Set(this.wss.clients) : new Set();
 
@@ -280,7 +280,7 @@ export class ChromiumExtensionRunner {
     });
   }
 
-  async createReloadManagerExtension() {
+  async createReloadManagerExtension(): Promise<string> {
     const tmpDir = new TempDir();
     await tmpDir.create();
     this.registerCleanup(() => tmpDir.remove());
@@ -306,6 +306,10 @@ export class ChromiumExtensionRunner {
         },
       })
     );
+
+    if (!this.wss) {
+      throw new Error('WebSocketServer closed');
+    }
 
     const wssInfo = this.wss.address();
 
@@ -408,7 +412,8 @@ export class ChromiumExtensionRunner {
     }
 
     if (this.wss) {
-      await new Promise((resolve) => this.wss.close(resolve));
+      await new Promise((resolve) =>
+        this.wss ? this.wss.close(resolve) : resolve());
       this.wss = null;
     }
 

--- a/src/extension-runners/chromium.js
+++ b/src/extension-runners/chromium.js
@@ -307,10 +307,7 @@ export class ChromiumExtensionRunner {
       })
     );
 
-    if (!this.wss) {
-      throw new Error('WebSocketServer closed');
-    }
-
+    // $FlowIgnore: this method is only called right after creating the server and so wss should be defined.
     const wssInfo = this.wss.address();
 
     const bgPage = `(function bgPage() {

--- a/src/extension-runners/firefox-android.js
+++ b/src/extension-runners/firefox-android.js
@@ -89,9 +89,9 @@ export type FirefoxAndroidExtensionRunnerParams = {|
  */
 export class FirefoxAndroidExtensionRunner {
   // Wait 3s before the next unix socket discovery loop.
-  static unixSocketDiscoveryRetryInterval = 3 * 1000;
+  static unixSocketDiscoveryRetryInterval: number = 3 * 1000;
   // Wait for at most 3 minutes before giving up.
-  static unixSocketDiscoveryMaxTime = 3 * 60 * 1000;
+  static unixSocketDiscoveryMaxTime: number = 3 * 60 * 1000;
 
   params: FirefoxAndroidExtensionRunnerParams;
   adbUtils: DefaultADBUtils;
@@ -168,7 +168,7 @@ export class FirefoxAndroidExtensionRunner {
   /**
    * Returns the runner name.
    */
-  getName() {
+  getName(): string {
     return 'Firefox Android';
   }
 

--- a/src/extension-runners/firefox-desktop.js
+++ b/src/extension-runners/firefox-desktop.js
@@ -73,7 +73,7 @@ export class FirefoxDesktopExtensionRunner {
   /**
    * Returns the runner name.
    */
-  getName() {
+  getName(): string {
     return 'Firefox Desktop';
   }
 

--- a/src/extension-runners/index.js
+++ b/src/extension-runners/index.js
@@ -45,7 +45,9 @@ export type MultiExtensionRunnerParams = {|
   desktopNotifications: typeof defaultDesktopNotifications,
 |};
 
-export async function createExtensionRunner(config: ExtensionRunnerConfig) {
+export async function createExtensionRunner(
+  config: ExtensionRunnerConfig
+): Promise<IExtensionRunner> {
   switch (config.target) {
     case 'firefox-desktop': {
       // TODO: use async import instead of require - https://github.com/mozilla/web-ext/issues/1306
@@ -86,7 +88,7 @@ export class MultiExtensionRunner {
   /**
    * Returns the runner name.
    */
-  getName() {
+  getName(): string {
     return 'Multi Extension Runner';
   }
 

--- a/src/firefox/index.js
+++ b/src/firefox/index.js
@@ -4,8 +4,7 @@ import path from 'path';
 import {promisify} from 'util';
 
 import {default as defaultFxRunner} from 'fx-runner';
-import FirefoxProfile, {copyFromUserProfile as defaultUserProfileCopier}
-  from 'firefox-profile';
+import FirefoxProfile from 'firefox-profile';
 import {fs} from 'mz';
 import eventToPromise from 'event-to-promise';
 
@@ -26,7 +25,9 @@ import type {ExtensionManifest} from '../util/manifest';
 
 const log = createLogger(__filename);
 
-const defaultAsyncFsStat = fs.stat.bind(fs);
+const defaultAsyncFsStat: typeof fs.stat = fs.stat.bind(fs);
+
+const defaultUserProfileCopier = FirefoxProfile.copyFromUserProfile;
 
 export const defaultFirefoxEnv = {
   XPCOM_DEBUG_BREAK: 'stack',

--- a/src/util/artifacts.js
+++ b/src/util/artifacts.js
@@ -7,7 +7,7 @@ import {createLogger} from './logger';
 
 const log = createLogger(__filename);
 
-const defaultAsyncFsAccess = fs.access.bind(fs);
+const defaultAsyncFsAccess: typeof fs.access = fs.access.bind(fs);
 
 type PrepareArtifactsDirOptions = {
   asyncMkdirp?: typeof defaultAsyncMkdirp,

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -91,7 +91,7 @@ export class ConsoleStream {
   }
 }
 
-export const consoleStream = new ConsoleStream();
+export const consoleStream: ConsoleStream = new ConsoleStream();
 
 
 // createLogger types and implementation.

--- a/src/util/temp-dir.js
+++ b/src/util/temp-dir.js
@@ -127,7 +127,7 @@ export class TempDir {
   /*
    * Remove the temp directory.
    */
-  remove() {
+  remove(): Promise<void> | void {
     if (!this._removeTempDir) {
       return;
     }

--- a/src/util/zip-dir.js
+++ b/src/util/zip-dir.js
@@ -3,4 +3,7 @@ import {promisify} from 'util';
 
 import zipDirModule from 'zip-dir';
 
-export const zipDir = promisify(zipDirModule);
+type PromisedZipDir =
+  (sourceDir: string, { filter(...any): boolean }) => Promise<Buffer>;
+
+export const zipDir: PromisedZipDir = promisify(zipDirModule);

--- a/tests/functional/common.js
+++ b/tests/functional/common.js
@@ -11,21 +11,25 @@ import * as tmpDirUtils from '../../src/util/temp-dir';
 export const withTempDir = tmpDirUtils.withTempDir;
 
 
-export const functionalTestsDir = path.resolve(__dirname);
-export const projectDir = path.join(functionalTestsDir, '..', '..');
-export const webExt = process.env.TEST_WEB_EXT_BIN ?
+export const functionalTestsDir: string = path.resolve(__dirname);
+export const projectDir: string = path.join(functionalTestsDir, '..', '..');
+export const webExt: string = process.env.TEST_WEB_EXT_BIN ?
   path.resolve(process.env.TEST_WEB_EXT_BIN) :
   path.join(projectDir, 'bin', 'web-ext');
-export const fixturesDir = path.join(functionalTestsDir, '..', 'fixtures');
-export const minimalAddonPath = path.join(fixturesDir, 'minimal-web-ext');
-export const fixtureEsmImport = path.join(fixturesDir, 'import-as-esm');
-export const fixtureCjsRequire = path.join(fixturesDir, 'require-as-cjs');
-export const fakeFirefoxPath = path.join(
+export const fixturesDir: string =
+  path.join(functionalTestsDir, '..', 'fixtures');
+export const minimalAddonPath: string =
+  path.join(fixturesDir, 'minimal-web-ext');
+export const fixtureEsmImport: string =
+  path.join(fixturesDir, 'import-as-esm');
+export const fixtureCjsRequire: string =
+  path.join(fixturesDir, 'require-as-cjs');
+export const fakeFirefoxPath: string = path.join(
   functionalTestsDir,
   process.platform === 'win32' ?
     'fake-firefox-binary.bat' : 'fake-firefox-binary.js'
 );
-export const fakeServerPath = path.join(
+export const fakeServerPath: string = path.join(
   functionalTestsDir, 'fake-amo-server.js'
 );
 

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -46,7 +46,7 @@ export class ZipFile {
   /**
    * Close the zip file and wait fd to release.
    */
-  close() {
+  close(): Promise<void> | null {
     this._zip.close();
     return this._close;
   }
@@ -193,14 +193,14 @@ export function fake<T>(
   return stub;
 }
 
-export function createFakeProcess() {
-  return fake(process, {}, ['EventEmitter', 'stdin']);
+export class StubChildProcess extends EventEmitter {
+  stderr: EventEmitter = new EventEmitter();
+  stdout: EventEmitter = new EventEmitter();
+  kill: any = sinon.spy(() => {});
 }
 
-export class StubChildProcess extends EventEmitter {
-  stderr = new EventEmitter();
-  stdout = new EventEmitter();
-  kill = sinon.spy(() => {});
+export function createFakeProcess(): any {
+  return fake(process, {}, ['EventEmitter', 'stdin']);
 }
 
 /*
@@ -217,7 +217,7 @@ type FakeFirefoxClientParams = {|
 export function fakeFirefoxClient({
   requestResult = {}, requestError,
   makeRequestResult = {}, makeRequestError,
-}: FakeFirefoxClientParams = {}) {
+}: FakeFirefoxClientParams = {}): any {
   return {
     disconnect: sinon.spy(() => {}),
     request: sinon.spy(
@@ -289,7 +289,7 @@ export const basicManifest = {
 /*
  * A basic manifest fixture without an applications property.
  */
-export const manifestWithoutApps = deepcopy(basicManifest);
+export const manifestWithoutApps: any = deepcopy(basicManifest);
 delete manifestWithoutApps.applications;
 
 /*
@@ -302,16 +302,16 @@ export class FakeExtensionRunner {
     this.params = params;
   }
 
-  getName() {
+  getName(): string {
     return 'Fake Extension Runner';
   }
 
   async run() {}
   async exit() {}
-  async reloadAllExtensions() {
+  async reloadAllExtensions(): Promise<any> {
     return [];
   }
-  async reloadExtensionBySourceDir(sourceDir: string) {
+  async reloadExtensionBySourceDir(sourceDir: string): Promise<any> {
     const runnerName = this.getName();
     return [{runnerName, sourceDir}];
   }
@@ -320,7 +320,7 @@ export class FakeExtensionRunner {
 
 export function getFakeFirefox(
   implementations: Object = {}, port: number = 6005
-) {
+): any {
   const profile = {}; // empty object just to avoid errors.
   const firefox = () => Promise.resolve();
   const allImplementations = {
@@ -334,7 +334,7 @@ export function getFakeFirefox(
   return fake(defaultFirefoxApp, allImplementations);
 }
 
-export function getFakeRemoteFirefox(implementations: Object = {}) {
+export function getFakeRemoteFirefox(implementations: Object = {}): any {
   return fake(RemoteFirefox.prototype, implementations);
 }
 

--- a/tests/unit/test-cmd/test.run.js
+++ b/tests/unit/test-cmd/test.run.js
@@ -58,9 +58,9 @@ function prepareRun(fakeInstallResult) {
 }
 
 describe('run', () => {
-  let androidRunnerStub: sinon.SinonStub;
-  let desktopRunnerStub: sinon.SinonStub;
-  let chromiumRunnerStub: sinon.SinonStub;
+  let androidRunnerStub: any;
+  let desktopRunnerStub: any;
+  let chromiumRunnerStub: any;
 
   beforeEach(() => {
     androidRunnerStub = sinon.stub(

--- a/tests/unit/test-extension-runners/test.chromium.js
+++ b/tests/unit/test-extension-runners/test.chromium.js
@@ -111,13 +111,6 @@ describe('util/extension-runners/chromium', async () => {
     assert.deepEqual(managerExtManifest.permissions, ['management', 'tabs']);
 
     await runnerInstance.exit();
-
-    // Test that `createReloadManagerExtension` does throw if the instance exited
-    // and its `wss` property has been already nullified.
-    assert.isRejected(
-      runnerInstance.createReloadManagerExtension(),
-      /WebSocketServer closed/,
-    ) ;
   });
 
 
@@ -635,6 +628,7 @@ describe('util/extension-runners/chromium', async () => {
       if (!runnerInstance.wss) {
         throw new Error('WebSocker server is not running');
       }
+      // $FlowIgnore: if runnerInstance.wss would be unexpectedly undefined the test case will fail.
       const wssInfo = runnerInstance.wss.address();
       const wsURL = `ws://${wssInfo.address}:${wssInfo.port}`;
       wsClient = new WebSocket(wsURL);

--- a/tests/unit/test-extension-runners/test.chromium.js
+++ b/tests/unit/test-extension-runners/test.chromium.js
@@ -111,6 +111,13 @@ describe('util/extension-runners/chromium', async () => {
     assert.deepEqual(managerExtManifest.permissions, ['management', 'tabs']);
 
     await runnerInstance.exit();
+
+    // Test that `createReloadManagerExtension` does throw if the instance exited
+    // and its `wss` property has been already nullified.
+    assert.isRejected(
+      runnerInstance.createReloadManagerExtension(),
+      /WebSocketServer closed/,
+    ) ;
   });
 
 

--- a/tests/unit/test-extension-runners/test.chromium.js
+++ b/tests/unit/test-extension-runners/test.chromium.js
@@ -119,6 +119,7 @@ describe('util/extension-runners/chromium', async () => {
     const runnerInstance = new ChromiumExtensionRunner(params);
     await runnerInstance.run();
 
+    // $FlowIgnore: allow to call addess even wss property can be undefined.
     const wssInfo = runnerInstance.wss.address();
     const wsURL = `ws://${wssInfo.address}:${wssInfo.port}`;
     const wsClient = new WebSocket(wsURL);
@@ -136,7 +137,7 @@ describe('util/extension-runners/chromium', async () => {
 
     const fakeSocket = new EventEmitter();
     sinon.spy(fakeSocket, 'on');
-    runnerInstance.wss.emit('connection', fakeSocket);
+    runnerInstance.wss?.emit('connection', fakeSocket);
     sinon.assert.calledOnce(fakeSocket.on);
 
     fakeSocket.emit('error', new Error('Fake wss socket ERROR'));
@@ -614,7 +615,7 @@ describe('util/extension-runners/chromium', async () => {
   );
 
   describe('reloadAllExtensions', () => {
-    let runnerInstance;
+    let runnerInstance: ChromiumExtensionRunner;
     let wsClient: WebSocket;
 
     beforeEach(async () => {
@@ -624,6 +625,9 @@ describe('util/extension-runners/chromium', async () => {
     });
 
     const connectClient = async () => {
+      if (!runnerInstance.wss) {
+        throw new Error('WebSocker server is not running');
+      }
       const wssInfo = runnerInstance.wss.address();
       const wsURL = `ws://${wssInfo.address}:${wssInfo.port}`;
       wsClient = new WebSocket(wsURL);
@@ -633,6 +637,7 @@ describe('util/extension-runners/chromium', async () => {
     afterEach(async () => {
       if (wsClient && (wsClient.readyState === WebSocket.OPEN)) {
         wsClient.close();
+        // $FlowIgnore: allow to nullify wsClient even if wsClient signature doesn't allow it.
         wsClient = null;
       }
       await runnerInstance.exit();
@@ -679,6 +684,7 @@ describe('util/extension-runners/chromium', async () => {
         });
         wsClient.close();
       });
+      // $FlowIgnore: allow to nullify wsClient even if wsClient signature doesn't allow it.
       wsClient = null;
     });
 

--- a/tests/unit/test-firefox/test.firefox.js
+++ b/tests/unit/test-firefox/test.firefox.js
@@ -114,6 +114,7 @@ describe('firefox', () => {
     it('executes the Firefox runner with a given profile', () => {
       const runner = createFakeFxRunner();
       const profile = fakeProfile;
+      // $FlowIgnore: allow use of fakeProfile as a fake FirefoxProfile instance.
       return runFirefox({fxRunner: runner, profile})
         .then(() => {
           sinon.assert.called(runner);
@@ -659,6 +660,7 @@ describe('firefox', () => {
     it('creates a finder', () => {
       const {FxProfile} = prepareProfileFinderTest();
       FxProfile.Finder = sinon.spy(FxProfile.Finder);
+      // $FlowIgnore: allow use of FxProfile as a fake FirefoxProfile class.
       firefox.defaultCreateProfileFinder({FxProfile});
       sinon.assert.calledWith(FxProfile.Finder, sinon.match(undefined));
     });
@@ -668,6 +670,7 @@ describe('firefox', () => {
       FxProfile.Finder = sinon.spy(FxProfile.Finder);
 
       const userDirectoryPath = '/non/existent/path';
+      // $FlowIgnore: allow use of FxProfile as a fake FirefoxProfile class.
       firefox.defaultCreateProfileFinder({userDirectoryPath, FxProfile});
 
       sinon.assert.called(FxProfile.Finder);
@@ -689,6 +692,7 @@ describe('firefox', () => {
 
       const profileFinder = firefox.defaultCreateProfileFinder({
         userDirectoryPath,
+        // $FlowIgnore: allow use of FxProfile as a fake FirefoxProfile class.
         FxProfile,
       });
 
@@ -715,6 +719,7 @@ describe('firefox', () => {
 
          const getter = firefox.defaultCreateProfileFinder({
            userDirectoryPath,
+           // $FlowIgnore: allow use of FxProfile as a fake FirefoxProfile class.
            FxProfile,
          });
 
@@ -744,6 +749,7 @@ describe('firefox', () => {
 
          const getter = firefox.defaultCreateProfileFinder({
            userDirectoryPath,
+           // $FlowIgnore: allow use of FxProfile as a fake FirefoxProfile class.
            FxProfile,
          });
 

--- a/tests/unit/test.web-ext.js
+++ b/tests/unit/test.web-ext.js
@@ -18,7 +18,7 @@ describe('webExt', () => {
   });
 
   describe('exposes commands', () => {
-    let stub: sinon.Stub;
+    let stub: any;
     afterEach(() => {
       stub.restore();
       stub = undefined;


### PR DESCRIPTION
This PR contains a number of changes needed to pass the flowtype checks on flow >= v0.132.0 (see #2003).

Most of the changes are only applied to the flow type signatures, but for some of the flowtype errors I opted to make some small changes on the implementation side (when it did look more appropriate).

Many of the new flowtype checks errors in #2003 are related to the dependencies, it looks that more recent flow versions are detecting when the types used are coming from a dependency that isn't typed using flow and the resulting types are all going to degrate to `any`.

Unfortunately the npm modules that are triggering these flowtype errors do not have their own flowtype declarations, and there isn't a third party one in the flow-types repository neither.

The easiest approach seems to be to include our own flow-typed declarations files in the project repository.

These declaration files are only including the subset of the modules that is actually being used in the web-ext sources, everything else is currently omitted.