### PR TITLE
feat: threw error if profile-create-new-if-missing used without profile

### DIFF
--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -124,7 +124,13 @@ export default async function run(
 
   const profileDir = firefoxProfile || chromiumProfile;
 
-  if (profileCreateIfMissing && profileDir) {
+  if (profileCreateIfMissing) {
+    if (!profileDir) {
+      throw new UsageError(
+        '--profile-create-if-missing should be paired ' +
+        'with --firefox-profile or --chromium-profile'
+      );
+    }
     const isDir = fs.existsSync(profileDir);
     if (isDir) {
       log.info(`Profile directory ${profileDir} already exists`);
@@ -132,11 +138,6 @@ export default async function run(
       log.info(`Profile directory not found. Creating directory ${profileDir}`);
       await fs.mkdir(profileDir);
     }
-  } else if (profileCreateIfMissing) {
-    throw new UsageError(
-      '--profile-create-if-missing should be paired ' +
-      'with --firefox-profile or --chromium-profile'
-    );
   }
 
   const runners = [];

--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -11,6 +11,7 @@ import {
 } from '../firefox/remote';
 import {createLogger} from '../util/logger';
 import defaultGetValidatedManifest from '../util/manifest';
+import {UsageError} from '../../src/errors';
 import {
   createExtensionRunner,
   defaultReloadStrategy,
@@ -131,6 +132,11 @@ export default async function run(
       log.info(`Profile directory not found. Creating directory ${profileDir}`);
       await fs.mkdir(profileDir);
     }
+  } else if (profileCreateIfMissing) {
+    throw new UsageError(
+      '--profile-create-if-missing should be paired ' +
+      'with --firefox-profile or --chromium-profile'
+    );
   }
 
   const runners = [];

--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -127,8 +127,8 @@ export default async function run(
   if (profileCreateIfMissing) {
     if (!profileDir) {
       throw new UsageError(
-        '--profile-create-if-missing should be paired ' +
-        'with --firefox-profile or --chromium-profile'
+        '--profile-create-if-missing requires ' +
+        '--firefox-profile or --chromium-profile'
       );
     }
     const isDir = fs.existsSync(profileDir);

--- a/tests/unit/test-cmd/test.run.js
+++ b/tests/unit/test-cmd/test.run.js
@@ -416,7 +416,7 @@ describe('run', () => {
          await assert.isRejected(promise, UsageError);
          await assert.isRejected(
            promise,
-           /should be paired with --firefox-profile or --chromium-profile/
+           /requires --firefox-profile or --chromium-profile/
          );
        });
   });

--- a/tests/unit/test-cmd/test.run.js
+++ b/tests/unit/test-cmd/test.run.js
@@ -7,6 +7,7 @@ import {assert} from 'chai';
 import sinon from 'sinon';
 
 import run from '../../../src/cmd/run';
+import {UsageError} from '../../../src/errors';
 import {
   fixturePath,
   FakeExtensionRunner,
@@ -406,5 +407,23 @@ describe('run', () => {
            profileCreateIfMissing: true,
          })
     );
+
+    it('throws error when used without firefox-profile or chromium-profile',
+       async () => {
+         const cmd = prepareRun();
+
+         let actualError = null;
+         try {
+           await cmd.run({ profileCreateIfMissing: true });
+         } catch (error) {
+           actualError = error;
+         }
+
+         assert.instanceOf(actualError, UsageError);
+         assert.match(
+           actualError && actualError.message,
+           /should be paired with --firefox-profile or --chromium-profile/
+         );
+       });
   });
 });

--- a/tests/unit/test-cmd/test.run.js
+++ b/tests/unit/test-cmd/test.run.js
@@ -411,17 +411,11 @@ describe('run', () => {
     it('throws error when used without firefox-profile or chromium-profile',
        async () => {
          const cmd = prepareRun();
+         const promise = cmd.run({ profileCreateIfMissing: true });
 
-         let actualError = null;
-         try {
-           await cmd.run({ profileCreateIfMissing: true });
-         } catch (error) {
-           actualError = error;
-         }
-
-         assert.instanceOf(actualError, UsageError);
-         assert.match(
-           actualError && actualError.message,
+         await assert.isRejected(promise, UsageError);
+         await assert.isRejected(
+           promise,
            /should be paired with --firefox-profile or --chromium-profile/
          );
        });


### PR DESCRIPTION
Follow up to #2064 based on @rpl's [comment](https://github.com/mozilla/web-ext/pull/2064#discussion_r518873064).

Throws error if `profile-create-new-if-missing` option used without `firefox-profile` or `chromium-profile`.

 