### PR TITLE
ci: bump next/experimental Node to 20/21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,8 @@ references:
   nodejs_versions:
     # nvm-windows wants a full Node version, not just `<major>.<minor>`.
     - &nodejs_current "16.14.2"
-    - &nodejs_next "18.15"
-    - &nodejs_experimental "19.3"
+    - &nodejs_next "20.9"
+    - &nodejs_experimental "21.1"
 
   nodejs_enum: &nodejs_enum
     type: enum


### PR DESCRIPTION
I put the latest Node.js versions as listed at https://nodejs.org in CI.
I did not bump the min version yet, to avoid backwards-incompatible breakages. We could probably do that as part of our 8.x release.

I expect CI to be green (in particular, that #2564 and #2917 are not causing failures).