### PR TITLE
feat: warn web-ext v7 users about upcoming changes to the sign command

### DIFF
--- a/src/cmd/sign.js
+++ b/src/cmd/sign.js
@@ -84,6 +84,12 @@ export default function sign(
     asyncFsReadFile = defaultAsyncFsReadFile,
   }: SignOptions = {}
 ): Promise<SignResult> {
+  if (!useSubmissionApi) {
+    log.warn(
+      'IMPORTANT: web-ext v8 will introduce a new AMO submission API for signing and you might need to take actions when upgrading from v7 to v8. You can test this upcoming change now by specifying `--use-submission-api` to the `sign` command. If you want to keep using the API you are using now (via "sign-addon"), you must stay on v7.'
+    );
+  }
+
   return withTempDir(async function (tmpDir) {
     await prepareArtifactsDir(artifactsDir);
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/web-ext/issues/2877

---

This will look like this:

```
❯ ./bin/web-ext.js sign --api-key="foo" --api-secret="bar"
Applying config file: ./package.json
IMPORTANT: web-ext v8 will introduce a new AMO submission API for signing and you might need to take actions when upgrading from v7 to v8. You can test this upcoming change now by specifying `--use-submission-api` to the `sign` command. If you want to keep using the API you are using now (via "sign-addon"), you must stay on v7.

[...]
```