### PR TITLE
chore: update npm audit ignore list

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -2,6 +2,8 @@
   "exceptions": [
     // ansi-regex advisory (transitive dependency introduced by update-notifier and
     // nyc).
-    "https://github.com/advisories/GHSA-93q8-gq69-wqmw"
+    "https://github.com/advisories/GHSA-93q8-gq69-wqmw",
+    // json-schema advisory (transitive dependency introduced by sign-addon).
+    "https://github.com/advisories/GHSA-896r-f27r-55mw"
   ]
 }

--- a/.nsprc
+++ b/.nsprc
@@ -2,8 +2,6 @@
   "exceptions": [
     // ansi-regex advisory (transitive dependency introduced by update-notifier and
     // nyc).
-    "https://github.com/advisories/GHSA-93q8-gq69-wqmw",
-    // trim-off-newlines (transitive dependency introduced by @commitlint/cli)
-    "https://github.com/advisories/GHSA-38fc-wpqx-33j7"
+    "https://github.com/advisories/GHSA-93q8-gq69-wqmw"
   ]
 }


### PR DESCRIPTION
All CI jobs are currently failing on the "npm audit" step, due to a json-schema advisory introduced by `request` npm package through transitive dependencies originated by:
- addons-linter 3.23.0 through dispensary (which is actually already fixed in addons-linter >= 4.1.0 where the dispensary dependency has been merged into addons-linter project and `request` npm package replaced by `node-fetch`) 
- sign-addon (which does currently use `request` as one of its direct dependencies) 

This PR includes the following changes:
- Removed from audit ignore list old trim-off-newlines advisories.
- Added json-schema advisory to npm audit ignore list

This PR is mainly meant to allow us to unblock the CI jobs in the short run (and in particular to allow #2350 to pass all CI jobs and get rid of one of the two dependencies that are currently introducing a transitive dependency for the `request` package), but we also follow up to remove from the ignore list at least the advisories that are related to non-"dev-only" dependencies:
- https://github.com/mozilla/web-ext/issues/2358

