### PR TITLE
feat: improve CLI output of the sign command

### DIFF
--- a/src/cmd/sign.js
+++ b/src/cmd/sign.js
@@ -67,25 +67,23 @@ export default function sign(
 
     if (id && !manifestId) {
       throw new UsageError(
-        `Cannot set custom ID ${id} - addon submission API requires a ` +
-          'custom ID be specified in the manifest',
+        `Cannot set custom ID ${id} - The add-on ID must be specified in the manifest.json file.`,
       );
     }
     if (idFromSourceDir && !manifestId) {
       throw new UsageError(
         'Cannot use previously auto-generated extension ID ' +
-          `${idFromSourceDir} - addon submission API ` +
-          'requires a custom ID be specified in the manifest',
+          `${idFromSourceDir} - This add-on ID must be specified in the manifest.json file.`,
       );
     }
     if (id && manifestId) {
       throw new UsageError(
         `Cannot set custom ID ${id} because manifest.json ` +
-          `declares ID ${manifestId}`,
+          `already defines ID ${manifestId}`,
       );
     }
     if (id) {
-      log.debug(`Using custom ID declared as --id=${id}`);
+      log.info(`Using custom ID declared as --id=${id}`);
     }
 
     if (manifestId) {
@@ -104,9 +102,7 @@ export default function sign(
     }
 
     if (!channel) {
-      throw new UsageError(
-        'channel is a required parameter for the addon submission API',
-      );
+      throw new UsageError('You must specify a channel');
     }
 
     let metaDataJson;
@@ -147,7 +143,6 @@ export default function sign(
 
       return result;
     } catch (clientError) {
-      log.info('FAIL');
       throw new WebExtError(clientError.message);
     }
   });

--- a/tests/unit/test-cmd/test.sign.js
+++ b/tests/unit/test-cmd/test.sign.js
@@ -134,7 +134,7 @@ describe('sign', () => {
       );
       await assert.isRejected(
         promiseSigned,
-        /requires a custom ID be specified in the manifest/,
+        /The add-on ID must be specified in the manifest.json file/,
       );
     }));
 
@@ -163,7 +163,7 @@ describe('sign', () => {
       await assert.isRejected(promiseSigned, /some-other-id - /);
       await assert.isRejected(
         promiseSigned,
-        /requires a custom ID be specified in the manifest/,
+        /This add-on ID must be specified in the manifest.json file/,
       );
     }));
 
@@ -187,7 +187,7 @@ describe('sign', () => {
       );
       await assert.isRejected(
         signPromise,
-        /manifest\.json declares ID basic-manifest@web-ext-test-suite/,
+        /manifest\.json already defines ID basic-manifest@web-ext-test-suite/,
       );
     }));
 
@@ -203,10 +203,7 @@ describe('sign', () => {
         },
       });
       await assert.isRejected(signPromise, UsageError);
-      await assert.isRejected(
-        signPromise,
-        /channel is a required parameter for the addon submission API/,
-      );
+      await assert.isRejected(signPromise, /You must specify a channel/);
     }));
 
   it('passes the apiProxy parameter to submissionAPI signer', () =>

--- a/tests/unit/test-util/test.submit-addon.js
+++ b/tests/unit/test-util/test.submit-addon.js
@@ -1120,7 +1120,7 @@ describe('util.submit-addon', () => {
           { body: {}, status: 400 },
         ]);
         const clientPromise = client.fetchJson(baseUrl);
-        await assert.isRejected(clientPromise, 'Bad Request: 400.');
+        await assert.isRejected(clientPromise, 'Bad Request: 400\n{}');
       });
 
       it('rejects with a promise on < 100 responses', async () => {


### PR DESCRIPTION
Various minor improvements to output useful information when using `web-ext sign`.

## Before

### linter error

```
$ ../web-ext/bin/web-ext.js sign --channel=listed --amo-metadata=metadata.json
Building web extension from /Users/william/projects/mozilla/test-ext
POSTing URL: https://addons.allizom.org/api/v5/addons/upload/
Waiting for Validation...
GETing URL: https://addons.allizom.org/api/v5/addons/upload/e3f6549d0c9a433fa1e06b5c2db55162/
GETing URL: https://addons.allizom.org/api/v5/addons/upload/e3f6549d0c9a433fa1e06b5c2db55162/
GETing URL: https://addons.allizom.org/api/v5/addons/upload/e3f6549d0c9a433fa1e06b5c2db55162/
Validation results: {
  errors: 1,
  warnings: 1,
  notices: 0,
  success: false,
 
  [...]

  message_tree: {},
  ending_tier: 5
}
Validation failed.
FAIL

WebExtError: Validation failed, open the following URL for more information: https://addons.allizom.org/api/v5/addons/upload/e3f6549d0c9a433fa1e06b5c2db55162/
    at file:///Users/william/projects/mozilla/web-ext/lib/cmd/sign.js:115:13
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Program.execute (file:///Users/william/projects/mozilla/web-ext/lib/program.js:273:7)
    at async file:///Users/william/projects/mozilla/web-ext/bin/web-ext.js:13:1
```

### missing mandatory metadata

```
$ ../web-ext/bin/web-ext.js sign --channel=listed --amo-metadata=metadata.json
Building web extension from /Users/william/projects/mozilla/test-ext
POSTing URL: https://addons.allizom.org/api/v5/addons/upload/
Waiting for Validation...
GETing URL: https://addons.allizom.org/api/v5/addons/upload/c26de26a9d524010b419a406c38c4e0b/
GETing URL: https://addons.allizom.org/api/v5/addons/upload/c26de26a9d524010b419a406c38c4e0b/
GETing URL: https://addons.allizom.org/api/v5/addons/upload/c26de26a9d524010b419a406c38c4e0b/
Validation results: {
  errors: 0,
  warnings: 1,
  notices: 0,
  success: true,
  compatibility_summary: { warnings: 0, errors: 0, notices: 0 },
  metadata: {
    listed: true,
    identified_files: {},
    id: '@test-ext',
    manifestVersion: 2,
    name: 'text-ext',
    type: 1,
    version: '1.0.0',
    experimentApiPaths: {},
    totalScannedFileSize: 1083,
    emptyFiles: [ '_locales/en/foo.txt' ],
    jsLibs: {},
    unknownMinifiedFiles: [ 'script.js' ]
  },
  messages: [
    {
      message: 'Inline scripts blocked by default',
      description: 'Default CSP rules prevent inline JavaScript from running (https://mzl.la/2pn32nd).',
      file: 'index.html',
      uid: 'f31214397b5e464184cf39bc2cf28efe',
      type: 'warning',
      id: [Array],
      tier: 1
    }
  ],
  message_tree: {},
  ending_tier: 5
}
PUTing URL: https://addons.allizom.org/api/v5/addons/addon/@test-ext/
Server Response: {
  summary: [ 'You must provide an object of {lang-code:value}.' ],
  version: {
    license: [
      'This field, or custom_license, is required for listed versions.'
    ]
  }
}
FAIL

WebExtError: Bad Request: Bad Request.
    at file:///Users/william/projects/mozilla/web-ext/lib/cmd/sign.js:115:13
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Program.execute (file:///Users/william/projects/mozilla/web-ext/lib/program.js:273:7)
    at async file:///Users/william/projects/mozilla/web-ext/bin/web-ext.js:13:1
```

### success

```
$ ../web-ext/bin/web-ext.js sign --channel=listed --amo-metadata=metadata.json
Building web extension from /Users/william/projects/mozilla/test-ext
POSTing URL: https://addons.allizom.org/api/v5/addons/upload/
Waiting for Validation...
GETing URL: https://addons.allizom.org/api/v5/addons/upload/d359d7edbb3f4a7db32dc7a505b16e49/
GETing URL: https://addons.allizom.org/api/v5/addons/upload/d359d7edbb3f4a7db32dc7a505b16e49/
GETing URL: https://addons.allizom.org/api/v5/addons/upload/d359d7edbb3f4a7db32dc7a505b16e49/
Validation results: {
  errors: 0,
  warnings: 0,
  notices: 0,
  success: true,
  compatibility_summary: { warnings: 0, errors: 0, notices: 0 },
  metadata: {
    listed: true,
    identified_files: {},
    id: '{db55bb9b-0d9f-407f-9b65-da9dd29c8d32}',
    manifestVersion: 2,
    name: '</script><script>alert(1); //',
    type: 1,
    version: '10249.0.0',
    experimentApiPaths: {},
    totalScannedFileSize: 656,
    emptyFiles: [],
    jsLibs: {},
    unknownMinifiedFiles: []
  },
  messages: [],
  message_tree: {},
  ending_tier: 5
}
PUTing URL: https://addons.allizom.org/api/v5/addons/addon/%7Bdb55bb9b-0d9f-407f-9b65-da9dd29c8d32%7D/
Waiting for Approval...
GETing URL: https://addons.allizom.org/api/v5/addons/addon/%7Bdb55bb9b-0d9f-407f-9b65-da9dd29c8d32%7D/versions/2501424/
GETing URL: https://addons.allizom.org/api/v5/addons/addon/%7Bdb55bb9b-0d9f-407f-9b65-da9dd29c8d32%7D/versions/2501424/
GETing URL: https://addons.allizom.org/api/v5/addons/addon/%7Bdb55bb9b-0d9f-407f-9b65-da9dd29c8d32%7D/versions/2501424/
GETing URL: https://addons.allizom.org/api/v5/addons/addon/%7Bdb55bb9b-0d9f-407f-9b65-da9dd29c8d32%7D/versions/2501424/
GETing URL: https://addons.allizom.org/api/v5/addons/addon/%7Bdb55bb9b-0d9f-407f-9b65-da9dd29c8d32%7D/versions/2501424/
GETing URL: https://addons.allizom.org/api/v5/addons/addon/%7Bdb55bb9b-0d9f-407f-9b65-da9dd29c8d32%7D/versions/2501424/
GETing URL: https://addons.allizom.org/api/v5/addons/addon/%7Bdb55bb9b-0d9f-407f-9b65-da9dd29c8d32%7D/versions/2501424/
GETing URL: https://addons.allizom.org/api/v5/addons/addon/%7Bdb55bb9b-0d9f-407f-9b65-da9dd29c8d32%7D/versions/2501424/
GETing URL: https://addons.allizom.org/api/v5/addons/addon/%7Bdb55bb9b-0d9f-407f-9b65-da9dd29c8d32%7D/versions/2501424/
GETing URL: https://addons.allizom.org/api/v5/addons/addon/%7Bdb55bb9b-0d9f-407f-9b65-da9dd29c8d32%7D/versions/2501424/
[ ... more GETing URL ... ]
GETing URL: https://addons.allizom.org/firefox/downloads/file/1119792/script_script_alert_1-10249.0.0.xpi
```

## After

### linter error

```
$ ../web-ext/bin/web-ext.js sign --channel=listed --amo-metadata=metadata.json
Building web extension from /Users/william/projects/mozilla/test-ext
Waiting for validation...

WebExtError: Validation failed:
{
  "errors": 1,
  "warnings": 1,
  "notices": 0,
  "success": false,
  
  [...]
  
  "message_tree": {},
  "ending_tier": 5
}
    at file:///Users/william/projects/mozilla/web-ext/lib/cmd/sign.js:114:13
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Program.execute (file:///Users/william/projects/mozilla/web-ext/lib/program.js:273:7)
    at async file:///Users/william/projects/mozilla/web-ext/bin/web-ext.js:13:1
```

### missing mandatory metadata

```
$ ../web-ext/bin/web-ext.js sign --channel=listed --amo-metadata=metadata.json
Building web extension from /Users/william/projects/mozilla/test-ext

WebExtError: Submission failed (2): Bad Request
{
  "summary": [
    "You must provide an object of {lang-code:value}."
  ],
  "version": {
    "license": [
      "This field, or custom_license, is required for listed versions."
    ]
  }
}
    at file:///Users/william/projects/mozilla/web-ext/lib/cmd/sign.js:114:13
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Program.execute (file:///Users/william/projects/mozilla/web-ext/lib/program.js:273:7)
    at async file:///Users/william/projects/mozilla/web-ext/bin/web-ext.js:13:1
```

### success

```
$ ../web-ext/bin/web-ext.js sign --channel=listed --amo-metadata=metadata.json
Building web extension from /Users/william/projects/mozilla/test-ext
Waiting for validation...
Waiting for approval...
Signed xpi downloaded: /Users/william/projects/mozilla/test-ext/web-ext-artifacts/script_script_alert_1-10248.0.0.xpi
```