### PR TITLE
Rename apiHost to amoBaseUrl

### DIFF
--- a/src/cmd/sign.js
+++ b/src/cmd/sign.js
@@ -26,7 +26,7 @@ export const extensionIdFile = '.web-extension-id';
 // Sign command types and implementation.
 
 export type SignParams = {|
-  apiHost: string,
+  amoBaseUrl: string,
   apiKey: string,
   apiProxy?: string,
   apiSecret: string,
@@ -51,7 +51,7 @@ export type SignOptions = {
 
 export default function sign(
   {
-    apiHost,
+    amoBaseUrl,
     apiKey,
     apiProxy,
     apiSecret,
@@ -142,13 +142,6 @@ export default function sign(
         );
       }
 
-      try {
-        const apiHostURL = new URL(apiHost);
-        apiHost = apiHostURL.origin;
-      } catch (err) {
-        throw new UsageError(`Invalid apiHost: ${apiHost}`);
-      }
-
       const signSubmitArgs = {
         apiKey,
         apiSecret,
@@ -163,7 +156,7 @@ export default function sign(
       try {
         if (useSubmissionApi) {
           // $FlowIgnore: we verify 'channel' is set above
-          result = await submitAddon({...signSubmitArgs, apiHost, channel});
+          result = await submitAddon({...signSubmitArgs, amoBaseUrl, channel});
         } else {
           const { success, id: newId, downloadedFiles } = await signAddon({
             ...signSubmitArgs,

--- a/src/program.js
+++ b/src/program.js
@@ -543,9 +543,10 @@ Example: $0 --help run.
       'sign',
       'Sign the extension so it can be installed in Firefox',
       commands.sign, {
-        'api-host': {
-          describe: 'Signing API host - only used with `use-submission-api`',
-          default: 'https://addons.mozilla.org',
+        'amo-base-url': {
+          describe:
+            'Signing API URL prefix - only used with `use-submission-api`',
+          default: 'https://addons.mozilla.org/api/v5',
           demandOption: true,
           type: 'string',
         },

--- a/src/util/submit-addon.js
+++ b/src/util/submit-addon.js
@@ -54,7 +54,7 @@ export class JwtApiAuth {
 
 type ClientConstructorParams = {|
   apiAuth: ApiAuth,
-  apiHost: string,
+  baseUrl: URL,
   validationCheckInterval?: number,
   validationCheckTimeout?: number,
   approvalCheckInterval?: number,
@@ -73,7 +73,7 @@ export default class Client {
 
   constructor({
     apiAuth,
-    apiHost,
+    baseUrl,
     validationCheckInterval = 1000,
     validationCheckTimeout = 300000, // 5 minutes.
     approvalCheckInterval = 1000,
@@ -81,7 +81,7 @@ export default class Client {
     downloadDir = process.cwd(),
   }: ClientConstructorParams) {
     this.apiAuth = apiAuth;
-    this.apiUrl = new URL('/api/v5/addons/', apiHost);
+    this.apiUrl = new URL('/addons/', baseUrl);
     this.validationCheckInterval = validationCheckInterval;
     this.validationCheckTimeout = validationCheckTimeout;
     this.approvalCheckInterval = approvalCheckInterval;
@@ -322,7 +322,7 @@ export default class Client {
 type signAddonParams = {|
   apiKey: string,
   apiSecret: string,
-  apiHost: string,
+  amoBaseUrl: string,
   timeout: number,
   id?: string,
   xpiPath: string,
@@ -335,7 +335,7 @@ type signAddonParams = {|
 export async function signAddon({
   apiKey,
   apiSecret,
-  apiHost,
+  amoBaseUrl,
   timeout,
   id,
   xpiPath,
@@ -354,9 +354,16 @@ export async function signAddon({
     throw new Error(`error with ${xpiPath}: ${statError}`);
   }
 
+  let baseUrl;
+  try {
+    baseUrl = new URL(amoBaseUrl);
+  } catch (err) {
+    throw new Error(`Invalid amoBaseUrl: ${amoBaseUrl}`);
+  }
+
   const client = new SubmitClient({
     apiAuth: new ApiAuthClass({ apiKey, apiSecret }),
-    apiHost,
+    baseUrl,
     validationCheckTimeout: timeout,
     approvalCheckTimeout: timeout,
     downloadDir,

--- a/src/util/submit-addon.js
+++ b/src/util/submit-addon.js
@@ -358,7 +358,7 @@ export async function signAddon({
   try {
     baseUrl = new URL(amoBaseUrl);
   } catch (err) {
-    throw new Error(`Invalid amoBaseUrl: ${amoBaseUrl}`);
+    throw new Error(`Invalid AMO API base URL: ${amoBaseUrl}`);
   }
 
   const client = new SubmitClient({

--- a/tests/unit/test-cmd/test.sign.js
+++ b/tests/unit/test-cmd/test.sign.js
@@ -26,7 +26,7 @@ describe('sign', () => {
 
   function getStubs() {
     const signingConfig = {
-      apiHost: 'http://not-the-real-amo.com',
+      amoBaseUrl: 'http://not-the-real-amo.com/api/v5',
       apiKey: 'AMO JWT issuer',
       apiSecret: 'AMO JWT secret',
       apiUrlPrefix: 'http://not-the-real-amo.com/api/v4',
@@ -126,8 +126,11 @@ describe('sign', () => {
           assert.equal(result.id, stubs.signingResult.id);
           // Do a sanity check that a built extension was passed to the
           // signer.
-          assert.include(stubs.submitAddon.firstCall.args[0].xpiPath,
-                         'minimal_extension-1.0.zip');
+          const submitAddonCall = stubs.submitAddon.firstCall.args[0];
+          assert.include(submitAddonCall.xpiPath, 'minimal_extension-1.0.zip');
+          assert.include(
+            submitAddonCall.amoBaseUrl, stubs.signingConfig.amoBaseUrl
+          );
         });
     }
   ));
@@ -147,32 +150,6 @@ describe('sign', () => {
           sinon.assert.calledWithMatch(
             stubs.signAddon,
             {id: getManifestId(manifestWithoutApps)}
-          );
-        });
-    }
-  ));
-
-  it('trims trailing "/" from apiHost', () => withTempDir(
-    (tmpDir) => {
-      const stubs = getStubs();
-      const apiHost = stubs.signingConfig.apiHost;
-      return sign(
-        tmpDir, stubs,
-        {
-          extraArgs: {
-            apiHost: `${apiHost}/`,
-            useSubmissionApi: true,
-            channel: 'unlisted',
-          },
-          extraOptions: {
-            preValidatedManifest: manifestWithoutApps,
-          },
-        })
-        .then(() => {
-          sinon.assert.called(stubs.submitAddon);
-          sinon.assert.calledWithMatch(
-            stubs.submitAddon,
-            {apiHost}
           );
         });
     }

--- a/tests/unit/test-util/test.submit-addon.js
+++ b/tests/unit/test-util/test.submit-addon.js
@@ -151,7 +151,7 @@ describe('util.submit-addon', () => {
       );
     });
 
-    it('throws error if xpiPath is invalid', async () => {
+    it('throws error if amoBaseUrl is an invalid URL', async () => {
       const amoBaseUrl = 'badUrl';
       const signAddonPromise = signAddon({...signAddonDefaults, amoBaseUrl});
       await assert.isRejected(

--- a/tests/unit/test-util/test.submit-addon.js
+++ b/tests/unit/test-util/test.submit-addon.js
@@ -70,7 +70,7 @@ describe('util.submit-addon', () => {
     const signAddonDefaults = {
       apiKey: 'some-key',
       apiSecret: 'ffff',
-      apiHost: 'https://some.url',
+      amoBaseUrl: 'https://some.url/api/v5',
       timeout: 1,
       downloadDir: '/some-dir/',
       xpiPath: '/some.xpi',
@@ -80,7 +80,8 @@ describe('util.submit-addon', () => {
     it('creates Client with parameters', async () => {
       const apiKey = 'fooKey';
       const apiSecret = '4321';
-      const apiHost = 'https://foo.host';
+      const amoBaseUrl = 'https://foo.host/api/v5';
+      const baseUrl = new URL(amoBaseUrl);
       const downloadDir = '/foo';
       const clientSpy = sinon.spy(Client);
       const apiAuthSpy = sinon.spy(JwtApiAuth);
@@ -89,7 +90,7 @@ describe('util.submit-addon', () => {
         ...signAddonDefaults,
         apiKey,
         apiSecret,
-        apiHost,
+        amoBaseUrl,
         downloadDir,
         SubmitClient: clientSpy,
         ApiAuthClass: apiAuthSpy,
@@ -106,7 +107,7 @@ describe('util.submit-addon', () => {
       assert.deepEqual(
         clientSpy.firstCall.args[0], {
           apiAuth: {},
-          apiHost,
+          baseUrl,
           validationCheckTimeout: signAddonDefaults.timeout,
           approvalCheckTimeout: signAddonDefaults.timeout,
           downloadDir,
@@ -152,16 +153,14 @@ describe('util.submit-addon', () => {
   });
 
   describe('Client', () => {
-    const apiHost = 'http://not-a-real-amo-api.com';
-    const apiPath = '/api/v5';
-    const apiHostPath = `${apiHost}${apiPath}`;
+    const baseUrl = new URL('http://not-a-real-amo-api.com/api/v5');
 
     const apiAuth = new JwtApiAuth(
       {apiKey: 'fake-api-key', apiSecret: '1234abcd'}
     );
     const clientDefaults = {
       apiAuth,
-      apiHost,
+      baseUrl,
       approvalCheckInterval: 0,
       validationCheckInterval: 0,
     };
@@ -216,7 +215,7 @@ describe('util.submit-addon', () => {
         const nodeFetchStub = sinon.stub(client, 'nodeFetch');
         mockNodeFetch(
           nodeFetchStub,
-          `${apiHostPath}/addons/upload/`,
+          new URL('/addons/upload/', baseUrl),
           'POST',
           [
             {
@@ -262,7 +261,7 @@ describe('util.submit-addon', () => {
         const uploadUuid = '@some-guid';
         mockNodeFetch(
           sinon.stub(client, 'nodeFetch'),
-          `${apiHostPath}/addons/upload/${uploadUuid}/`,
+          new URL(`/addons/upload/${uploadUuid}/`, baseUrl),
           'GET',
           [
             {
@@ -285,7 +284,7 @@ describe('util.submit-addon', () => {
         const uploadUuid = '@some-guid';
         mockNodeFetch(
           sinon.stub(client, 'nodeFetch'),
-          `${apiHostPath}/addons/upload/${uploadUuid}/`,
+          new URL(`/addons/upload/${uploadUuid}/`, baseUrl),
           'GET',
           [
             { body: {}, status: 200 },
@@ -308,10 +307,10 @@ describe('util.submit-addon', () => {
           validationCheckInterval: 1,
         });
         const uploadUuid = '@some-guid';
-        const validationUrl = `${apiHost}/to/validation/report`;
+        const validationUrl = new URL('/to/validation/report', baseUrl);
         mockNodeFetch(
           sinon.stub(client, 'nodeFetch'),
-          `${apiHostPath}/addons/upload/${uploadUuid}/`,
+          new URL(`/addons/upload/${uploadUuid}/`, baseUrl),
           'GET',
           [
             { body: {}, status: 200 },
@@ -334,7 +333,7 @@ describe('util.submit-addon', () => {
         const client = new Client(clientDefaults);
         mockNodeFetch(
           sinon.stub(client, 'nodeFetch'),
-          `${apiHostPath}/addons/addon/`,
+          new URL('/addons/addon/', baseUrl),
           'POST',
           [
             { body: sampleAddonDetail, status: 202 },
@@ -352,7 +351,7 @@ describe('util.submit-addon', () => {
         const guid = '@some-addon-guid';
         mockNodeFetch(
           sinon.stub(client, 'nodeFetch'),
-          `${apiHostPath}/addons/addon/${guid}/`,
+          new URL(`/addons/addon/${guid}/`, baseUrl),
           'POST',
           [
             { body: sampleAddonDetail, status: 202 },
@@ -373,11 +372,11 @@ describe('util.submit-addon', () => {
         });
         const addonId = '@random-addon';
         const versionId = 0;
-        const detailPath =
-          `${apiPath}/addons/addon/${addonId}/versions/${versionId}/`;
+        const detailUrl =
+          new URL(`/addons/addon/${addonId}/versions/${versionId}/`, baseUrl);
         mockNodeFetch(
           sinon.stub(client, 'nodeFetch'),
-          `${apiHost}${detailPath}`,
+          detailUrl,
           'GET',
           [{ body: {}, status: 200 }]
         );
@@ -393,12 +392,12 @@ describe('util.submit-addon', () => {
         });
         const addonId = '@random-addon';
         const versionId = 0;
-        const detailPath =
-          `${apiPath}/addons/addon/${addonId}/versions/${versionId}/`;
-        const url = `${apiHost}file/download/url`;
+        const detailUrl =
+          new URL(`/addons/addon/${addonId}/versions/${versionId}/`, baseUrl);
+        const url = new URL('/file/download/url', baseUrl);
         mockNodeFetch(
           sinon.stub(client, 'nodeFetch'),
-          `${apiHost}${detailPath}`,
+          detailUrl,
           'GET',
           [
             { body: {}, status: 200 },
@@ -414,7 +413,7 @@ describe('util.submit-addon', () => {
     describe('downloadSignedFile', () => {
       const filename = 'download.xpi';
       const filePath = `/path/to/${filename}`;
-      const fileUrl = new URL(filePath, apiHost);
+      const fileUrl = new URL(filePath, baseUrl);
       const addonId = '@some-addon-id';
 
       it('downloads the file to tmpdir', () => withTempDir(async (tmpDir) => {
@@ -508,13 +507,13 @@ describe('util.submit-addon', () => {
       const addUploadMocks = () => {
         mockNodeFetch(
           nodeFetchStub,
-          `${apiHostPath}/addons/upload/`,
+          new URL('/addons/upload/', baseUrl),
           'POST',
           [{ body: sampleUploadDetail, status: 200 }]
         );
         mockNodeFetch(
           nodeFetchStub,
-          `${apiHostPath}/addons/upload/${uploadUuid}/`,
+          new URL(`/addons/upload/${uploadUuid}/`, baseUrl),
           'GET',
           [
             {
@@ -526,10 +525,10 @@ describe('util.submit-addon', () => {
       };
 
       const addApprovalMocks = (versionId) => {
-        const url = `${apiHost}${downloadPath}`;
+        const url = (new URL(downloadPath, baseUrl).toString());
         mockNodeFetch(
           nodeFetchStub,
-          `${apiHostPath}/addons/addon/${addonId}/versions/${versionId}/`,
+          new URL(`/addons/addon/${addonId}/versions/${versionId}/`, baseUrl),
           'GET',
           [
             {
@@ -554,7 +553,7 @@ describe('util.submit-addon', () => {
           addUploadMocks();
           mockNodeFetch(
             nodeFetchStub,
-            `${apiHostPath}/addons/addon/`,
+            new URL('/addons/addon/', baseUrl),
             'POST',
             [{ body: sampleAddonDetail, status: 200 }]
           );
@@ -571,13 +570,13 @@ describe('util.submit-addon', () => {
 
         mockNodeFetch(
           nodeFetchStub,
-          `${apiHostPath}/addons/addon/${addonId}/`,
+          new URL(`/addons/addon/${addonId}/`, baseUrl),
           'PUT',
           [{ body: sampleAddonDetail, status: 200 }]
         );
         mockNodeFetch(
           nodeFetchStub,
-          `${apiHostPath}/addons/addon/${addonId}/versions/${query}`,
+          new URL(`/addons/addon/${addonId}/versions/${query}`, baseUrl),
           'GET',
           [
             {
@@ -596,7 +595,6 @@ describe('util.submit-addon', () => {
     describe('fetchJson', () => {
       const client = new Client(clientDefaults);
       const nodeFetchStub = sinon.stub(client, 'nodeFetch');
-      const urlToFetch = new URL(apiHost);
 
       afterEach(() => {
         nodeFetchStub.reset();
@@ -605,33 +603,33 @@ describe('util.submit-addon', () => {
       it('rejects with a promise on not ok responses', async () => {
         mockNodeFetch(
           nodeFetchStub,
-          urlToFetch,
+          baseUrl,
           'GET',
           [{ body: {}, status: 400 }]
         );
-        const clientPromise = client.fetchJson(urlToFetch);
+        const clientPromise = client.fetchJson(baseUrl);
         await assert.isRejected(clientPromise, 'Bad Request: 400.');
       });
 
       it('rejects with a promise on < 100 responses', async () => {
         mockNodeFetch(
           nodeFetchStub,
-          urlToFetch,
+          baseUrl,
           'GET',
           [{ body: {}, status: 99 }]
         );
-        const clientPromise = client.fetchJson(urlToFetch);
+        const clientPromise = client.fetchJson(baseUrl);
         await assert.isRejected(clientPromise, 'Bad Request: 99.');
       });
 
       it('rejects with a promise on >= 500 responses', async () => {
         mockNodeFetch(
           nodeFetchStub,
-          urlToFetch,
+          baseUrl,
           'GET',
           [{ body: {}, status: 500 }]
         );
-        const clientPromise = client.fetchJson(urlToFetch);
+        const clientPromise = client.fetchJson(baseUrl);
         await assert.isRejected(clientPromise, 'Bad Request: 500.');
       });
 
@@ -639,11 +637,11 @@ describe('util.submit-addon', () => {
         const resJson = {thing: ['other'], this: {that: 1}};
         mockNodeFetch(
           nodeFetchStub,
-          urlToFetch,
+          baseUrl,
           'GET',
           [{ body: resJson, status: 200 }]
         );
-        const responseJson = await client.fetchJson(urlToFetch);
+        const responseJson = await client.fetchJson(baseUrl);
         expect(responseJson).to.eql(resJson);
       });
     });
@@ -651,7 +649,6 @@ describe('util.submit-addon', () => {
     describe('fetch', () => {
       const client = new Client(clientDefaults);
       let nodeFetchStub;
-      const urlToFetch = new URL(apiHost);
 
       beforeEach(() => {
         nodeFetchStub = sinon.stub(client, 'nodeFetch');
@@ -664,7 +661,7 @@ describe('util.submit-addon', () => {
       it('sets json content type for string type body', async () => {
         nodeFetchStub.resolves(new JSONResponse({}, 200));
 
-        await client.fetch(urlToFetch, 'POST', 'body');
+        await client.fetch(baseUrl, 'POST', 'body');
 
         assert.equal(
           nodeFetchStub.firstCall.args[1].headers['Content-Type'],
@@ -676,7 +673,7 @@ describe('util.submit-addon', () => {
       it("doesn't set content type for FormData type body", async () => {
         nodeFetchStub.resolves(new JSONResponse({}, 200));
 
-        await client.fetch(urlToFetch, 'POST', new FormData());
+        await client.fetch(baseUrl, 'POST', new FormData());
 
         assert.equal(
           nodeFetchStub.firstCall.args[1].headers['Content-Type'],
@@ -688,7 +685,7 @@ describe('util.submit-addon', () => {
       it("doesn't set content type for no body", async () => {
         nodeFetchStub.resolves(new JSONResponse({}, 200));
 
-        await client.fetch(urlToFetch, 'POST');
+        await client.fetch(baseUrl, 'POST');
 
         assert.equal(
           nodeFetchStub.firstCall.args[1].headers['Content-Type'],

--- a/tests/unit/test-util/test.submit-addon.js
+++ b/tests/unit/test-util/test.submit-addon.js
@@ -150,6 +150,15 @@ describe('util.submit-addon', () => {
         'Error: ENOENT: no such file or directory'
       );
     });
+
+    it('throws error if xpiPath is invalid', async () => {
+      const amoBaseUrl = 'badUrl';
+      const signAddonPromise = signAddon({...signAddonDefaults, amoBaseUrl});
+      await assert.isRejected(
+        signAddonPromise,
+        `Invalid AMO API base URL: ${amoBaseUrl}`
+      );
+    });
   });
 
   describe('Client', () => {


### PR DESCRIPTION
fixes #2504 + makes the base url constractor arg a `URL` in `Client` to be consistent with internal use in the class.