### PR TITLE
fix: Chrome not opening special chrome URLs or extension specific pages

### DIFF
--- a/src/extension-runners/chromium.js
+++ b/src/extension-runners/chromium.js
@@ -129,17 +129,18 @@ export class ChromiumExtensionRunner {
 
     const chromeFlags = [...DEFAULT_CHROME_FLAGS];
     let startingUrl;
-    var specialStartingUrls = [];
+    let specialStartingUrls = [];
     if (this.params.startUrl) {
+      const specialUrlFormats = ['chrome://', 'chrome-extension://'];
       const startingUrls = Array.isArray(this.params.startUrl) ?
         this.params.startUrl : [this.params.startUrl];
 
       // Extract URLs starting with chrome:// from startingUrls and let bg.js open them instead
       specialStartingUrls = startingUrls.filter(
-        (item) => (item.toLowerCase().startsWith('chrome://')));
+        (item) => (specialUrlFormats.some((format) => item.toLowerCase().startsWith(format))));
 
       const strippedStartingUrls = startingUrls.filter(
-        (item) => !(item.toLowerCase().startsWith('chrome://')));
+        (item) => !(specialUrlFormats.some((format) => item.toLowerCase().startsWith(format))));
 
       startingUrl = strippedStartingUrls.shift();
       chromeFlags.push(...strippedStartingUrls);
@@ -269,8 +270,7 @@ export class ChromiumExtensionRunner {
     });
   }
 
-  async createReloadManagerExtension(
-    specialStartingUrls: Array<string>): Promise<string> {
+  async createReloadManagerExtension(specialStartingUrls) {
     const tmpDir = new TempDir();
     await tmpDir.create();
     this.registerCleanup(() => tmpDir.remove());

--- a/src/extension-runners/chromium.js
+++ b/src/extension-runners/chromium.js
@@ -132,23 +132,32 @@ export class ChromiumExtensionRunner {
     let specialStartingUrls = [];
     if (this.params.startUrl) {
       const specialUrlFormats = ['chrome://', 'chrome-extension://'];
-      const startingUrls = Array.isArray(this.params.startUrl) ?
-        this.params.startUrl : [this.params.startUrl];
+      const startingUrls = Array.isArray(this.params.startUrl)
+        ? this.params.startUrl
+        : [this.params.startUrl];
 
       // Extract URLs starting with chrome:// from startingUrls and let bg.js open them instead
-      specialStartingUrls = startingUrls.filter(
-        (item) => (specialUrlFormats.some((format) => item.toLowerCase().startsWith(format))));
+      specialStartingUrls = startingUrls.filter((item) =>
+        specialUrlFormats.some((format) =>
+          item.toLowerCase().startsWith(format)
+        )
+      );
 
       const strippedStartingUrls = startingUrls.filter(
-        (item) => !(specialUrlFormats.some((format) => item.toLowerCase().startsWith(format))));
+        (item) =>
+          !specialUrlFormats.some((format) =>
+            item.toLowerCase().startsWith(format)
+          )
+      );
 
       startingUrl = strippedStartingUrls.shift();
       chromeFlags.push(...strippedStartingUrls);
     }
 
     // Create the extension that will manage the addon reloads
-    this.reloadManagerExtension =
-      await this.createReloadManagerExtension(specialStartingUrls);
+    this.reloadManagerExtension = await this.createReloadManagerExtension(
+      specialStartingUrls
+    );
 
     // Start chrome pointing it to a given profile dir
     const extensions = [this.reloadManagerExtension]

--- a/tests/unit/test-extension-runners/test.chromium.js
+++ b/tests/unit/test-extension-runners/test.chromium.js
@@ -112,42 +112,54 @@ describe('util/extension-runners/chromium', async () => {
     await runnerInstance.exit();
   });
 
-  it('does insert special urls in companion extension '
-    + '& excludes them from args', async () => {
-    const {params} = prepareExtensionRunnerParams({
-      params: {startUrl:
-        ['url1', 'chrome://version', 'url2', 'chrome://extensions', 'chrome-extension://id/page.html'],
-      },
-    });
-    const runnerInstance = new ChromiumExtensionRunner(params);
-    await runnerInstance.run();
+  it(
+    'does insert special urls in companion extension ' +
+      '& excludes them from args',
+    async () => {
+      const { params } = prepareExtensionRunnerParams({
+        params: {
+          startUrl: [
+            'url1',
+            'chrome://version',
+            'url2',
+            'chrome://extensions',
+            'chrome-extension://id/page.html',
+          ],
+        },
+      });
+      const runnerInstance = new ChromiumExtensionRunner(params);
+      await runnerInstance.run();
 
-    const {reloadManagerExtension} = runnerInstance;
+      const { reloadManagerExtension } = runnerInstance;
 
-    assert.equal(await fs.exists(reloadManagerExtension), true);
+      assert.equal(await fs.exists(reloadManagerExtension), true);
 
-    const bgScript = path.join(reloadManagerExtension, 'bg.js');
-    const expectedStr =
-      'const chromeTabList = ["chrome://version","chrome://extensions","chrome-extension://id/page.html"]';
-    assert.include(await fs.readFile(
-      bgScript, 'utf8'), expectedStr, 'bg.js does not contain special urls');
+      const bgScript = path.join(reloadManagerExtension, 'bg.js');
+      const expectedStr =
+        'const chromeTabList = ["chrome://version","chrome://extensions","chrome-extension://id/page.html"]';
+      assert.include(
+        await fs.readFile(bgScript, 'utf8'),
+        expectedStr,
+        'bg.js does not contain special urls'
+      );
 
-    sinon.assert.calledOnce(params.chromiumLaunch);
-    //assert special urls are not present
-    sinon.assert.calledWithMatch(params.chromiumLaunch, {
-      ignoreDefaultFlags: true,
-      enableExtensions: true,
-      chromePath: undefined,
-      chromeFlags: [
-        ...DEFAULT_CHROME_FLAGS,
-        'url2',
-        `--load-extension=${reloadManagerExtension},/fake/sourceDir`,
-      ],
-      startingUrl: 'url1',
-    });
+      sinon.assert.calledOnce(params.chromiumLaunch);
+      //assert special urls are not present
+      sinon.assert.calledWithMatch(params.chromiumLaunch, {
+        ignoreDefaultFlags: true,
+        enableExtensions: true,
+        chromePath: undefined,
+        chromeFlags: [
+          ...DEFAULT_CHROME_FLAGS,
+          'url2',
+          `--load-extension=${reloadManagerExtension},/fake/sourceDir`,
+        ],
+        startingUrl: 'url1',
+      });
 
-    await runnerInstance.exit();
-  });
+      await runnerInstance.exit();
+    }
+  );
 
   it('controls the "reload manager" from a websocket server', async () => {
     const { params } = prepareExtensionRunnerParams();

--- a/tests/unit/test-extension-runners/test.chromium.js
+++ b/tests/unit/test-extension-runners/test.chromium.js
@@ -116,7 +116,8 @@ describe('util/extension-runners/chromium', async () => {
     + '& excludes them from args', async () => {
     const {params} = prepareExtensionRunnerParams({
       params: {startUrl:
-        ['url1', 'chrome://version', 'url2', 'chrome://extensions']},
+        ['url1', 'chrome://version', 'url2', 'chrome://extensions', 'chrome-extension://id/page.html'],
+      },
     });
     const runnerInstance = new ChromiumExtensionRunner(params);
     await runnerInstance.run();
@@ -127,7 +128,7 @@ describe('util/extension-runners/chromium', async () => {
 
     const bgScript = path.join(reloadManagerExtension, 'bg.js');
     const expectedStr =
-      'const chromeTabList = ["chrome://version","chrome://extensions"]';
+      'const chromeTabList = ["chrome://version","chrome://extensions","chrome-extension://id/page.html"]';
     assert.include(await fs.readFile(
       bgScript, 'utf8'), expectedStr, 'bg.js does not contain special urls');
 


### PR DESCRIPTION
This continues the PR from https://github.com/mozilla/web-ext/pull/2321 and resolves the original issues in https://github.com/mozilla/web-ext/issues/1979

Additionally, I have expanded the special handler cases to handle urls in the format `chrome-extension://`.