### PR TITLE
fix: Resolve input sourceDir to absolute path

### DIFF
--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import { fs } from 'mz';
 
 import defaultBuildExtension from './build.js';
@@ -61,6 +63,7 @@ export default async function run(
     getValidatedManifest = defaultGetValidatedManifest,
   } = {},
 ) {
+  sourceDir = path.resolve(sourceDir);
   log.info(`Running web extension from ${sourceDir}`);
   if (preInstall) {
     log.info(

--- a/src/program.js
+++ b/src/program.js
@@ -430,7 +430,7 @@ Example: $0 --help run.
       default: process.cwd(),
       requiresArg: true,
       type: 'string',
-      coerce: (arg) => (arg != null ? path.resolve(arg) : undefined),
+      coerce: (arg) => arg ?? undefined,
     },
     'artifacts-dir': {
       alias: 'a',

--- a/tests/unit/test-cmd/test.run.js
+++ b/tests/unit/test-cmd/test.run.js
@@ -128,6 +128,21 @@ describe('run', () => {
     });
   });
 
+  it('turns sourceDir into an absolute path', async () => {
+    const getFakeManifest = sinon.spy();
+    const cmd = await prepareRun();
+
+    await cmd.run(
+      { sourceDir: '.' },
+      { getValidatedManifest: getFakeManifest },
+    );
+
+    sinon.assert.calledOnce(desktopRunnerStub);
+    const runnerParams = desktopRunnerStub.firstCall.args[0];
+    const [{ sourceDir: expectedSourceDir }] = runnerParams.extensions;
+    assert.equal(expectedSourceDir, process.cwd());
+  });
+
   it('passes the expected parameters to the extension runner', async () => {
     const cmd = await prepareRun();
     const runOptions = {

--- a/tests/unit/test.program.js
+++ b/tests/unit/test.program.js
@@ -481,19 +481,6 @@ describe('program.main', () => {
     sinon.assert.calledWith(fakeVersionGetter, projectRoot);
   });
 
-  it('turns sourceDir into an absolute path', () => {
-    const fakeCommands = fake(commands, {
-      build: () => Promise.resolve(),
-    });
-    return execProgram(['build', '--source-dir', '..'], {
-      commands: fakeCommands,
-    }).then(() => {
-      sinon.assert.calledWithMatch(fakeCommands.build, {
-        sourceDir: path.resolve(path.join(process.cwd(), '..')),
-      });
-    });
-  });
-
   it('normalizes the artifactsDir path', () => {
     const fakeCommands = fake(commands, {
       build: () => Promise.resolve(),


### PR DESCRIPTION
Fixes #2993. 

Add a patch that turns the `run.js` sourceDir into an absolute path.