### PR TITLE
fix: Fixes #1979 [opening of chrome:// url in cmdLine]

### DIFF
--- a/src/extension-runners/chromium.js
+++ b/src/extension-runners/chromium.js
@@ -158,9 +158,20 @@ export class ChromiumExtensionRunner {
       this.params.extensions.map(({sourceDir}) => sourceDir)
     ).join(',');
 
-    const {chromiumBinary} = this.params;
-
     log.debug('Starting Chromium instance...');
+
+    const {chromiumBinary} = this.params;
+    const url = this.params.startUrl;
+    if (url && !Array.isArray(url) && url.startsWith('chrome://')) {
+      //send message to reloadManagerExtension
+      const chromeUrl = url;
+      let wsClient: WebSocket;
+      const forwardUrlMsg = JSON.stringify({
+        url: chromeUrl,
+        type: 'webExtReloadExtensionComplete',
+      });
+      wsClient.send(forwardUrlMsg);
+    }
 
     if (chromiumBinary) {
       log.debug(`(chromiumBinary: ${chromiumBinary})`);


### PR DESCRIPTION
### **This is a draft PR, work in progress.**

A few doubts:
1. I logged `chromium binary` and `this.params`, where` chromiumBinary = this.params`.
`chromiumBinary` gives `undefined`, while `this.params` gives something like 
```
extensions: [ { sourceDir: '/fake/sourceDir', manifestData: [Object] } ],
  keepProfileChanges: false,
  startUrl: undefined,
  chromiumLaunch: [Function],
  desktopNotifications: [Function]
}
```
May I know why?

2. I have created a new message as directed by you to forward the chrome:// URL, but the wsClient is not defined. How do I know which port/ URL to send the message to the reloadManagerExtension?
3. It is mentioned in the comments by rpl and you that extensions are able to open chrome:// url through chrome.tabs.query. 
While the reload message type had the key "type", I didnt know what the key for url should be in the message I constructed. How can I find that out? 
Thanks!