### PR TITLE
fix(deps): fixed yargs import for yarn 3.x + pnp

### DIFF
--- a/src/program.js
+++ b/src/program.js
@@ -6,9 +6,7 @@ import {readFileSync} from 'fs';
 import camelCase from 'camelcase';
 import decamelize from 'decamelize';
 import yargs from 'yargs';
-// TODO(rpl): try to remove the following suppress comment after updating flow to more recent versions.
-// $FlowFixMe: flow doesn't seem to read yet the `exports` property from the yargs package.json.
-import { Parser as yargsParser } from 'yargs/yargs';
+import { Parser as yargsParser } from 'yargs/helpers';
 
 import defaultCommands from './cmd';
 import {UsageError} from './errors';


### PR DESCRIPTION
fixes #2332 , process of arriving at this change documented there

I did not make this change out of some sort of expertise in js dependency loading mechanisms, but by trial and error and eliminating the odd one out. I did however test this change in my personal project by modifying the downloaded npm artifact's code in the same way, and I ran `npm test` in this repo after this change too. If I understand [the author's comment](https://github.com/yargs/yargs/blob/main/yargs#L1) right, this change can't be harmful.

I'm willing to put in more time to work with you on proving this change fixes something, but please reach out with instructions then. I'll give you a live demo via a discord call if you want, or a repo to reproduce it on (which is already linked in the issue).