### PR TITLE
fix: Accept the --no-input global cli option and ensure it is parsed into a noInput boolean option

### DIFF
--- a/src/program.js
+++ b/src/program.js
@@ -177,6 +177,15 @@ export class Program {
       argv.noReload = !argv.reload;
     }
 
+    // Yargs doesn't accept --no-input as a valid option if there isn't a
+    // --input option defined to be negated, to fix that the --input is
+    // defined and hidden from the yargs help output and we define here
+    // the negated argument name that we expect to be set in the parsed
+    // arguments (and fix https://github.com/mozilla/web-ext/issues/1860).
+    if (argv.input != null) {
+      argv.noInput = !argv.input;
+    }
+
     // Replacement for the "requiresArg: true" parameter until the following bug
     // is fixed: https://github.com/yargs/yargs/issues/1098
     if (argv.ignoreFiles && !argv.ignoreFiles.length) {
@@ -447,6 +456,13 @@ Example: $0 --help run.
     },
     'no-input': {
       describe: 'Disable all features that require standard input',
+      type: 'boolean',
+      demandOption: false,
+    },
+    'input': {
+      // This option is defined to make yargs to accept the --no-input
+      // defined above, but we hide it from the yargs help output.
+      hidden: true,
       type: 'boolean',
       demandOption: false,
     },

--- a/tests/functional/test.cli.nocommand.js
+++ b/tests/functional/test.cli.nocommand.js
@@ -1,5 +1,6 @@
 /* @flow */
 import {describe, it} from 'mocha';
+import {assert} from 'chai';
 
 import {
   withTempDir, execWebExt, reportCommandErrors,
@@ -21,4 +22,14 @@ describe('web-ext', () => {
       }
     });
   }));
+
+  it('should hide --input from --help output',
+     () => withTempDir(async (tmpDir) => {
+       const cmd = execWebExt(['--help'], {cwd: tmpDir.path()});
+       const { stdout } = await cmd.waitForExit;
+       assert.equal(stdout.includes('--input'), false,
+                    'help does not include --input');
+       assert.equal(stdout.includes('--no-input'), true,
+                    'help does include --no-input');
+     }));
 });

--- a/tests/unit/test.program.js
+++ b/tests/unit/test.program.js
@@ -865,6 +865,16 @@ describe('program.main', () => {
         fakeCommands.run.resetHistory();
       });
     }
+
+    it('does set noInput to undefined if --no-input is not specified',
+       async () => {
+         fakeCommands.run.resetHistory();
+         await execProgram(['run'], { commands: fakeCommands });
+         sinon.assert.calledWithMatch(
+           fakeCommands.run,
+           {noInput: undefined}
+         );
+       });
   });
 
 });

--- a/tests/unit/test.program.js
+++ b/tests/unit/test.program.js
@@ -841,6 +841,32 @@ describe('program.main', () => {
     }
   );
 
+  describe('--no-input', () => {
+    const fakeCommands = fake(commands, {
+      run: () => Promise.resolve(),
+    });
+
+    const testCases = [
+      ['--no-input', {noInput: true}],
+      ['--no-input=false', {noInput: false}],
+      ['--no-input=true', {noInput: true}],
+      ['--input', {noInput: false}],
+      ['--input=false', {noInput: true}],
+      ['--input=true', {noInput: false}],
+    ];
+
+    for (const [cliArg, expectedParsed] of testCases) {
+      it(`does parse ${cliArg} into the expected command options`, async () => {
+        await execProgram(['run', cliArg], {commands: fakeCommands});
+        sinon.assert.calledWithMatch(
+          fakeCommands.run,
+          expectedParsed
+        );
+        fakeCommands.run.resetHistory();
+      });
+    }
+  });
+
 });
 
 describe('program.defaultVersionGetter', () => {

--- a/tests/unit/test.program.js
+++ b/tests/unit/test.program.js
@@ -853,28 +853,20 @@ describe('program.main', () => {
       ['--input', {noInput: false}],
       ['--input=false', {noInput: true}],
       ['--input=true', {noInput: false}],
+      ['-v', {noInput: undefined}],
     ];
 
-    for (const [cliArg, expectedParsed] of testCases) {
-      it(`does parse ${cliArg} into the expected command options`, async () => {
-        await execProgram(['run', cliArg], {commands: fakeCommands});
-        sinon.assert.calledWithMatch(
-          fakeCommands.run,
-          expectedParsed
-        );
-        fakeCommands.run.resetHistory();
-      });
+    for (const [cliArg, expected] of testCases) {
+      it(`does parse "${cliArg}" cli argument as ${JSON.stringify(expected)}`,
+         async () => {
+           await execProgram(['run', cliArg], {commands: fakeCommands});
+           sinon.assert.calledWithMatch(
+             fakeCommands.run,
+             expected
+           );
+           fakeCommands.run.resetHistory();
+         });
     }
-
-    it('does set noInput to undefined if --no-input is not specified',
-       async () => {
-         fakeCommands.run.resetHistory();
-         await execProgram(['run'], { commands: fakeCommands });
-         sinon.assert.calledWithMatch(
-           fakeCommands.run,
-           {noInput: undefined}
-         );
-       });
   });
 
 });


### PR DESCRIPTION
This PR contains some minor changes to make sure we do accept the --no-input global cli option as documented and that it is parsed into the noInput boolean option the web-ext commands expects (plus a new test case to make sure we do not regress again on future updates of the yargs npm dependency).

Fixes #1860