### PR TITLE
fix: Fenix does not require WRITE_EXTERNAL_STORAGE permission to be granted

### DIFF
--- a/src/extension-runners/firefox-android.js
+++ b/src/extension-runners/firefox-android.js
@@ -411,12 +411,10 @@ export class FirefoxAndroidExtensionRunner {
     log.debug('Checking read/write permissions needed for web-ext' +
               `on ${selectedFirefoxApk}...`);
 
-    // Runtime permission needed to be able to run Firefox on a temporarily created profile
-    // on android versions >= 23 (Android Marshmallow, which is the first version where
-    // these permissions are optional and have to be granted explicitly).
+    // Runtime permissions needed to Firefox to be able to access the
+    // xpi file uploaded to the android device or emulator.
     const requiredPermissions = [
       'android.permission.READ_EXTERNAL_STORAGE',
-      'android.permission.WRITE_EXTERNAL_STORAGE',
     ];
 
     await adbUtils.ensureRequiredAPKRuntimePermissions(

--- a/tests/unit/test-extension-runners/test.firefox-android.js
+++ b/tests/unit/test-extension-runners/test.firefox-android.js
@@ -959,13 +959,12 @@ describe('util/extension-runners/firefox-android', () => {
              fakeADBUtils.ensureRequiredAPKRuntimePermissions,
              'emulator-1', 'org.mozilla.firefox', [
                'android.permission.READ_EXTERNAL_STORAGE',
-               'android.permission.WRITE_EXTERNAL_STORAGE',
              ]
            );
 
            sinon.assert.callOrder(
              fakeADBUtils.getAndroidVersionNumber,
-             fakeADBUtils.ensureRequiredAPKRuntimePermissions
+             fakeADBUtils.ensureRequiredAPKRuntimePermissions,
            );
          }
 


### PR DESCRIPTION
Fixes #2304

For Fenix we don't need the WRITE_EXTERNAL_STORAGE permission to be granted:
- it was required for Fennec because `web-ext run` was also running it in a separate temporary profile as we do on desktop
- but Fennec doesn't support that and so the WRITE_EXTERNAL_STORAGE permission isn't really necessary
- We still need the READ_EXTERNAL_STORAGE permission to have been granted, to allow Fennec to load the xpi file that `web-ext run` uploads to the android emulator or device

TODO:
- [x] confirm with Rob that we are both ok with the strategy drafted in this PR (or agree on an alternative one)
- [x] ~~add a more specific test case for the behavior expected~~
- [x] test on an android 11 emulator or device and a recent Fenix and GeckoViewExample builds     