### PR TITLE
feat: Add `--firefox-preview` option to the `lint` command

### DIFF
--- a/src/program.js
+++ b/src/program.js
@@ -425,6 +425,15 @@ export async function main(
   const program = new Program(argv, {absolutePackageDir});
   const version = await getVersion(absolutePackageDir);
 
+  // This is an option shared by some commands but not all of them, hence why
+  // it isn't a global option.
+  const firefoxPreviewOption = {
+    describe: 'Turn on developer preview features in Firefox' +
+    ' (defaults to "mv3")',
+    demandOption: false,
+    type: 'array',
+  };
+
   // yargs uses magic camel case expansion to expose options on the
   // final argv object. For example, the 'artifacts-dir' option is alternatively
   // available as argv.artifactsDir.
@@ -709,12 +718,7 @@ Example: $0 --help run.
         demandOption: false,
         type: 'array',
       },
-      'firefox-preview': {
-        describe: 'Turn on developer preview features in Firefox' +
-          ' (defaults to "mv3")',
-        demandOption: false,
-        type: 'array',
-      },
+      'firefox-preview': firefoxPreviewOption,
       // Firefox for Android CLI options.
       'adb-bin': {
         describe: 'Specify a custom path to the adb binary',
@@ -810,6 +814,7 @@ Example: $0 --help run.
         type: 'boolean',
         default: false,
       },
+      'firefox-preview': firefoxPreviewOption,
     })
     .command('docs', 'Open the web-ext documentation in a browser',
              commands.docs, {});

--- a/tests/unit/test-cmd/test.lint.js
+++ b/tests/unit/test-cmd/test.lint.js
@@ -143,6 +143,8 @@ describe('lint', () => {
           output: 'json',
           boring: true,
           selfHosted: true,
+          minManifestVersion: 2,
+          maxManifestVersion: 2,
         },
       });
     });
@@ -167,4 +169,18 @@ describe('lint', () => {
     });
   });
 
+  describe('firefox-preview', () => {
+    it('enables MV3 support in addons-linter', async () => {
+      const {lint, createLinter} = setUp();
+
+      await lint({firefoxPreview: ['mv3']});
+
+      sinon.assert.calledWithMatch(createLinter, {
+        config: {
+          minManifestVersion: 2,
+          maxManifestVersion: 3,
+        },
+      });
+    });
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/mozilla/web-ext/issues/2484

---

This option (which defaults to 'mv3') will configure addons-linter to
lint MV2 and MV3 extensions when specified.