### PR TITLE
chore: remove 'fast-json-patch' from the exclusion list in .nsprc

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,6 +1,4 @@
 {
   "exceptions": [
-    // See: https://github.com/mozilla/web-ext/issues/2589
-    "https://github.com/advisories/GHSA-8gh8-hqwg-xf34"
   ]
 }


### PR DESCRIPTION
Fixes https://github.com/mozilla/web-ext/issues/2596