### PR TITLE
chore(deps): update dependency flow-bin to v0.138.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "eslint-plugin-async-await": "0.0.0",
         "eslint-plugin-flowtype": "5.2.0",
         "eslint-plugin-import": "2.22.1",
-        "flow-bin": "0.137.0",
+        "flow-bin": "0.138.0",
         "git-rev-sync": "3.0.1",
         "html-entities": "1.3.1",
         "mocha": "8.2.1",
@@ -7353,9 +7353,9 @@
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA=="
     },
     "node_modules/flow-bin": {
-      "version": "0.137.0",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.137.0.tgz",
-      "integrity": "sha512-ytwUn68fPKK/VWVpCxJ4KNeNIjCC/uX0Ll6Z1E98sOXfMknB000WtgQjKYDdO6tOR8mvXBE0adzjgCrChVympw==",
+      "version": "0.138.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.138.0.tgz",
+      "integrity": "sha512-y3twwNeN0FWEK0vvJo/5SiC/OQVlhubGRyOPIS6p49b2yiiWE/cBFG/aC9kFXFfh7Orewe5O5B2X0+IiEOCYIw==",
       "dev": true,
       "bin": {
         "flow": "cli.js"
@@ -21645,9 +21645,9 @@
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA=="
     },
     "flow-bin": {
-      "version": "0.137.0",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.137.0.tgz",
-      "integrity": "sha512-ytwUn68fPKK/VWVpCxJ4KNeNIjCC/uX0Ll6Z1E98sOXfMknB000WtgQjKYDdO6tOR8mvXBE0adzjgCrChVympw==",
+      "version": "0.138.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.138.0.tgz",
+      "integrity": "sha512-y3twwNeN0FWEK0vvJo/5SiC/OQVlhubGRyOPIS6p49b2yiiWE/cBFG/aC9kFXFfh7Orewe5O5B2X0+IiEOCYIw==",
       "dev": true
     },
     "fluent-syntax": {

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "eslint-plugin-async-await": "0.0.0",
     "eslint-plugin-flowtype": "5.2.0",
     "eslint-plugin-import": "2.22.1",
-    "flow-bin": "0.137.0",
+    "flow-bin": "0.138.0",
     "git-rev-sync": "3.0.1",
     "html-entities": "1.3.1",
     "mocha": "8.2.1",


### PR DESCRIPTION
- Supersedes #2072
- Avoids to downgrade the lockfile to version 1

It looks that the unexpected change in #2072 is due to using npm < v7, which will downgrade automatically the lockfile to version 1,
see this fragment from the npm source in the v6 branch:
- https://github.com/npm/cli/blob/39a25ae560d17393b2a7b8fbc2abc424654604b7/lib/install/read-shrinkwrap.js#L28-L30

This PR avoid the unexpected big package-lock.json by using npm v7 (`npx npm@7 install --package-lock-only`) locally to generate the minimal package-lock.json diff that we were expecting to see in #2072.

