### PR TITLE
docs: document "deved" alias for "firefoxdeveloperedition"

### DIFF
--- a/src/program.js
+++ b/src/program.js
@@ -653,7 +653,7 @@ Example: $0 --help run.
           'or firefox.exe. ' +
           'If not specified, the default Firefox will be used. ' +
           'You can specify the following aliases in lieu of a path: ' +
-          'firefox, beta, nightly, firefoxdeveloperedition. ' +
+          'firefox, beta, nightly, firefoxdeveloperedition (or deved). ' +
           'For Flatpak, use `flatpak:org.mozilla.firefox` where ' +
           '`org.mozilla.firefox` is the application ID.',
         demandOption: false,


### PR DESCRIPTION
This documents the "deved" alias introduced in #1906, which was released in 4.3.0.

This feature was requested again at https://github.com/mozilla/web-ext/issues/2627 because the alias was not well-known.