### PR TITLE
fix: Cannot find Firefox package on device with work profile

### DIFF
--- a/src/util/adb.js
+++ b/src/util/adb.js
@@ -86,13 +86,31 @@ export default class ADBUtils {
     return devices.map((dev) => dev.id);
   }
 
-  async discoverInstalledFirefoxAPKs(deviceId, firefoxApk) {
-    log.debug(`Listing installed Firefox APKs on ${deviceId}`);
+  async getCurrentUser(deviceId) {
+    log.debug(`Retrieving  current user on ${deviceId}`);
 
+    const currentUser = await this.runShellCommand(deviceId, [
+      'am',
+      'get-current-user',
+    ]);
+
+    const userId = parseInt(currentUser.trim());
+    if (isNaN(userId)) {
+      throw new WebExtError(`Unable to retrieve current user on ${deviceId}`);
+    }
+    return userId;
+  }
+
+  async discoverInstalledFirefoxAPKs(deviceId, firefoxApk) {
+    const userId = await this.getCurrentUser(deviceId);
+
+    log.debug(`Listing installed Firefox APKs on ${deviceId}`);
     const pmList = await this.runShellCommand(deviceId, [
       'pm',
       'list',
       'packages',
+      '--user',
+      `${userId}`,
     ]);
 
     return pmList

--- a/tests/unit/test-util/test.adb.js
+++ b/tests/unit/test-util/test.adb.js
@@ -224,11 +224,51 @@ describe('utils/adb', () => {
       });
 
       sinon.assert.calledOnce(adb.fakeADBDevice.shell);
+    });
+
+    it('retrieves current user', async () => {
+      const adb = getFakeADBKit({
+        adbkitUtil: {
+          readAll: sinon.spy(() => {
+            return Promise.resolve(Buffer.from('123\n'));
+          }),
+        },
+      });
+
+      const adbUtils = new ADBUtils({ adb });
+      const promise = adbUtils.getCurrentUser();
+
+      sinon.assert.calledOnce(adb.fakeADBDevice.shell);
       sinon.assert.calledWith(adb.fakeADBDevice.shell, [
-        'pm',
-        'list',
-        'packages',
+        'am',
+        'get-current-user',
       ]);
+      const result = await assert.isFulfilled(promise);
+      assert.equal(result, 123);
+    });
+
+    it('rejects invalid get-current-user output', async () => {
+      const adb = getFakeADBKit({
+        adbkitUtil: {
+          readAll: sinon.spy(() => {
+            return Promise.resolve(Buffer.from('No user'));
+          }),
+        },
+      });
+
+      const adbUtils = new ADBUtils({ adb });
+      const promise = adbUtils.getCurrentUser();
+
+      sinon.assert.calledOnce(adb.fakeADBDevice.shell);
+      sinon.assert.calledWith(adb.fakeADBDevice.shell, [
+        'am',
+        'get-current-user',
+      ]);
+      await assert.isRejected(
+        promise,
+        WebExtError,
+        /Unable to retrieve current user/,
+      );
     });
 
     it('resolves the array of the installed firefox APKs', async () => {
@@ -242,11 +282,27 @@ describe('utils/adb', () => {
           }),
         },
       });
+
+      const stubGetCurrentUser = sinon.stub(
+        ADBUtils.prototype,
+        'getCurrentUser',
+      );
+      stubGetCurrentUser.resolves(0);
+
       const adbUtils = new ADBUtils({ adb });
 
       const promise = adbUtils.discoverInstalledFirefoxAPKs('device1');
       const packages = await assert.isFulfilled(promise);
+      sinon.assert.calledOnce(stubGetCurrentUser);
+      sinon.assert.calledWith(stubGetCurrentUser, 'device1');
       sinon.assert.calledOnce(adb.fakeADBDevice.shell);
+      sinon.assert.calledWith(adb.fakeADBDevice.shell, [
+        'pm',
+        'list',
+        'packages',
+        '--user',
+        '0',
+      ]);
       sinon.assert.calledOnce(adb.util.readAll);
       assert.deepEqual(packages, ['org.mozilla.fennec', 'org.mozilla.firefox']);
     });


### PR DESCRIPTION
On some devices with work profile enabled, `adb shell pm list packages` will fail with permission error.
Avoid reaching work profile and scan packages for the primary user instead.
