### PR TITLE
feat: introduce a --firefox-preview flag for 'web-ext run'

### DIFF
--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -43,6 +43,7 @@ export type CmdRunParams = {|
   startUrl?: Array<string>,
   target?: Array<string>,
   args?: Array<string>,
+  firefoxPreview: Array<string>,
 
   // Android CLI options.
   adbBin?: string,
@@ -89,6 +90,7 @@ export default async function run(
     startUrl,
     target,
     args,
+    firefoxPreview = [],
     // Android CLI options.
     adbBin,
     adbHost,
@@ -126,7 +128,12 @@ export default async function run(
 
   // Create an alias for --pref since it has been transformed into an
   // object containing one or more preferences.
-  const customPrefs = pref;
+  const customPrefs: FirefoxPreferences = {...pref};
+  if (firefoxPreview.includes('mv3')) {
+    log.info('Configuring Firefox preferences for Manifest V3');
+    customPrefs['extensions.manifestV3.enabled'] = true;
+  }
+
   const manifestData = await getValidatedManifest(sourceDir);
 
   const profileDir = firefoxProfile || chromiumProfile;

--- a/src/program.js
+++ b/src/program.js
@@ -691,6 +691,12 @@ Example: $0 --help run.
         demandOption: false,
         type: 'array',
       },
+      'firefox-preview': {
+        describe: 'Turn on developer preview features in Firefox',
+        demandOption: false,
+        default: ['mv3'],
+        type: 'array',
+      },
       // Firefox for Android CLI options.
       'adb-bin': {
         describe: 'Specify a custom path to the adb binary',

--- a/tests/unit/test-cmd/test.run.js
+++ b/tests/unit/test-cmd/test.run.js
@@ -454,4 +454,22 @@ describe('run', () => {
          );
        });
   });
+
+  describe('firefox-preview', () => {
+    it('supports the MV3 preview', async () => {
+      const cmd = await prepareRun();
+      const runOptions = {
+        firefoxPreview: ['mv3'],
+      };
+
+      await cmd.run(runOptions);
+
+      sinon.assert.calledOnce(desktopRunnerStub);
+      const runnerParams = desktopRunnerStub.firstCall.args[0];
+
+      assert.deepEqual(runnerParams.customPrefs, {
+        'extensions.manifestV3.enabled': true,
+      });
+    });
+  });
 });

--- a/tests/unit/test.program.js
+++ b/tests/unit/test.program.js
@@ -912,6 +912,16 @@ describe('program.main', () => {
     }
   });
 
+  it('sets the default firefox preview to "mv3"', async () => {
+    const fakeCommands = fake(commands, {
+      run: () => Promise.resolve(),
+    });
+
+    await execProgram(['run', '--firefox-preview'], {commands: fakeCommands});
+
+    const {firefoxPreview} = fakeCommands.run.firstCall.args[0];
+    assert.deepEqual(firefoxPreview, ['mv3']);
+  });
 });
 
 describe('program.defaultVersionGetter', () => {


### PR DESCRIPTION
This flag allows to enable the [Firefox Dev Preview for Manifest V3][get-involved] (at the moment, given that was my main use case). I've been light on testing but it covers enough. I don't think we need to be super fancy right now (personally).

[get-involved]: https://blog.mozilla.org/addons/2022/06/08/manifest-v3-firefox-developer-preview-how-to-get-involved/