### PR TITLE
fix: Improved debounce to prevent multiple extension reloads on consecutive file changes

### DIFF
--- a/src/watcher.js
+++ b/src/watcher.js
@@ -36,7 +36,7 @@ export default function onSourceChange(
     artifactsDir,
     onChange,
     shouldWatchFile,
-    debounceTime = 1000,
+    debounceTime = 500,
   }: OnSourceChangeParams
 ): Watchpack {
   // When running on Windows, transform the ignored paths and globs
@@ -51,7 +51,8 @@ export default function onSourceChange(
     new Watchpack({ignored}) :
     new Watchpack();
 
-  const executeImmediately = true;
+  // Allow multiple files to be changed before reloading the extension
+  const executeImmediately = false;
   onChange = debounce(onChange, debounceTime, executeImmediately);
 
   watcher.on('change', (filePath) => {

--- a/tests/unit/test.watcher.js
+++ b/tests/unit/test.watcher.js
@@ -93,6 +93,7 @@ describe('watcher', () => {
   );
 
   it('watches for changes in the sourceDir', async () => {
+    const defaultDebounce = 500;
     const {
       onChange,
       watchedFilePath,
@@ -101,6 +102,8 @@ describe('watcher', () => {
     } = await watchChange({
       touchedFile: 'foo.txt',
     });
+
+    await new Promise((resolve) => setTimeout(resolve, defaultDebounce + 50));
 
     sinon.assert.calledOnce(onChange);
     assert.equal(watchedDirPath, tmpDirPath);


### PR DESCRIPTION
Fixes #2249 

This is a rebase of #2259, with the same author metadata and no actual changes (the patch does still apply cleanly as is).