### PR TITLE
fix: firefoxPreview option should be set to mv3 only when explicitly requested

### DIFF
--- a/src/program.js
+++ b/src/program.js
@@ -221,6 +221,10 @@ export class Program {
       throw new UsageError('Not enough arguments following: start-url');
     }
 
+    if (Array.isArray(argv.firefoxPreview) && !argv.firefoxPreview.length) {
+      argv.firefoxPreview = ['mv3'];
+    }
+
     return argv;
   }
 
@@ -692,9 +696,9 @@ Example: $0 --help run.
         type: 'array',
       },
       'firefox-preview': {
-        describe: 'Turn on developer preview features in Firefox',
+        describe: 'Turn on developer preview features in Firefox' +
+          ' (defaults to "mv3")',
         demandOption: false,
-        default: ['mv3'],
         type: 'array',
       },
       // Firefox for Android CLI options.

--- a/tests/unit/test.program.js
+++ b/tests/unit/test.program.js
@@ -922,6 +922,18 @@ describe('program.main', () => {
     const {firefoxPreview} = fakeCommands.run.firstCall.args[0];
     assert.deepEqual(firefoxPreview, ['mv3']);
   });
+
+  it('does not set any firefox preview prefs by default', async () => {
+    const fakeCommands = fake(commands, {
+      run: () => Promise.resolve(),
+    });
+
+    await execProgram(['run'], {commands: fakeCommands});
+
+    const {firefoxPreview} = fakeCommands.run.firstCall.args[0];
+    assert.deepEqual(firefoxPreview, undefined);
+  });
+
 });
 
 describe('program.defaultVersionGetter', () => {


### PR DESCRIPTION
The --firefox-preview web-ext option we introduced in v7.1.0 should not default to mv3 if it wasn't explicitly passed as an option (either on the command line or through the web-ext config file).

Unfortunately setting a default value through the yargs `default` property will always set `argv.firefoxPreview` to `['mv3']` even when it is not explicitly passed, `demandOptions` set to `false` makes the cli option not mandatory but it doesn't ignore the default value.

This PR adds an additional test case to make sure that `argv.firefoxPreview` is `undefined` when not explicitly passed as an option, and a small tweak to program.js that make sure `argv.firefoxPreview` defaults to `['mv3']` if it was set to an empty array (and so when `--firefox-preview` was explicitly passed but without any value specified explicitly).