### PR TITLE
feat: add chromium debugger port option

### DIFF
--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -54,6 +54,7 @@ export type CmdRunParams = {|
   // Chromium Desktop CLI options.
   chromiumBinary?: string,
   chromiumProfile?: string,
+  chromiumDebuggerPort?: number,
 |};
 
 export type CmdRunOptions = {
@@ -100,6 +101,7 @@ export default async function run(
     // Chromium CLI options.
     chromiumBinary,
     chromiumProfile,
+    chromiumDebuggerPort,
   }: CmdRunParams,
   {
     buildExtension = defaultBuildExtension,
@@ -243,6 +245,7 @@ export default async function run(
       ...commonRunnerParams,
       chromiumBinary,
       chromiumProfile,
+      chromiumDebuggerPort,
     };
 
     const chromiumRunner = await createExtensionRunner({

--- a/src/extension-runners/chromium.js
+++ b/src/extension-runners/chromium.js
@@ -28,6 +28,7 @@ type ChromiumSpecificRunnerParams = {|
   chromiumBinary?: string,
   chromiumProfile?: string,
   chromiumLaunch?: typeof defaultChromiumLaunch,
+  chromiumDebuggerPort?: number,
 |};
 
 export type ChromiumExtensionRunnerParams = {|
@@ -232,6 +233,7 @@ export class ChromiumExtensionRunner {
       userDataDir,
       // Ignore default flags to keep the extension enabled.
       ignoreDefaultFlags: true,
+      port: this.params.chromiumDebuggerPort,
     });
 
     this.chromiumInstance.process.once('close', () => {

--- a/src/program.js
+++ b/src/program.js
@@ -674,6 +674,11 @@ Example: $0 --help run.
         demandOption: false,
         type: 'string',
       },
+      'chromium-debugger-port': {
+        describe: 'Listen port number of the Chromium debugger',
+        demandOption: false,
+        type: 'number',
+      },
       'profile-create-if-missing': {
         describe: 'Create the profile directory if it does not already exist',
         demandOption: false,

--- a/src/program.js
+++ b/src/program.js
@@ -675,7 +675,9 @@ Example: $0 --help run.
         type: 'string',
       },
       'chromium-debugger-port': {
-        describe: 'Listen port number of the Chromium debugger',
+        describe:
+          'An unused port number, for use by the Chromium debugger. ' +
+          'If not specified, a random port will be used.',
         demandOption: false,
         type: 'number',
       },

--- a/tests/unit/test-cmd/test.run.js
+++ b/tests/unit/test-cmd/test.run.js
@@ -329,6 +329,26 @@ describe('run', () => {
     );
   });
 
+  it('provides a chromiumDebuggerPort option to the Chromium runner', async () => {
+    const fakeChromiumDebuggerPort = 59222;
+    const cmd = await prepareRun();
+    await cmd.run({
+      target: ['chromium'],
+      chromiumDebuggerPort: fakeChromiumDebuggerPort,
+    });
+
+    sinon.assert.calledWithMatch(chromiumRunnerStub, {
+      chromiumDebuggerPort: sinon.match.number,
+    });
+
+    const { chromiumDebuggerPort } = chromiumRunnerStub.firstCall.args[0];
+    assert.equal(
+      chromiumDebuggerPort,
+      fakeChromiumDebuggerPort,
+      'Got the expected chromiumDebuggerPort option'
+    );
+  });
+
   it('creates multiple extension runners', async () => {
     const cmd = await prepareRun();
     await cmd.run({ target: ['firefox-android', 'firefox-desktop'] });


### PR DESCRIPTION
Fixes #2284

This PR adds an option to specify the debugger port number for chromium-based browsers.
The motivation is to make debugger attachments declarative and manageable.

Note: It seems that the unit test is failing in an area unrelated to my modification.