### PR TITLE
docs: Added alias for watch-file option and updated option description

### DIFF
--- a/src/program.js
+++ b/src/program.js
@@ -617,9 +617,12 @@ Example: $0 --help run.
         type: 'boolean',
       },
       'watch-file': {
-        describe: 'Reload the extension only when the contents of this' +
-                  ' file changes. This is useful if you use a custom' +
-                  ' build process for your extension',
+        alias: ['watch-files'],
+        describe: 'Reload the extension only when the content of these' +
+                  ' files change. This is useful if you use a custom' +
+                  ' build process for your extension or if you want web-ext' +
+                  ' to explicitly watch for changes to specific files,' +
+                  ' without watching the extension directory tree\n',
         demandOption: false,
         type: 'array',
       },


### PR DESCRIPTION
Added alias for watch-file option and updated option description to reflect recent changes to the option

Continuation of #2125. Opening this PR in response to the discussion in [extension-workshop PR #950 C3](https://github.com/mozilla/extension-workshop/pull/910#issuecomment-776797076)

@rpl Are there any tests to check if the alias does work as expected?