### PR TITLE
chore: Disabled commitlint rule body-max-line-length

### DIFF
--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -5,6 +5,7 @@ module.exports = {
     "footer-leading-blank": [0, "never"],
     "header-max-length": [1, "always", 72],
     "subject-case": [0, "never"],
-    "subject-full-stop": [0, "never"]
+    "subject-full-stop": [0, "never"],
+    "body-max-line-length": [0, "never"]
   }
 }


### PR DESCRIPTION
I don't  recall to have hit this commitlint requirement before, and so I'm not sure if it has been added in a recent commitlint version and we didn't notice it, anyway we recently hit this in #2436 and it feels unnecessary for what we actually use commitlint for, and so this PR is disabling it.