### PR TITLE
feat: enable MV3 by default in `web-ext lint` command

### DIFF
--- a/src/cmd/lint.js
+++ b/src/cmd/lint.js
@@ -95,14 +95,20 @@ export default function lint(
     selfHosted,
     shouldScanFile: (fileName) => fileFilter.wantFile(fileName),
     minManifestVersion: 2,
-    maxManifestVersion: 2,
+    maxManifestVersion: 3,
     // This mimics the first command line argument from yargs, which should be
     // the directory to the extension.
     _: [sourceDir],
   };
 
   if (firefoxPreview.includes('mv3')) {
-    config.maxManifestVersion = 3;
+    log.warn(
+      [
+        'Manifest Version 3 is now officially supported and',
+        '"--firefox-preview=mv3" is no longer needed.',
+        'In addition, the "mv3" value will be removed in the future.',
+      ].join(' ')
+    );
   }
 
   log.debug(`Running addons-linter on ${sourceDir}`);

--- a/tests/unit/test-cmd/test.lint.js
+++ b/tests/unit/test-cmd/test.lint.js
@@ -143,7 +143,7 @@ describe('lint', () => {
           boring: true,
           selfHosted: true,
           minManifestVersion: 2,
-          maxManifestVersion: 2,
+          maxManifestVersion: 3,
         },
       });
     });
@@ -165,21 +165,6 @@ describe('lint', () => {
       const { shouldScanFile } = createLinter.firstCall.args[0].config;
       shouldScanFile('path/to/file');
       sinon.assert.calledWith(fileFilter.wantFile, 'path/to/file');
-    });
-  });
-
-  describe('firefox-preview', () => {
-    it('enables MV3 support in addons-linter', async () => {
-      const { lint, createLinter } = setUp();
-
-      await lint({ firefoxPreview: ['mv3'] });
-
-      sinon.assert.calledWithMatch(createLinter, {
-        config: {
-          minManifestVersion: 2,
-          maxManifestVersion: 3,
-        },
-      });
     });
   });
 });


### PR DESCRIPTION
Refs https://github.com/mozilla/web-ext/issues/2549

---

I'll update `web-ext run` in a different patch.