### PR TITLE
chore: Increased test-functional mocha timeout to reduce test.lib.imports.js intermittency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ commands:
         # Custom mocha timeout to reduce intermittent failures triggered
         # by one of the functional tests (triggered by the before all hook
         # of the test.lib.imports.js).
-        default: 20000
+        default: 30000
     steps:
       ## NOTE: by setting the configured python to /bin/false we are forcing
       ## the production mode tests to fail if any of the dependencies is a


### PR DESCRIPTION
test.lib.imports.js is failing intermittently with a slightly higher intermittency, likely due to the fact that we do run (on purpose) npm ci using the last npm version (since #2146) but the test function are using the npm version installed by default along with the nodejs version being tested.