### PR TITLE
write id to file upon successful submission

### DIFF
--- a/src/cmd/sign.js
+++ b/src/cmd/sign.js
@@ -194,7 +194,7 @@ export default function sign(
           }
           result = { id: newId, downloadedFiles };
           // All information about the downloaded files would have already been
-          // logged by signAddon(). submitAddon() calls saveIdToSourceDir itself.
+          // logged by signAddon(). submitAddon() calls saveIdToFile itself.
           await saveIdToFile(savedIdPath, newId);
           log.info(`Extension ID: ${newId}`);
           log.info('SUCCESS');


### PR DESCRIPTION
fixes #2491 - and could address #2490 (at least in part) by clearly stating the addon id after it's available from AMO.