### PR TITLE
fix: Bump minimum nodejs version supported to v12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,10 @@ references:
   # The nodejs version set as `nodejs_current` is the one used to
   # release the package on npm.
   nodejs_versions:
-    - &nodejs_current "10"
-    - &nodejs_next "12"
-    - &nodejs_experimental "14"
+    - &nodejs_current "12"
+    - &nodejs_next "14"
+    ## TODO: replace this with 16 as soon as it becomes available
+    - &nodejs_experimental "15"
 
   nodejs_enum: &nodejs_enum
     type: enum

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "index.mjs"
   ],
   "engines": {
-    "node": ">=10.0.0",
+    "node": ">=12.0.0",
     "npm": ">=5.6.0 <7.0.0"
   },
   "engine-strict": true,


### PR DESCRIPTION
This PR does bump the minimum nodejs version supported to v12 (would likely still work for now on nodejs v10 but it will print a warning when installed from npm, with yarn the user will have to explicitly pass the yarn CLI option to ask yarn to allow installing the package without enforcing the mininum nodejs version).

Along with bumping the minimum supported version, it does also add nodejs v15 to the nodejs versions we do run as part of the CI jobs (which is meant to be replaced with nodejs 16 once it will be released).