### PR TITLE
chore(npm): Required npm to be strictly < v7 in package.json (fixes #2145)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "engines": {
     "node": ">=10.0.0",
-    "npm": ">=5.6.0"
+    "npm": ">=5.6.0 <7.0.0"
   },
   "engine-strict": true,
   "bin": {


### PR DESCRIPTION
This PR does explicitly set npm engine compatibility to be strictly < v7
This should be hopefully be enough to prevent renovatebot to try to upgrade our lockfile to `lockfileVersion: 2`, as it seems to result in a lockfile incompatible with npm v6 and as a side effect it does make all recent CI jobs related to renovatebot PR to fail on the `npm ci` step (as described in https://github.com/mozilla/web-ext/pull/2142#issuecomment-772584368).

I double-checked locally that even if the npm engine required has to be strictly < v7, `npx npm@7 ci` is still completing successfully with the `lockfileVersion: 1` (and just printing a warning to mention that the npm version being used is not officially compatible with the web-ext package).

Unfortunately we can only be 100% sure that this change is going to be enough to force renovatebot to don't upgrade the lockfile in its PRs only after we have merged this PR and then asked renovatebot to rebase its own PR on top of this change.

Fixes #2145.