### PR TITLE
docs: fix URL for good first bug label

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ development more awesome by contributing to the `web-ext` tool. Here are links t
 
 If you're looking for a small task to work on so you can get familiar with the
 process of contributing patches, have a read through these
-[good first bugs](https://github.com/mozilla/web-ext/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+bug%22).
+[good first bugs](https://github.com/mozilla/web-ext/issues?q=is%3Aissue+is%3Aopen+label%3A%22contrib%3A+good+first+bug%22).
 
 If you'd like to work on a bug, please comment on it to let the maintainers know. If someone else has already commented and taken up that bug, please refrain from working on it and submitting a PR without asking the maintainers as it leads to unnecessary duplication of effort.
 


### PR DESCRIPTION
The contributor docs contain a link to issues with a `good first bug` label that no longer exists. This PR fixes the URL to point to the updated label `contrib: good first bug`.