### PR TITLE
chore(deps): ignore https://github.com/advisories/GHSA-72xf-g2v4-qvf3 (tough-cookie)

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,6 +1,9 @@
 {
   "exceptions": [
     // See: https://github.com/mozilla/web-ext/issues/2678
-    "https://github.com/advisories/GHSA-p8p7-x288-28g6"
+    "https://github.com/advisories/GHSA-p8p7-x288-28g6",
+
+    // See: https://github.com/mozilla/web-ext/issues/2678
+    "https://github.com/advisories/GHSA-72xf-g2v4-qvf3"
   ]
 }


### PR DESCRIPTION
This PR adds tough-cookie (transitive dependency got through `sign-addon -> request -> tough-cookie`) to the nsprc file.