### PR TITLE
fix: Support Android 11

### DIFF
--- a/src/util/adb.js
+++ b/src/util/adb.js
@@ -11,7 +11,7 @@ import packageIdentifiers, {
   defaultApkComponents,
 } from '../firefox/package-identifiers';
 
-export const DEVICE_DIR_BASE = '/sdcard/';
+export const DEVICE_DIR_BASE = '/data/local/tmp/';
 export const ARTIFACTS_DIR_PREFIX = 'web-ext-artifacts-';
 
 const log = createLogger(__filename);

--- a/tests/unit/test-extension-runners/test.firefox-android.js
+++ b/tests/unit/test-extension-runners/test.firefox-android.js
@@ -361,7 +361,7 @@ describe('util/extension-runners/firefox-android', () => {
     it('does check for existing artifacts dirs', async () => {
       const adbOverrides = {
         getOrCreateArtifactsDir: sinon.spy(
-          () => Promise.resolve('/sdcard/web-ext-dir')
+          () => Promise.resolve('/data/local/tmp/web-ext-dir')
         ),
         detectOrRemoveOldArtifacts: sinon.spy(() => Promise.resolve(false)),
       };
@@ -402,7 +402,7 @@ describe('util/extension-runners/firefox-android', () => {
     it('does optionally remove older artifacts dirs', async () => {
       const adbOverrides = {
         getOrCreateArtifactsDir: sinon.spy(
-          () => Promise.resolve('/sdcard/web-ext-dir')
+          () => Promise.resolve('/data/local/tmp/web-ext-dir')
         ),
         detectOrRemoveOldArtifacts: sinon.spy(() => Promise.resolve(true)),
       };

--- a/tests/unit/test-util/test.adb.js
+++ b/tests/unit/test-util/test.adb.js
@@ -533,7 +533,7 @@ describe('utils/adb', () => {
 
       const result = await assert.isFulfilled(promise);
 
-      assert.match(result, /^\/sdcard\/web-ext-artifacts-/);
+      assert.match(result, /^\/data\/local\/tmp\/web-ext-artifacts-/);
 
       sinon.assert.calledTwice(adb.fakeADBClient.shell);
       sinon.assert.calledWithMatch(
@@ -557,7 +557,8 @@ describe('utils/adb', () => {
          const adbUtils = new ADBUtils({adb});
 
          // Add an artifact dir to the adbUtils internal map.
-         const fakeArtifactsDir = '/sdcard/web-ext-artifacts-already-created';
+         const fakeArtifactsDir =
+           '/data/local/tmp/web-ext-artifacts-already-created';
          adbUtils.artifactsDirMap.set('device1', fakeArtifactsDir);
 
          const promise = adbUtils.getOrCreateArtifactsDir('device1');
@@ -577,7 +578,7 @@ describe('utils/adb', () => {
         },
         testFn: (adbUtils) => {
           adbUtils.artifactsDirMap.set(
-            'device1', '/sdcard/webext-artifacts-fake'
+            'device1', '/data/local/tmp/webext-artifacts-fake'
           );
           return adbUtils.clearArtifactsDir('device1');
         },
@@ -586,7 +587,7 @@ describe('utils/adb', () => {
       sinon.assert.calledOnce(adb.fakeADBClient.shell);
       sinon.assert.calledWithMatch(
         adb.fakeADBClient.shell, 'device1',
-        ['rm', '-rf', '/sdcard/webext-artifacts-fake']
+        ['rm', '-rf', '/data/local/tmp/webext-artifacts-fake']
       );
     });
 
@@ -601,7 +602,10 @@ describe('utils/adb', () => {
       });
       const adbUtils = new ADBUtils({adb});
 
-      adbUtils.artifactsDirMap.set('device1', '/sdcard/webext-artifacts-fake');
+      adbUtils.artifactsDirMap.set(
+        'device1',
+        '/data/local/tmp/webext-artifacts-fake'
+      );
       const promise = adbUtils.clearArtifactsDir('device1');
 
       await assert.isFulfilled(promise);
@@ -609,7 +613,7 @@ describe('utils/adb', () => {
       sinon.assert.calledOnce(adb.fakeADBClient.shell);
       sinon.assert.calledWithMatch(
         adb.fakeADBClient.shell, 'device1',
-        ['rm', '-rf', '/sdcard/webext-artifacts-fake']
+        ['rm', '-rf', '/data/local/tmp/webext-artifacts-fake']
       );
     });
 


### PR DESCRIPTION
This fixes #2173.

On Android 11, Fenix is no longer requesting access to the entire `/sdcard/` and uses more fine grained permissions now. web-ext was still assuming it did have permission.

To fix this, we use another directory, `/data/local/tmp/` that we do have access to. I think this directory is used by Android Studio and the rest of the official Android toolchain.

# Before

```
$ web-ext run -t firefox-android --android-device=192.168.3.70:5555 --firefox-apk org.mozilla.fenix
Running web extension from /home/home/WebstormProjects/darkreader/debug-firefox
Selected ADB device: 192.168.3.70:5555
Stopping existing instances of org.mozilla.fenix...
Old artifacts directories have been found on 192.168.3.70:5555 device. Use --adb-remove-old-artifacts to remove them automatically.
Starting org.mozilla.fenix...
Waiting for org.mozilla.fenix Remote Debugging Server...
Make sure to enable "Remote Debugging via USB" from Settings -> Developer Tools if it is not yet enabled.
Building web extension from /home/home/WebstormProjects/darkreader/debug-firefox
Waiting for org.mozilla.fenix Remote Debugging Server...
Make sure to enable "Remote Debugging via USB" from Settings -> Developer Tools if it is not yet enabled.
You can connect to this Android device on TCP port 44615

o: installTemporaryAddon: Error: Error: Could not install add-on at '/sdcard/web-ext-artifacts-1615624272033/dark_reader-4.9.29.xpi': [Exception... "Component returned failure code: 0x80520015 (NS_ERROR_FILE_ACCESS_DENIED) [nsIZipReader.open]"  nsresult: "0x80520015 (NS_ERROR_FILE_ACCESS_DENIED)"  location: "JS frame :: resource://gre/modules/addons/XPIInstall.jsm :: XPIPackage :: line 321"  data: no]
    at b.installTemporaryAddon (/home/home/.nvm/versions/node/v15.10.0/lib/node_modules/web-ext/dist/web-ext.js:1:43043)
    at processTicksAndRejections (node:internal/process/task_queues:94:5)
    at w.rdpInstallExtensions (/home/home/.nvm/versions/node/v15.10.0/lib/node_modules/web-ext/dist/web-ext.js:1:27002)
    at w.run (/home/home/.nvm/versions/node/v15.10.0/lib/node_modules/web-ext/dist/web-ext.js:1:20597)
    at async Promise.all (index 0)
    at x.run (/home/home/.nvm/versions/node/v15.10.0/lib/node_modules/web-ext/dist/web-ext.js:1:5299)
    at $ (/home/home/.nvm/versions/node/v15.10.0/lib/node_modules/web-ext/dist/web-ext.js:1:10137)
    at O.execute (/home/home/.nvm/versions/node/v15.10.0/lib/node_modules/web-ext/dist/web-ext.js:1:64433)
```

# After

```
$ web-ext run -t firefox-android --android-device=192.168.3.70:5555 --firefox-apk org.mozilla.fenix
Running web extension from /home/home/WebstormProjects/darkreader/debug-firefox
Selected ADB device: 192.168.3.70:5555
Stopping existing instances of org.mozilla.fenix...
Starting org.mozilla.fenix...
Waiting for org.mozilla.fenix Remote Debugging Server...
Make sure to enable "Remote Debugging via USB" from Settings -> Developer Tools if it is not yet enabled.
Building web extension from /home/home/WebstormProjects/darkreader/debug-firefox
Waiting for org.mozilla.fenix Remote Debugging Server...
Make sure to enable "Remote Debugging via USB" from Settings -> Developer Tools if it is not yet enabled.
You can connect to this Android device on TCP port 36069
Installed /data/local/tmp/web-ext-artifacts-1615624405277/dark_reader-4.9.29.xpi as a temporary add-on
The extension will reload if any source file changes
Press R to reload (and Ctrl-C to quit)
```

# Test environment

Tested on a OnePlus 7 Pro running `OP7Pro_O2_BETA_3` with Fenix `210310 17:03`.

Tested the following:
- `npm test`
- Installing an extension and running it
- CTRL-C while it's running
- Deleting the temporary folder in `/data/local/tmp/`, force quitting the app, and relaunching it