### PR TITLE
fix: Android 13 startActivity with correct intent action and category

### DIFF
--- a/src/util/adb.js
+++ b/src/util/adb.js
@@ -355,12 +355,26 @@ export default class ADBUtils {
     }
 
     await wrapADBCall(async () => {
-      await adbClient.getDevice(deviceId).startActivity({
-        wait: true,
-        action: 'android.activity.MAIN',
-        component,
-        extras,
-      });
+      try {
+        // TODO: once Fenix (release) uses Android 13, we can get rid of this
+        // call and only use the second call in the `catch` block.
+        await adbClient.getDevice(deviceId).startActivity({
+          wait: true,
+          action: 'android.activity.MAIN',
+          component,
+          extras,
+        });
+      } catch {
+        // Android 13+ requires a different action/category but we still need
+        // to support older Fenix builds.
+        await adbClient.getDevice(deviceId).startActivity({
+          wait: true,
+          action: 'android.intent.action.MAIN',
+          category: 'android.intent.category.LAUNCHER',
+          component,
+          extras,
+        });
+      }
     });
   }
 

--- a/tests/unit/test-util/test.adb.js
+++ b/tests/unit/test-util/test.adb.js
@@ -819,9 +819,21 @@ describe('utils/adb', () => {
         },
       });
 
-      sinon.assert.calledOnce(adb.fakeADBDevice.startActivity);
+      sinon.assert.calledTwice(adb.fakeADBDevice.startActivity);
       sinon.assert.calledWithMatch(adb.fakeADBDevice.startActivity, {
         action: 'android.activity.MAIN',
+        component: 'org.mozilla.firefox_mybuild/.App',
+        extras: [
+          {
+            key: 'args',
+            value: '-profile /fake/custom/profile/path',
+          },
+        ],
+        wait: true,
+      });
+      sinon.assert.calledWithMatch(adb.fakeADBDevice.startActivity, {
+        action: 'android.intent.action.MAIN',
+        category: 'android.intent.category.LAUNCHER',
         component: 'org.mozilla.firefox_mybuild/.App',
         extras: [
           {


### PR DESCRIPTION
Due to Android 13 changes described [here](https://developer.android.com/guide/components/intents-filters#match-intent-filter) which require activities to now match action and categories this PR updates the `.startActivity` to do this. 

Locally building and testing shows this to now work in Fenix as expected with the command:
`web-ext run -t firefox-android --adb-device DEVICE_ID_HERE --firefox-apk org.mozilla.fenix.debug --firefox-apk-component App`