### PR TITLE
feat: enabled watching multiple files via `--watch-file`

### DIFF
--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -38,7 +38,7 @@ export type CmdRunParams = {|
   noReload: boolean,
   preInstall: boolean,
   sourceDir: string,
-  watchFile?: string,
+  watchFile?: Array<string>,
   watchIgnored?: Array<string>,
   startUrl?: Array<string>,
   target?: Array<string>,
@@ -117,6 +117,11 @@ export default async function run(
     log.info('Disabled auto-reloading because it\'s not possible with ' +
              '--pre-install');
     noReload = true;
+  }
+
+  if (watchFile != null && (!Array.isArray(watchFile) ||
+      !watchFile.every((el) => typeof el === 'string'))) {
+    throw new UsageError('Unexpected watchFile type');
   }
 
   // Create an alias for --pref since it has been transformed into an

--- a/src/extension-runners/index.js
+++ b/src/extension-runners/index.js
@@ -239,7 +239,7 @@ export class MultiExtensionRunner {
 export type WatcherCreatorParams = {|
   reloadExtension: (string) => void,
   sourceDir: string,
-  watchFile?: string,
+  watchFile?: Array<string>,
   watchIgnored?: Array<string>,
   artifactsDir: string,
   onSourceChange?: OnSourceChangeFn,
@@ -276,7 +276,7 @@ export function defaultWatcherCreator(
 export type ReloadStrategyParams = {|
   extensionRunner: IExtensionRunner,
   sourceDir: string,
-  watchFile?: string,
+  watchFile?: Array<string>,
   watchIgnored?: Array<string>,
   artifactsDir: string,
   ignoreFiles?: Array<string>,

--- a/src/program.js
+++ b/src/program.js
@@ -619,7 +619,7 @@ Example: $0 --help run.
                   ' file changes. This is useful if you use a custom' +
                   ' build process for your extension',
         demandOption: false,
-        type: 'string',
+        type: 'array',
       },
       'watch-ignored': {
         describe: 'Paths and globs patterns that should not be ' +

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -18,7 +18,7 @@ export type OnChangeFn = () => any;
 
 export type OnSourceChangeParams = {|
   sourceDir: string,
-  watchFile?: string,
+  watchFile?: Array<string>,
   watchIgnored?: Array<string>,
   artifactsDir: string,
   onChange: OnChangeFn,
@@ -57,18 +57,22 @@ export default function onSourceChange(
     proxyFileChanges({artifactsDir, onChange, filePath, shouldWatchFile});
   });
 
-  log.debug(`Watching for file changes in ${watchFile || sourceDir}`);
+  log.debug(
+    `Watching ${watchFile ? watchFile.join(',') : sourceDir} for changes`
+  );
 
   const watchedDirs = [];
   const watchedFiles = [];
 
   if (watchFile) {
-    if (fs.existsSync(watchFile) && !fs.lstatSync(watchFile).isFile()) {
-      throw new UsageError('Invalid --watch-file value: ' +
-        `"${watchFile}" is not a file.`);
-    }
+    for (const filePath of watchFile) {
+      if (fs.existsSync(filePath) && !fs.lstatSync(filePath).isFile()) {
+        throw new UsageError('Invalid --watch-file value: ' +
+          `"${filePath}" is not a file.`);
+      }
 
-    watchedFiles.push(watchFile);
+      watchedFiles.push(filePath);
+    }
   } else {
     watchedDirs.push(sourceDir);
   }

--- a/tests/unit/test-cmd/test.run.js
+++ b/tests/unit/test-cmd/test.run.js
@@ -161,12 +161,22 @@ describe('run', () => {
     }, {firefoxApp, firefoxClient});
   });
 
+  it('throws if watchFile is not an array', async () => {
+    const cmd = prepareRun();
+    await assert.isRejected(
+      cmd.run({noReload: false, watchFile: 'invalid-value.txt' }),
+      /Unexpected watchFile type/
+    );
+  });
+
   it('can watch and reload the extension', async () => {
     const cmd = prepareRun();
     const {sourceDir, artifactsDir} = cmd.argv;
     const {reloadStrategy} = cmd.options;
 
-    const watchFile = fixturePath('minimal-web-ext', 'manifest.json');
+    const watchFile = [
+      fixturePath('minimal-web-ext', 'manifest.json'),
+    ];
 
     await cmd.run({noReload: false, watchFile });
     assert.equal(reloadStrategy.called, true);

--- a/tests/unit/test.program.js
+++ b/tests/unit/test.program.js
@@ -543,15 +543,13 @@ describe('program.main', () => {
       });
   });
 
-  it('calls run with a watched file', () => {
-    const watchFile = 'path/to/fake/file.txt';
-
+  async function testWatchFileOption(watchFile) {
     const fakeCommands = fake(commands, {
       run: () => Promise.resolve(),
     });
 
     return execProgram(
-      ['run', '--watch-file', watchFile],
+      ['run', '--watch-file', ...watchFile],
       {commands: fakeCommands})
       .then(() => {
         sinon.assert.calledWithMatch(
@@ -559,6 +557,16 @@ describe('program.main', () => {
           {watchFile}
         );
       });
+  }
+
+  it('calls run with a watched file', () => {
+    testWatchFileOption(['path/to/fake/file.txt']);
+  });
+
+  it('calls run with multiple watched files', () => {
+    testWatchFileOption(
+      ['path/to/fake/file.txt', 'path/to/fake/file2.txt']
+    );
   });
 
   async function testWatchIgnoredOption(watchIgnored) {

--- a/tests/unit/test.watcher.js
+++ b/tests/unit/test.watcher.js
@@ -13,7 +13,7 @@ import {withTempDir} from '../../src/util/temp-dir';
 import { makeSureItFails } from './helpers';
 
 type AssertWatchedParams = {
-  watchFile?: string,
+  watchFile?: Array<string>,
   touchedFile: string,
 }
 
@@ -28,7 +28,7 @@ describe('watcher', () => {
       const someFile = path.join(tmpDir.path(), touchedFile);
 
       if (watchFile) {
-        watchFile = path.join(tmpDir.path(), watchFile);
+        watchFile = watchFile.map((f) => path.join(tmpDir.path(), f));
       }
 
       var resolveChange;
@@ -116,7 +116,7 @@ describe('watcher', () => {
         watchedDirPath,
         tmpDirPath,
       } = await watchChange({
-        watchFile: 'foo.txt',
+        watchFile: ['foo.txt'],
         touchedFile: 'foo.txt',
       });
 
@@ -132,7 +132,7 @@ describe('watcher', () => {
         watchedDirPath,
         tmpDirPath,
       } = await watchChange({
-        watchFile: 'bar.txt',
+        watchFile: ['bar.txt'],
         touchedFile: 'foo.txt',
       });
 
@@ -143,7 +143,7 @@ describe('watcher', () => {
 
     it('throws error if a non-file is passed into --watch-file', () => {
       return watchChange({
-        watchFile: '/',
+        watchFile: ['/'],
         touchedFile: 'foo.txt',
       }).then(makeSureItFails()).catch((error) => {
         assert.match(


### PR DESCRIPTION
Fixes #2104 

This allows passing multiple paths to `--watch-file` in order for `web-ext`. It tweaks the current tests to address the changes and make sure they still pass.