### PR TITLE
test: Skip unit tests for git commit info in web-ext version when tests are not running from a git repository

### DIFF
--- a/tests/unit/test.program.js
+++ b/tests/unit/test.program.js
@@ -911,10 +911,15 @@ describe('program.defaultVersionGetter', () => {
   });
 
   it('returns git commit information in development', function() {
-    const commit = `${git.branch()}-${git.long()}`;
-    const testBuildEnv = {globalEnv: 'development'};
-    assert.equal(defaultVersionGetter(projectRoot, testBuildEnv),
-                 commit);
+    return fs.exists(path.join(projectRoot, '.git')).then((exists) => {
+      if (!exists) {
+        this.skip();
+      }
+      const commit = `${git.branch()}-${git.long()}`;
+      const testBuildEnv = {globalEnv: 'development'};
+      assert.equal(defaultVersionGetter(projectRoot, testBuildEnv),
+                   commit);
+    });
   });
 });
 


### PR DESCRIPTION
For example, from a GitHub source tarball archive

Background: I'm the maintainer of [web-ext](https://archlinux.org/packages/community/any/web-ext/) package on Arch Linux, and I chose GitHub source tarballs (e.g., https://github.com/mozilla/web-ext/archive/5.5.0/web-ext-5.5.0.tar.gz) instead of the full git repository for building that package for saving disk space and a little time when building on Arch Linux's shared build server.