### PR TITLE
chore(test): Fixed missing coverage data

### DIFF
--- a/scripts/lib/mocha.js
+++ b/scripts/lib/mocha.js
@@ -26,6 +26,13 @@ const runMocha = (args, execMochaOptions = {}, coverageEnabled) => {
 
   const res = spawnSync(binPath, binArgs, {
     ...execMochaOptions,
+    env: {
+      ...process.env,
+      // Make sure NODE_ENV is set to test (which also enable babel
+      // install plugin for all modules transpiled on the fly by the
+      // tests/babel-loader.js).
+      NODE_ENV: 'test',
+    },
     stdio: 'inherit',
   });
 


### PR DESCRIPTION
this PR fixes the missing code coverage data (which was due to babel istanbul plugin not being activated through NODE_ENV env variable set to 'test').