### PR TITLE
fix: Set default adb host to 127.0.0.1 to prevent localhost resolution mismatch in nodejs 17

### DIFF
--- a/src/extension-runners/firefox-android.js
+++ b/src/extension-runners/firefox-android.js
@@ -51,6 +51,12 @@ const ignoredParams = {
   args: '--args',
 };
 
+// Default adbHost to 127.0.0.1 to prevent issues with nodejs 17
+// (because if not specified adbkit may default to ipv6 while
+// adb may still only be listening on the ipv4 address),
+// see https://github.com/mozilla/web-ext/issues/2337.
+const DEFAULT_ADB_HOST = '127.0.0.1';
+
 const getIgnoredParamsWarningsMessage = (optionName) => {
   return `The Firefox for Android target does not support ${optionName}`;
 };
@@ -120,7 +126,7 @@ export class FirefoxAndroidExtensionRunner {
   async run(): Promise<void> {
     const {
       adbBin,
-      adbHost,
+      adbHost = DEFAULT_ADB_HOST,
       adbPort,
       ADBUtils = DefaultADBUtils,
     } = this.params;


### PR DESCRIPTION
Small tweak to cover the "firefox-android extension runner" part of #2337 (similarly to how #2339 covers the web-ext side of the issue with the chromium extension runner issue on nodejs 17).