### PR TITLE
feat: Wrap web-ext usage output at terminal width

### DIFF
--- a/src/program.js
+++ b/src/program.js
@@ -89,6 +89,7 @@ export class Program {
       'boolean-negation': true,
     });
     this.yargs.strict();
+    this.yargs.wrap(this.yargs.terminalWidth());
 
     this.commands = {};
     this.options = {};


### PR DESCRIPTION
- Detects the terminal width (in characters) using `yargs.terminalWidth()`.
- Sets the generated `yargs` usage to wrap at the terminal width instead of at the default (maximum) 80 characters.
- Should improve `web-ext` readability by utilizing the full terminal window, when it is greater than 80 characters wide.
- In particular, `--help` output is improved.
- Testing would require a TTY emulator. Tests were added and removed due to build system tooling issues.

See

- https://yargs.js.org/docs/#api-reference-wrapcolumns


<details>

<summary>Before: (maximum) 80 characters wide</summary>

```text
Usage: web-ext [options] command

Option values can also be set by declaring an environment variable prefixed
with $WEB_EXT_. For example: $WEB_EXT_SOURCE_DIR=/path is the same as
--source-dir=/path.

To view specific help for any given command, add the command name.
Example: web-ext --help run.


Commands:
  web-ext build  Create an extension package from source
  web-ext sign   Sign the extension so it can be installed in Firefox
  web-ext run    Run the extension
  web-ext lint   Validate the extension source
  web-ext docs   Open the web-ext documentation in a browser

Options:
      --version           Show version number                          [boolean]
  -s, --source-dir        Web extension source directory.
                                [string] [required] [default: "/home/joelpurra"]
  -a, --artifacts-dir     Directory where artifacts will be saved.
              [string] [required] [default: "/home/joelpurra/web-ext-artifacts"]
  -v, --verbose           Show verbose output                          [boolean]
  -i, --ignore-files      A list of glob patterns to define which files should
                          be ignored. (Example: --ignore-files=path/to/first.js
                          path/to/second.js "**/*.log")                  [array]
      --no-input          Disable all features that require standard input
                                                                       [boolean]
  -c, --config            Path to a CommonJS config file to set option defaults
                                                                        [string]
      --config-discovery  Discover config files in home directory and working
                          directory. Disable with --no-config-discovery.
                                                       [boolean] [default: true]
  -h, --help              Show help                                    [boolean]

You must specify a command
```

</details>

<details>

<summary>After: 120 characters wide (example, autodetected)</summary>

```text
Usage: web-ext [options] command

Option values can also be set by declaring an environment variable prefixed
with $WEB_EXT_. For example: $WEB_EXT_SOURCE_DIR=/path is the same as
--source-dir=/path.

To view specific help for any given command, add the command name.
Example: web-ext --help run.


Commands:
  web-ext build  Create an extension package from source
  web-ext sign   Sign the extension so it can be installed in Firefox
  web-ext run    Run the extension
  web-ext lint   Validate the extension source
  web-ext docs   Open the web-ext documentation in a browser

Options:
      --version           Show version number                                                                  [boolean]
  -s, --source-dir        Web extension source directory.               [string] [required] [default: "/home/joelpurra"]
  -a, --artifacts-dir     Directory where artifacts will be saved.
                                                      [string] [required] [default: "/home/joelpurra/web-ext-artifacts"]
  -v, --verbose           Show verbose output                                                                  [boolean]
  -i, --ignore-files      A list of glob patterns to define which files should be ignored. (Example:
                          --ignore-files=path/to/first.js path/to/second.js "**/*.log")                          [array]
      --no-input          Disable all features that require standard input                                     [boolean]
  -c, --config            Path to a CommonJS config file to set option defaults                                 [string]
      --config-discovery  Discover config files in home directory and working directory. Disable with
                          --no-config-discovery.                                               [boolean] [default: true]
  -h, --help              Show help                                                                            [boolean]

You must specify a command
```

</details>