### PR TITLE
fix: Replaced unmaintained dependencies firefox-client and node-firefox-connect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2984,24 +2984,6 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@cliqz-oss/firefox-client": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@cliqz-oss/firefox-client/-/firefox-client-0.3.1.tgz",
-      "integrity": "sha512-RO+Tops/wGnBzWoZYkCraqyh2JqOejqJq5/a4b54HhmjTNSKdUPwAOK17EGg/zPb0nWqkuB7QyZsI9bo+ev8Kw==",
-      "requires": {
-        "colors": "0.5.x",
-        "js-select": "~0.6.0"
-      }
-    },
-    "@cliqz-oss/node-firefox-connect": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@cliqz-oss/node-firefox-connect/-/node-firefox-connect-1.2.1.tgz",
-      "integrity": "sha512-O/IyiB5pfztCdmxQZg0/xeq5w+YiP3gtJz8d4We2EpLPKzbDVjOrtfLKYgVfm6Ya6mbvDge1uLkSRwaoVCWKnA==",
-      "requires": {
-        "@cliqz-oss/firefox-client": "0.3.1",
-        "es6-promise": "^2.0.1"
-      }
-    },
     "@commitlint/cli": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-11.0.0.tgz",
@@ -3742,11 +3724,6 @@
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
-    },
-    "JSONSelect": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/JSONSelect/-/JSONSelect-0.2.1.tgz",
-      "integrity": "sha1-QVQYpSbTP+MddLTe+jyDbUhewgM="
     },
     "JSONStream": {
       "version": "1.3.5",
@@ -5046,11 +5023,6 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
       "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw=="
     },
-    "colors": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
-      "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q="
-    },
     "columnify": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
@@ -5848,11 +5820,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
-    },
-    "es6-promise": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
-      "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw="
     },
     "es6-promisify": {
       "version": "6.1.1",
@@ -7801,15 +7768,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/jetpack-id/-/jetpack-id-1.0.0.tgz",
       "integrity": "sha1-LPn7rkbYB0/Ba33gBxyO/rykc6Y="
-    },
-    "js-select": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/js-select/-/js-select-0.6.0.tgz",
-      "integrity": "sha1-woTiKCTVknrsli3N8kcXSu+w0ZA=",
-      "requires": {
-        "JSONSelect": "0.2.1",
-        "traverse": "0.4.x"
-      }
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -11306,11 +11264,6 @@
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
       }
-    },
-    "traverse": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.4.6.tgz",
-      "integrity": "sha1-0EsigOTHkqWBVCnve4tgxkyczDQ="
     },
     "trim": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -59,8 +59,6 @@
   "dependencies": {
     "@babel/polyfill": "7.12.1",
     "@babel/runtime": "7.12.13",
-    "@cliqz-oss/firefox-client": "0.3.1",
-    "@cliqz-oss/node-firefox-connect": "1.2.1",
     "@devicefarmer/adbkit": "2.11.3",
     "addons-linter": "2.17.0",
     "bunyan": "1.8.15",

--- a/src/firefox/rdp-client.js
+++ b/src/firefox/rdp-client.js
@@ -1,0 +1,299 @@
+/* @flow */
+import net from 'net';
+import EventEmitter from 'events';
+import domain from 'domain';
+
+export type RDPRequest = {
+  to: string,
+  type: string,
+}
+
+export type RDPResult = {
+  from: string,
+  type: string,
+}
+
+export type Deferred = {|
+  resolve: Function,
+  reject: Function,
+|}
+
+type ParseResult = {|
+  data: Buffer,
+  rdpMessage?: Object,
+  error?: Error,
+  fatal?: boolean,
+|}
+
+export const DEFAULT_PORT = 6000;
+export const DEFAULT_HOST = '127.0.0.1';
+
+const UNSOLICITED_EVENTS = new Set([
+  'tabNavigated',
+  'styleApplied',
+  'propertyChange',
+  'networkEventUpdate',
+  'networkEvent',
+  'propertyChange',
+  'newMutations',
+  'frameUpdate',
+  'tabListChanged',
+]);
+
+// Parse RDP packets: BYTE_LENGTH + ':' + DATA.
+export function parseRDPMessage(data: Buffer): ParseResult {
+  const str = data.toString();
+  const sepIdx = str.indexOf(':');
+  if (sepIdx < 1) {
+    return {data};
+  }
+
+  const byteLen = parseInt(str.slice(0, sepIdx));
+  if (isNaN(byteLen)) {
+    const error = new Error('Error parsing RDP message length');
+    return {data, error, fatal: true};
+  }
+
+  if (data.length - (sepIdx + 1) < byteLen) {
+    // Can't parse yet, will retry once more data has been received.
+    return {data};
+  }
+
+  data = data.slice(sepIdx + 1);
+  const msg = data.slice(0, byteLen);
+  data = data.slice(byteLen);
+
+  try {
+    return {data, rdpMessage: JSON.parse(msg.toString())};
+  } catch (error) {
+    return {data, error, fatal: false};
+  }
+}
+
+export function connectToFirefox(port: number): Promise<FirefoxRDPClient> {
+  const client = new FirefoxRDPClient();
+  return client.connect(port).then(() => client);
+}
+
+export default class FirefoxRDPClient extends EventEmitter {
+  _incoming: Buffer;
+  _pending: Array<{| request: RDPRequest, deferred: Deferred |}>;
+  _active: Map<string, Deferred>;
+  _rdpConnection: net.Socket;
+  _onData: Function;
+  _onError: Function;
+  _onEnd: Function;
+  _onTimeout: Function;
+
+  constructor() {
+    super();
+    this._incoming = Buffer.alloc(0);
+    this._pending = [];
+    this._active = new Map();
+
+    this._onData = this.onData.bind(this);
+    this._onError = this.onError.bind(this);
+    this._onEnd = this.onEnd.bind(this);
+    this._onTimeout = this.onTimeout.bind(this);
+  }
+
+  connect(port: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      // Create a domain to wrap the errors that may be triggered
+      // by creating the client connection (e.g. ECONNREFUSED)
+      // so that we can reject the promise returned instead of
+      // exiting the entire process.
+      const d = domain.create();
+      d.once('error', reject);
+      d.run(() => {
+        const conn = net.createConnection({
+          port,
+          host: DEFAULT_HOST,
+        });
+
+        this._rdpConnection = conn;
+        conn.on('data', this._onData);
+        conn.on('error', this._onError);
+        conn.on('end', this._onEnd);
+        conn.on('timeout', this._onTimeout);
+
+        // Resolve once the expected initial root message
+        // has been received.
+        this._expectReply('root', {resolve, reject});
+      });
+    });
+  }
+
+  disconnect(): void {
+    if (!this._rdpConnection) {
+      return;
+    }
+
+    const conn = this._rdpConnection;
+    conn.off('data', this._onData);
+    conn.off('error', this._onError);
+    conn.off('end', this._onEnd);
+    conn.off('timeout', this._onTimeout);
+    conn.end();
+
+    this._rejectAllRequests(new Error('RDP connection closed'));
+  }
+
+  _rejectAllRequests(error: Error) {
+    for (const activeDeferred of this._active.values()) {
+      activeDeferred.reject(error);
+    }
+    this._active.clear();
+
+    for (const {deferred} of this._pending) {
+      deferred.reject(error);
+    }
+    this._pending = [];
+  }
+
+  async request(requestProps: string | RDPRequest): Promise<RDPResult> {
+    let request: RDPRequest;
+
+    if (typeof requestProps === 'string') {
+      request = {to: 'root', type: requestProps};
+    } else {
+      request = requestProps;
+    }
+
+    if (request.to == null) {
+      throw new Error(
+        `Unexpected RDP request without target actor: ${request.type}`
+      );
+    }
+
+    return new Promise((resolve, reject) => {
+      const deferred = {resolve, reject};
+      this._pending.push({request, deferred});
+      this._flushPendingRequests();
+    });
+  }
+
+  _flushPendingRequests(): void {
+    this._pending = this._pending.filter(({request, deferred}) => {
+      if (this._active.has(request.to)) {
+        // Keep in the pending requests until there are no requests
+        // active on the target RDP actor.
+        return true;
+      }
+
+      const conn = this._rdpConnection;
+      if (!conn) {
+        throw new Error('RDP connection closed');
+      }
+
+      try {
+        let str = JSON.stringify(request);
+        str = `${Buffer.from(str).length}:${str}`;
+        conn.write(str);
+        this._expectReply(request.to, deferred);
+      } catch (err) {
+        deferred.reject(err);
+      }
+
+      // Remove the pending request from the queue.
+      return false;
+    });
+  }
+
+  _expectReply(targetActor: string, deferred: Deferred): void {
+    if (this._active.has(targetActor)) {
+      throw new Error(`${targetActor} does already have an active request`);
+    }
+
+    this._active.set(targetActor, deferred);
+  }
+
+  _handleMessage(rdpData: Object): void {
+    if (rdpData.from == null) {
+      if (rdpData.error) {
+        this.emit('rdp-error', rdpData);
+        return;
+      }
+
+      this.emit('error', new Error(
+        `Received an RDP message without a sender actor: ${
+          JSON.stringify(rdpData)
+        }`
+      ));
+      return;
+    }
+
+    if (UNSOLICITED_EVENTS.has(rdpData.type)) {
+      this.emit('unsolicited-event', rdpData);
+      return;
+    }
+
+    if (this._active.has(rdpData.from)) {
+      const deferred = this._active.get(rdpData.from);
+      this._active.delete(rdpData.from);
+      if (rdpData.error) {
+        deferred?.reject(rdpData);
+      } else {
+        deferred?.resolve(rdpData);
+      }
+      this._flushPendingRequests();
+      return;
+    }
+
+    this.emit('error', new Error(
+      `Unexpected RDP message received: ${JSON.stringify(rdpData)}`
+    ));
+  }
+
+  _readMessage(): boolean {
+    const {
+      data, rdpMessage, error, fatal,
+    } = parseRDPMessage(this._incoming);
+
+    this._incoming = data;
+
+    if (error) {
+      this.emit(
+        'error',
+        new Error(`Error parsing RDP packet: ${String(error)}`)
+      );
+      // Disconnect automatically on a fatal error.
+      if (fatal) {
+        this.disconnect();
+      }
+      // Caller can parse the next message if the error wasn't fatal
+      // (e.g. the RDP packet that couldn't be parsed has been already
+      // removed from the incoming data buffer).
+      return !fatal;
+    }
+
+    if (!rdpMessage) {
+      // Caller will need to wait more data to parse the next message.
+      return false;
+    }
+
+    this._handleMessage(rdpMessage);
+    // Caller can try to parse the next message from the remining data.
+    return true;
+  }
+
+  onData(data: Buffer) {
+    this._incoming = Buffer.concat([this._incoming, data]);
+    while (this._readMessage()) {
+      // Keep parsing and handling messages until readMessage
+      // returns false.
+    }
+  }
+
+  onError(error: Error) {
+    this.emit('error', error);
+  }
+
+  onEnd() {
+    this.emit('end');
+  }
+
+  onTimeout() {
+    this.emit('timeout');
+  }
+}

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -204,50 +204,14 @@ export function createFakeProcess(): any {
 }
 
 /*
- * Returns a fake Firefox client as would be returned by
- * connect() of 'node-firefox-connect'
+ * Returns a fake FirefoxRDPClient as would be returned by
+ * rdp-module connectToFirefox().
  */
-
-type FakeFirefoxClientParams = {|
-  requestResult?: Object,
-  requestError?: Object,
-  makeRequestResult?: Object,
-  makeRequestError?: Object,
-|}
-export function fakeFirefoxClient({
-  requestResult = {}, requestError,
-  makeRequestResult = {}, makeRequestError,
-}: FakeFirefoxClientParams = {}): any {
+export function fakeFirefoxClient(): any {
   return {
     disconnect: sinon.spy(() => {}),
-    request: sinon.spy(
-      (request, callback) => callback(requestError, requestResult)),
-    // This is client.client, the actual underlying connection.
-    client: {
-      on: () => {},
-      makeRequest: sinon.spy((request, callback) => {
-        //
-        // The real function returns a response object that you
-        // use like this:
-        // if (response.error) {
-        //   ...
-        // } else {
-        //   response.something; // ...
-        // }
-        //
-        if (makeRequestError) {
-          let error;
-          if (typeof makeRequestError === 'object') {
-            error = makeRequestError;
-          } else {
-            error = {error: makeRequestError};
-          }
-          callback(error);
-        } else {
-          callback(makeRequestResult);
-        }
-      }),
-    },
+    on: () => {},
+    request: sinon.stub().resolves({}),
   };
 }
 

--- a/tests/unit/test-firefox/test.rdp-client.js
+++ b/tests/unit/test-firefox/test.rdp-client.js
@@ -1,0 +1,374 @@
+/* @flow */
+import net from 'net';
+
+import {describe, it, beforeEach, afterEach} from 'mocha';
+import {assert} from 'chai';
+import sinon from 'sinon';
+
+import FirefoxRDPClient, {
+  connectToFirefox,
+  parseRDPMessage,
+} from '../../../src/firefox/rdp-client';
+
+function createFakeRDPServer() {
+  let lastSocket;
+
+  function sendRDPMessage(msg: Object) {
+    let data = Buffer.from(JSON.stringify(msg));
+    data = Buffer.concat([
+      Buffer.from(`${data.length}:`),
+      data,
+    ]);
+    lastSocket.write(data);
+  }
+
+  const server = net.createServer((socket) => {
+    lastSocket?.destroy();
+    lastSocket = socket;
+    // Send the initial RDP root message.
+    sendRDPMessage({from: 'root'});
+  });
+
+  return {
+    server,
+    sendRDPMessage,
+    get port() {
+      return server.address()?.port;
+    },
+    get socket() {
+      return lastSocket;
+    },
+    async listen() {
+      return new Promise((resolve) => server.listen(resolve));
+    },
+    destroy() {
+      lastSocket?.destroy();
+      return new Promise((resolve) => server.close(resolve));
+    },
+    get awaitConnected() {
+      return new Promise((resolve) => {
+        server.once('connection', resolve);
+      });
+    },
+    get awaitData() {
+      return new Promise((resolve) => {
+        lastSocket.once('data', (data) => resolve(data));
+      });
+    },
+  };
+}
+
+describe('rdp-client', () => {
+  describe('parseRDPMessage', () => {
+    it('returns a fatal error on failing to parse RDP message length', () => {
+      const data = Buffer.from('NOT_A_NUMBER:fakerdpdata');
+      const res = parseRDPMessage(data);
+      assert.isUndefined(res.rdpMessage);
+      assert.instanceOf(res.error, Error);
+      assert.match(res.error?.message, /Error parsing RDP message length/);
+      assert.isTrue(res.fatal);
+      assert.strictEqual(res.data.length, data.length);
+    });
+
+    it('returns a non-fatal error on failing to parse RDP message data', () => {
+      const data = Buffer.from('1:{');
+      const res = parseRDPMessage(data);
+      assert.isUndefined(res.rdpMessage);
+      assert.instanceOf(res.error, Error);
+      assert.isFalse(res.fatal);
+      assert.strictEqual(res.data.length, 0);
+    });
+
+    it('does parse RDP message when all expected data is available', () => {
+      const rdpObj = {from: 'fake-actor'};
+      const rdpBuffer = Buffer.from(JSON.stringify(rdpObj));
+      // Create a buffer with an incomplete rdp message.
+      const incompleteData = Buffer.concat([
+        Buffer.from(`${rdpBuffer.length}:`),
+        rdpBuffer.slice(0, rdpBuffer.length - 5),
+      ]);
+
+      let res = parseRDPMessage(incompleteData);
+      assert.isUndefined(res.rdpMessage);
+      assert.isUndefined(res.error, Error);
+      assert.strictEqual(res.data, incompleteData);
+
+      const fullData = Buffer.concat([
+        incompleteData,
+        rdpBuffer.slice(rdpBuffer.length - 5),
+      ]);
+
+      res = parseRDPMessage(fullData);
+      assert.isUndefined(res.error, Error);
+      assert.strictEqual(res.data.length, 0);
+      assert.deepEqual(res.rdpMessage, rdpObj);
+    });
+  });
+
+  describe('FirefoxRDPClient', () => {
+    let fakeRDPServer;
+    let client: FirefoxRDPClient;
+
+    beforeEach(() => {
+      fakeRDPServer = createFakeRDPServer();
+    });
+
+    afterEach(async () => {
+      client?.disconnect();
+      await fakeRDPServer?.destroy();
+    });
+
+    async function getConnectedRDPClient() {
+      await fakeRDPServer.listen();
+      const promiseServerConn = fakeRDPServer.awaitConnected;
+      const promiseClientConn = connectToFirefox(fakeRDPServer.port);
+      const sock = await promiseServerConn;
+      assert.instanceOf(sock, net.Socket);
+      client = await promiseClientConn;
+    }
+
+    function assertClientHasNoRequests() {
+      assert.equal(client._active.size, 0);
+      assert.equal(client._pending.length, 0);
+    }
+
+    it('connects to a Firefox RDP server', async () => {
+      await getConnectedRDPClient();
+    });
+
+    it('forwards some of the events emitted by the connection', async () => {
+      await getConnectedRDPClient();
+      const forwardedEvents = ['error', 'end', 'timeout'];
+      const expectedData = {
+        error: new Error('fake-error'),
+        // no data is expected for end and timeout events.
+        end: undefined,
+        timeout: undefined,
+      };
+      for (const name of forwardedEvents) {
+        const promiseEvent = new Promise((resolve) =>
+          client.once(name, (evt) => resolve(evt)));
+        client._rdpConnection.emit(name, expectedData[name]);
+        assert.equal(await promiseEvent, expectedData[name],
+                     `${name} event got forwarded as expected`);
+      }
+    });
+
+    describe('request', () => {
+      it('sends an RDP request', async () => {
+        const expectedRequest = {to: 'root', type: 'getRoot'};
+        const expectedResponse = {from: 'root', addonsActor: 'fake-actor-id'};
+        await getConnectedRDPClient();
+
+        // Assert expected data received by the RDP server when sending
+        // an RDP request by requestType string.
+        const promiseServerData = fakeRDPServer.awaitData;
+        const promiseResponse = client.request('getRoot');
+        const res = parseRDPMessage(await promiseServerData);
+        assert.isUndefined(res.error);
+        assert.deepEqual(res.rdpMessage, expectedRequest);
+
+        // Assert request promise resolved with the RDP server
+        // response.
+        fakeRDPServer.sendRDPMessage(expectedResponse);
+        assert.deepEqual(await promiseResponse, expectedResponse);
+
+        // Send another RDP request by passing the entire RDP message.
+        const promiseServerData2 = fakeRDPServer.awaitData;
+        const promiseResponse2 = client.request({to: 'root', type: 'getRoot'});
+        const res2 = parseRDPMessage(await promiseServerData2);
+        assert.isUndefined(res2.error);
+        assert.deepEqual(res2.rdpMessage, expectedRequest);
+        fakeRDPServer.sendRDPMessage(expectedResponse);
+        assert.deepEqual(await promiseResponse2, expectedResponse);
+      });
+
+      it('rejects on RDP request without a target actor', async () => {
+        await getConnectedRDPClient();
+        await assert.isRejected(
+          // $FlowIgnore: ignore flowtype error for testing purpose.
+          client.request({type: 'getRoot'}),
+          /Unexpected RDP request without target actor/
+        );
+      });
+
+      it('rejects on RDP request on source actor RDP error reply', async () => {
+        await getConnectedRDPClient();
+        const promiseRes = client.request('getRoot');
+        const serverReply = {from: 'root', error: 'fake-error', message: 'msg'};
+        fakeRDPServer.sendRDPMessage(serverReply);
+
+        const rdpReply = await assert.isRejected(promiseRes);
+        assert.notInstanceOf(rdpReply, Error);
+        assert.deepEqual(rdpReply, serverReply);
+      });
+
+      it('does disconnect on fatal parsing error', async () => {
+        await getConnectedRDPClient();
+        let error;
+        client.once('error', (err) => error = err);
+        const promiseRes = client.request('getRoot');
+        fakeRDPServer.socket.write(Buffer.from('NaN:fakerdpdata'));
+        await assert.isRejected(promiseRes, /RDP connection closed/);
+        assert.instanceOf(error, Error);
+      });
+    });
+
+    describe('handleMessage', () => {
+      it('emits rdp-error event on RDP error and no source actor', async () => {
+        await getConnectedRDPClient();
+        const promiseRDPError = new Promise((resolve) => {
+          client.once('rdp-error', (err) => resolve(err));
+        });
+        const rdpError = {error: 'fake-err', message: 'fake-msg'};
+        fakeRDPServer.sendRDPMessage(rdpError);
+        assert.deepEqual(await promiseRDPError, rdpError);
+      });
+
+      it('emits an unsolicited-event on known request types', async () => {
+        await getConnectedRDPClient();
+        const promiseEvent = new Promise((resolve) => {
+          client.once('unsolicited-event', (msg) => resolve(msg));
+        });
+        const unsolicitedEvent = {
+          from: 'root',
+          type: 'tabListChanged',
+        };
+        fakeRDPServer.sendRDPMessage(unsolicitedEvent);
+        assert.deepEqual(await promiseEvent, unsolicitedEvent);
+      });
+
+      async function testHandleMessageError(rdpMsg, expectedErrorMessage) {
+        await getConnectedRDPClient();
+        const promiseError = new Promise((resolve) => {
+          client.once('error', (err) => resolve(err));
+        });
+        fakeRDPServer.sendRDPMessage(rdpMsg);
+        const error = await promiseError;
+        assert.instanceOf(error, Error);
+        assert.match(
+          error?.message,
+          expectedErrorMessage
+        );
+      }
+
+      it('emits an error event on messages with no source actor', () =>
+        testHandleMessageError(
+          {message: 'fake-msg'},
+          /Received an RDP message without a sender actor/
+        ));
+
+      it('emits error event on unexpected source actor', () =>
+        testHandleMessageError(
+          {message: 'fake-msg', from: 'unexpected-actor'},
+          /Unexpected RDP message received/
+        ));
+    });
+
+    describe('flushPendingRequests', () => {
+      it('does queue multiple requests for the same target actor', async () => {
+        await getConnectedRDPClient();
+        const promiseResponse1 = client.request('request1');
+        const promiseResponse2 = client.request('request2');
+
+        // Expect one active and one pending request.
+        assert.equal(client._active.size, 1);
+        assert.equal(client._pending.length, 1);
+
+        const response1 = {from: 'root', resultFor: 'request1'};
+        const response2 = {from: 'root', resultFor: 'request2'};
+
+        fakeRDPServer.sendRDPMessage(response1);
+        assert.deepEqual(await promiseResponse1, response1);
+
+        // Expect one active and no pending request.
+        assert.equal(client._active.size, 1);
+        assert.equal(client._pending.length, 0);
+
+        fakeRDPServer.sendRDPMessage(response2);
+        assert.deepEqual(await promiseResponse2, response2);
+      });
+
+      it('rejects requests if not connected', async () => {
+        const c = new FirefoxRDPClient();
+        await assert.isRejected(
+          c.request('getRoot'),
+          /RDP connection closed/
+        );
+      });
+
+      it('rejects all requests on closed connection', async () => {
+        await getConnectedRDPClient();
+        const awaitResponse = client.request('active-request');
+        const awaitResponse2 = client.request('pending-request');
+        client.disconnect();
+        await assert.isRejected(awaitResponse, /RDP connection closed/);
+        await assert.isRejected(awaitResponse2, /RDP connection closed/);
+        assertClientHasNoRequests();
+      });
+
+      it('rejects request if fails to stringify', async () => {
+        // Create an object with a circular dependency to trigger a stringify.
+        // exception.
+        const req = {to: 'root'};
+        // $FlowIgnore: ignore flowtype error for testing purpose.
+        req.circular = req;
+
+        await getConnectedRDPClient();
+        await assert.isRejected(
+          // $FlowIgnore: ignore flowtype error for testing purpose.
+          client.request(req),
+          Error,
+        );
+        assertClientHasNoRequests();
+      });
+
+      describe('_expectReply', () => {
+        // Not an expected scenario, just added for coverage.
+        it('throws if target actor has an active request', async () => {
+          await getConnectedRDPClient();
+          client.request('getRoot');
+          const expectedActive = client._active.get('root');
+
+          const fakeDeferred = {resolve: () => {}, reject: () => {}};
+          assert.throws(
+            () => client._expectReply('root', fakeDeferred),
+            /root does already have an active request/
+          );
+
+          assert.strictEqual(client._active.get('root'), expectedActive);
+        });
+      });
+    });
+  });
+
+  describe('FirefoxRDPClient disconnect', () => {
+    it('does remove connection event listeners', async () => {
+      const c = new FirefoxRDPClient();
+      const fakeConn = {
+        end: sinon.spy(),
+        off: sinon.spy(),
+      };
+
+      // $FlowIgnore: allow overwrite property for testing purpose.
+      c._rdpConnection = fakeConn;
+      // $FlowIgnore
+      c._onData = function fakeOnData() {};
+      // $FlowIgnore
+      c._onError = function fakeOnError() {};
+      // $FlowIgnore
+      c._onEnd = function fakeOnEnd() {};
+      // $FlowIgnore
+      c._onTimeout = function fakeOnTimeout() {};
+
+      c.disconnect();
+      sinon.assert.calledOnce(fakeConn.end);
+      sinon.assert.callCount(fakeConn.off, 4);
+      sinon.assert.calledWith(fakeConn.off, 'data', c._onData);
+      sinon.assert.calledWith(fakeConn.off, 'error', c._onError);
+      sinon.assert.calledWith(fakeConn.off, 'end', c._onEnd);
+      sinon.assert.calledWith(fakeConn.off, 'timeout', c._onTimeout);
+    });
+  });
+
+});

--- a/tests/unit/test-firefox/test.remote.js
+++ b/tests/unit/test-firefox/test.remote.js
@@ -71,13 +71,23 @@ describe('firefox.remote', () => {
     it('listens to client events', () => {
       const client = fakeFirefoxClient();
       const listener = sinon.spy(() => {});
-      client.client.on = listener;
+      client.on = listener;
       makeInstance(client); // this will register listeners
+
       // Make sure no errors are thrown when the client emits
       // events and calls each handler.
-      listener.firstCall.args[1](); // disconnect
-      listener.secondCall.args[1](); // end
-      listener.thirdCall.args[1]({}); // message
+      const eventListenerTests = ([
+        ['disconnect', undefined],
+        ['end', undefined],
+        ['unsolicited-event', {}],
+        ['rdp-error', {}],
+        ['error', new Error('fake')],
+      ]);
+      for (let i = 0; i < eventListenerTests.length; i++) {
+        const [name, data] = eventListenerTests[i];
+        listener.getCall(i).calledWith(name);
+        listener.getCall(i).args[1](data);
+      }
     });
 
     describe('disconnect', () => {
@@ -95,16 +105,15 @@ describe('firefox.remote', () => {
       it('makes requests to an add-on actor', async () => {
         const addon = fakeAddon();
         const stubResponse = {requestTypes: ['reload']};
-        const client = fakeFirefoxClient({
-          makeRequestResult: stubResponse,
-        });
+        const client = fakeFirefoxClient();
+        client.request = sinon.stub().resolves(stubResponse);
 
         const conn = makeInstance(client);
         const response = await conn.addonRequest(addon, 'requestTypes');
 
-        sinon.assert.called(client.client.makeRequest);
+        sinon.assert.called(client.request);
         sinon.assert.calledWithMatch(
-          client.client.makeRequest,
+          client.request,
           {type: 'requestTypes', to: 'serv1.localhost'});
 
         assert.deepEqual(response, stubResponse);
@@ -112,20 +121,19 @@ describe('firefox.remote', () => {
 
       it('throws when add-on actor requests fail', async () => {
         const addon = fakeAddon();
-        const client = fakeFirefoxClient({
-          makeRequestError: {
-            error: 'unknownError',
-            message: 'some actor failure',
-          },
+        const client = fakeFirefoxClient();
+        client.request = sinon.stub().rejects({
+          error: 'unknownError',
+          message: 'some actor failure',
         });
 
         const conn = makeInstance(client);
         await conn.addonRequest(addon, 'requestTypes')
           .then(makeSureItFails())
           .catch(onlyInstancesOf(WebExtError, (error) => {
-            assert.equal(
+            assert.match(
               error.message,
-              'unknownError: some actor failure');
+              /unknownError: some actor failure/);
           }));
       });
     });
@@ -134,10 +142,9 @@ describe('firefox.remote', () => {
 
       it('gets an installed add-on by ID', async () => {
         const someAddonId = 'some-id';
-        const client = fakeFirefoxClient({
-          requestResult: {
-            addons: [{id: 'another-id'}, {id: someAddonId}, {id: 'bazinga'}],
-          },
+        const client = fakeFirefoxClient();
+        client.request = sinon.stub().resolves({
+          addons: [{id: 'another-id'}, {id: someAddonId}, {id: 'bazinga'}],
         });
         const conn = makeInstance(client);
         const addon = await conn.getInstalledAddon(someAddonId);
@@ -145,10 +152,9 @@ describe('firefox.remote', () => {
       });
 
       it('throws an error when the add-on is not installed', async () => {
-        const client = fakeFirefoxClient({
-          requestResult: {
-            addons: [{id: 'one-id'}, {id: 'other-id'}],
-          },
+        const client = fakeFirefoxClient();
+        client.request = sinon.stub().resolves({
+          addons: [{id: 'one-id'}, {id: 'other-id'}],
         });
         const conn = makeInstance(client);
         await conn.getInstalledAddon('missing-id')
@@ -160,9 +166,8 @@ describe('firefox.remote', () => {
       });
 
       it('throws an error when listAddons() fails', async () => {
-        const client = fakeFirefoxClient({
-          requestError: new Error('some internal error'),
-        });
+        const client = fakeFirefoxClient();
+        client.request = sinon.stub().rejects(new Error('some internal error'));
         const conn = makeInstance(client);
         await conn.getInstalledAddon('some-id')
           .then(makeSureItFails())
@@ -172,6 +177,7 @@ describe('firefox.remote', () => {
               'Remote Firefox: listAddons() error: Error: some internal error');
           }));
       });
+
     });
 
     describe('checkForAddonReloading', () => {
@@ -182,7 +188,7 @@ describe('firefox.remote', () => {
         const conn = makeInstance();
 
         // $FlowIgnore: allow overwrite not writable property for testing purpose.
-        conn.addonRequest = sinon.spy(() => Promise.resolve(stubResponse));
+        conn.addonRequest = sinon.stub().resolves(stubResponse);
 
         const returnedAddon = await conn.checkForAddonReloading(addon);
         sinon.assert.called(conn.addonRequest);
@@ -215,7 +221,7 @@ describe('firefox.remote', () => {
 
         // $FlowIgnore: allow overwrite not writable property for testing purpose.
         conn.addonRequest =
-          sinon.spy(() => Promise.resolve({requestTypes: ['reload']}));
+          sinon.stub().resolves({requestTypes: ['reload']});
         const checkedAddon = await conn.checkForAddonReloading(addon);
         const finalAddon = await conn.checkForAddonReloading(checkedAddon);
         // This should remember not to check a second time.
@@ -227,10 +233,11 @@ describe('firefox.remote', () => {
     describe('installTemporaryAddon', () => {
 
       it('throws getRoot errors', async () => {
-        const client = fakeFirefoxClient({
+        const client = fakeFirefoxClient();
+        client.request = sinon.stub().rejects(
           // listTabs and getRoot response:
-          requestError: new Error('some listTabs error'),
-        });
+          new Error('some listTabs error'),
+        );
         const conn = makeInstance(client);
         await conn.installTemporaryAddon('/path/to/addon')
           .then(makeSureItFails())
@@ -245,10 +252,9 @@ describe('firefox.remote', () => {
       });
 
       it('fails when there is no add-ons actor', async () => {
-        const client = fakeFirefoxClient({
-          // A getRoot and listTabs response that does not contain addonsActor.
-          requestResult: {},
-        });
+        const client = fakeFirefoxClient();
+        // A getRoot and listTabs response that does not contain addonsActor.
+        client.request = sinon.stub().resolves({from: 'root'});
         const conn = makeInstance(client);
         await conn.installTemporaryAddon('/path/to/addon')
           .then(makeSureItFails())
@@ -262,46 +268,54 @@ describe('firefox.remote', () => {
       });
 
       it('lets you install an add-on temporarily', async () => {
-        const client = fakeFirefoxClient({
-          // getRoot response:
-          requestResult: {
-            addonsActor: 'addons1.actor.conn',
-          },
-          // installTemporaryAddon response:
-          makeRequestResult: {
-            addon: {id: 'abc123@temporary-addon'},
-          },
+        const client = fakeFirefoxClient();
+        client.request = sinon.spy(async (request) => {
+          if (request === 'getRoot') {
+            return {addonsActor: 'addons1.actor.conn'};
+          }
+
+          if (request.type === 'installTemporaryAddon') {
+            return {
+              addon: {id: 'abc123@temporary-addon'},
+            };
+          }
         });
         const conn = makeInstance(client);
         const response = await conn.installTemporaryAddon('/path/to/addon');
         assert.equal(response.addon.id, 'abc123@temporary-addon');
 
         // When called without error, there should not be any fallback.
-        sinon.assert.calledOnce(client.request);
+        sinon.assert.calledTwice(client.request);
         sinon.assert.calledWith(client.request, 'getRoot');
       });
 
       it('falls back to listTabs when getRoot is unavailable', async () => {
-        const client = fakeFirefoxClient({
-          // installTemporaryAddon response:
-          makeRequestResult: {
-            addon: {id: 'abc123@temporary-addon'},
-          },
-        });
+        const client = fakeFirefoxClient();
         client.request = sinon.stub();
+        const addonsActor = 'addons1.actor.conn';
+        const addonPath = '/path/to/addon';
+
+        client.request.withArgs({
+          type: 'installTemporaryAddon',
+          to: addonsActor,
+          addonPath,
+        }).resolves({
+          addon: {id: 'abc123@temporary-addon'},
+        });
+
         // Sample response from Firefox 49.
-        client.request.withArgs('getRoot').callsArgWith(1, {
+        client.request.withArgs('getRoot').rejects({
           error: 'unrecognizedPacketType',
           message: 'Actor root does not recognize the packet type getRoot',
         });
-        client.request.withArgs('listTabs').callsArgWith(1, undefined, {
-          addonsActor: 'addons1.actor.conn',
+        client.request.withArgs('listTabs').resolves({
+          addonsActor,
         });
         const conn = makeInstance(client);
-        const response = await conn.installTemporaryAddon('/path/to/addon');
+        const response = await conn.installTemporaryAddon(addonPath);
         assert.equal(response.addon.id, 'abc123@temporary-addon');
 
-        sinon.assert.calledTwice(client.request);
+        sinon.assert.callCount(client.request, 3);
         sinon.assert.calledWith(client.request, 'getRoot');
         sinon.assert.calledWith(client.request, 'listTabs');
       });
@@ -310,11 +324,11 @@ describe('firefox.remote', () => {
         const client = fakeFirefoxClient();
         client.request = sinon.stub();
         // Sample response from Firefox 48.
-        client.request.withArgs('getRoot').callsArgWith(1, {
+        client.request.withArgs('getRoot').rejects({
           error: 'unrecognizedPacketType',
           message: 'Actor root does not recognize the packet type getRoot',
         });
-        client.request.withArgs('listTabs').callsArgWith(1, undefined, {});
+        client.request.withArgs('listTabs').resolves({});
         const conn = makeInstance(client);
         await conn.installTemporaryAddon('/path/to/addon')
           .then(makeSureItFails())
@@ -330,16 +344,19 @@ describe('firefox.remote', () => {
       });
 
       it('throws install errors', async () => {
-        const client = fakeFirefoxClient({
-          // listTabs response:
-          requestResult: {
-            addonsActor: 'addons1.actor.conn',
-          },
-          // installTemporaryAddon response:
-          makeRequestError: {
-            error: 'install error',
-            message: 'error message',
-          },
+        const client = fakeFirefoxClient();
+        client.request = sinon.spy(async (request) => {
+          if (request === 'getRoot') {
+            return {
+              addonsActor: 'addons1.actor.conn',
+            };
+          }
+          if (request.type === 'installTemporaryAddon') {
+            return Promise.reject({
+              error: 'install error',
+              message: 'error message',
+            });
+          }
         });
         const conn = makeInstance(client);
         await conn.installTemporaryAddon('/path/to/addon')
@@ -358,12 +375,12 @@ describe('firefox.remote', () => {
         const conn = makeInstance();
 
         // $FlowIgnore: allow overwrite not writable property for testing purpose.
-        conn.getInstalledAddon = sinon.spy(() => Promise.resolve(addon));
+        conn.getInstalledAddon = sinon.stub().resolves(addon);
         // $FlowIgnore: allow overwrite not writable property for testing purpose.
         conn.checkForAddonReloading =
           (addonToCheck) => Promise.resolve(addonToCheck);
         // $FlowIgnore: allow overwrite not writable property for testing purpose.
-        conn.addonRequest = sinon.spy(() => Promise.resolve({}));
+        conn.addonRequest = sinon.stub().resolves({});
 
         await conn.reloadAddon('some-id');
         sinon.assert.called(conn.getInstalledAddon);


### PR DESCRIPTION
This PR contains a new `src/firefox/rdp-client.js` module that replaces the subset of feature we do use in web-ext from the unmaintained dependencies firefox-client and node-firefox-connect (and additional  unit tests to cover this new module).

By removing the firefox-client npm package from the dependencies we do also avoid one of the deprecation warnings related to `js-select@0.6.0` being logged when the web-ext package is installed by a user:
```
npm WARN deprecated js-select@0.6.0: Package no longer supported. Contact support@npmjs.com for more info.
```