### PR TITLE
chore: Remove json-schema from .nsprc ignore list

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -2,8 +2,6 @@
   "exceptions": [
     // ansi-regex advisory (transitive dependency introduced by update-notifier and
     // nyc).
-    "https://github.com/advisories/GHSA-93q8-gq69-wqmw",
-    // json-schema advisory (transitive dependency introduced by sign-addon).
-    "https://github.com/advisories/GHSA-896r-f27r-55mw"
+    "https://github.com/advisories/GHSA-93q8-gq69-wqmw"
   ]
 }


### PR DESCRIPTION
Fixes #2358 (the json-schema transitive dependency has been updated to a non affected one by #2361).