### PR TITLE
feat: Add support for config files in ES module format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "fs-extra": "11.2.0",
         "fx-runner": "1.4.0",
         "https-proxy-agent": "^7.0.0",
-        "import-fresh": "3.3.0",
         "jose": "4.15.4",
         "jszip": "3.10.1",
         "mkdirp": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "fs-extra": "11.2.0",
     "fx-runner": "1.4.0",
     "https-proxy-agent": "^7.0.0",
-    "import-fresh": "3.3.0",
     "jose": "4.15.4",
     "jszip": "3.10.1",
     "mkdirp": "1.0.4",

--- a/src/cmd/config.js
+++ b/src/cmd/config.js
@@ -1,0 +1,7 @@
+import { createLogger } from '../util/logger.js';
+
+const log = createLogger(import.meta.url);
+
+export default async function config(configData) {
+  log.info(`Config data:\n\n${JSON.stringify(configData, null, 2)}`);
+}

--- a/src/cmd/dump-config.js
+++ b/src/cmd/dump-config.js
@@ -3,5 +3,5 @@ import { createLogger } from '../util/logger.js';
 const log = createLogger(import.meta.url);
 
 export default async function config(configData) {
-  log.info(`${JSON.stringify(configData, null, 2)}`);
+  log.info(JSON.stringify(configData, null, 2));
 }

--- a/src/cmd/dump-config.js
+++ b/src/cmd/dump-config.js
@@ -3,5 +3,5 @@ import { createLogger } from '../util/logger.js';
 const log = createLogger(import.meta.url);
 
 export default async function config(configData) {
-  log.info(`Config data:\n\n${JSON.stringify(configData, null, 2)}`);
+  log.info(`${JSON.stringify(configData, null, 2)}`);
 }

--- a/src/cmd/index.js
+++ b/src/cmd/index.js
@@ -8,13 +8,13 @@ async function build(params, options) {
   return runCommand(params, options);
 }
 
-async function config(params, options) {
-  const { default: runCommand } = await import('./config.js');
+async function docs(params, options) {
+  const { default: runCommand } = await import('./docs.js');
   return runCommand(params, options);
 }
 
-async function docs(params, options) {
-  const { default: runCommand } = await import('./docs.js');
+async function dumpConfig(params, options) {
+  const { default: runCommand } = await import('./dump-config.js');
   return runCommand(params, options);
 }
 
@@ -33,4 +33,4 @@ async function sign(params, options) {
   return runCommand(params, options);
 }
 
-export default { build, config, docs, lint, run, sign };
+export default { build, docs, dumpConfig, lint, run, sign };

--- a/src/cmd/index.js
+++ b/src/cmd/index.js
@@ -8,6 +8,16 @@ async function build(params, options) {
   return runCommand(params, options);
 }
 
+async function config(params, options) {
+  const { default: runCommand } = await import('./config.js');
+  return runCommand(params, options);
+}
+
+async function docs(params, options) {
+  const { default: runCommand } = await import('./docs.js');
+  return runCommand(params, options);
+}
+
 async function lint(params, options) {
   const { default: runCommand } = await import('./lint.js');
   return runCommand(params, options);
@@ -23,9 +33,4 @@ async function sign(params, options) {
   return runCommand(params, options);
 }
 
-async function docs(params, options) {
-  const { default: runCommand } = await import('./docs.js');
-  return runCommand(params, options);
-}
-
-export default { build, lint, run, sign, docs };
+export default { build, config, docs, lint, run, sign };

--- a/src/config.js
+++ b/src/config.js
@@ -140,7 +140,7 @@ export async function loadJSConfigFile(filePath) {
     if (resolvedFilePath.endsWith('.mjs')) {
       const nonce = `${Date.now()}-${Math.random()}`;
       const { default: configDefault, ...esmConfigMod } = await import(
-        `${resolvedFilePath}?nonce=${nonce}`
+        `file://${resolvedFilePath}?nonce=${nonce}`
       );
       // ESM modules may expose both a default and named exports and so
       // we merge the named exports of top of what may have been set in

--- a/src/config.js
+++ b/src/config.js
@@ -143,6 +143,9 @@ export async function loadJSConfigFile(filePath) {
     `Loading JS config file: "${filePath}" ` +
       `(resolved to "${resolvedFilePath}")`,
   );
+  if (filePath.endsWith('.js')) {
+    log.warn(`WARNING: config file ${filePath} ${WARN_LEGACY_JS_EXT}`);
+  }
   let configObject;
   try {
     const nonce = `${Date.now()}-${Math.random()}`;

--- a/src/config.js
+++ b/src/config.js
@@ -12,21 +12,23 @@ import { UsageError, WebExtError } from './errors.js';
 
 const log = createLogger(import.meta.url);
 
+// NOTE: this error message is used in an interpolated string (while the other two help
+// messages are being logged as is).
 export const WARN_LEGACY_JS_EXT = [
-  'should be renamed to .cjs or .mjs to ensure its format is not ambiguous.',
-  'Config files with .js extensions are deprecated and will not be loaded anymore',
-  'in the next web-ext major version.',
+  'should be renamed to ".cjs" or ".mjs" file extension to ensure its format is not ambiguous.',
+  'Config files with the ".js" file extension are deprecated and will not be loaded anymore',
+  'in a future web-ext major version.',
 ].join(' ');
 
 export const HELP_ERR_MODULE_FROM_ESM = [
   'This config file belongs to a package.json file with "type" set to "module".',
-  'Rename the config file to end in .cjs or rename it to .mjs and rewrite it to an ES module.',
+  'Change the file extension to ".cjs" or rewrite it as an ES module and use the ".mjs" file extension.',
 ].join(' ');
 
 export const HELP_ERR_IMPORTEXPORT_CJS = [
-  'This config file is defined as an ESM module, but it belongs to either a project dir',
+  'This config file is defined as an ES module, but it belongs to either a project directory',
   'with a package.json file with "type" set to "commonjs" or one without any package.json file.',
-  'Rename the config file to end in ".mjs" to fix the config loading error.',
+  'Change the file extension to ".mjs" to fix the config loading error.',
 ].join(' ');
 
 const ERR_IMPORT_FROM_CJS = 'Cannot use import statement outside a module';
@@ -160,8 +162,8 @@ export async function loadJSConfigFile(filePath) {
 
     if (configModule.default) {
       const { default: configDefault, ...esmConfigMod } = configModule;
-      // ESM modules may expose both a default and named exports and so
-      // we merge the named exports of top of what may have been set in
+      // ES modules may expose both a default and named exports and so
+      // we merge the named exports on top of what may have been set in
       // the default export.
       configObject = { ...configDefault, ...esmConfigMod };
     } else {

--- a/src/program.js
+++ b/src/program.js
@@ -523,7 +523,7 @@ Example: $0 --help run.
     )
     .command(
       'dump-config',
-      'Run config discovery and dump the resulting config data',
+      'Run config discovery and dump the resulting config data as JSON',
       commands.dumpConfig,
       {},
     )

--- a/src/program.js
+++ b/src/program.js
@@ -522,6 +522,12 @@ Example: $0 --help run.
       },
     )
     .command(
+      'config',
+      'Run config discovery and dump the resulting config data',
+      commands.config,
+      {},
+    )
+    .command(
       'sign',
       'Sign the extension so it can be installed in Firefox',
       commands.sign,

--- a/src/program.js
+++ b/src/program.js
@@ -307,8 +307,8 @@ export class Program {
         );
       }
 
-      configFiles.forEach((configFileName) => {
-        const configObject = loadJSConfigFile(configFileName);
+      for (const configFileName of configFiles) {
+        const configObject = await loadJSConfigFile(configFileName);
         adjustedArgv = applyConfigToArgv({
           argv: adjustedArgv,
           argvFromCLI: argv,
@@ -316,7 +316,7 @@ export class Program {
           configObject,
           options: this.options,
         });
-      });
+      }
 
       if (adjustedArgv.verbose) {
         // Ensure that the verbose is enabled when specified in a config file.

--- a/src/program.js
+++ b/src/program.js
@@ -300,7 +300,7 @@ export class Program {
           .map((f) => f.replace(process.cwd(), '.'))
           .map((f) => f.replace(os.homedir(), '~'))
           .join(', ');
-        log.info(
+        log.debug(
           'Applying config file' +
             `${configFiles.length !== 1 ? 's' : ''}: ` +
             `${niceFileList}`,
@@ -522,9 +522,9 @@ Example: $0 --help run.
       },
     )
     .command(
-      'config',
+      'dump-config',
       'Run config discovery and dump the resulting config data',
-      commands.config,
+      commands.dumpConfig,
       {},
     )
     .command(

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -31,6 +31,8 @@ export class ConsoleStream {
       const msg = this.format(packet);
       if (this.isCapturing) {
         this.capturedMessages.push(msg);
+      } else if (packet.level > bunyan.INFO) {
+        localProcess.stderr.write(msg);
       } else {
         localProcess.stdout.write(msg);
       }

--- a/tests/functional/test.cli.dump-config.js
+++ b/tests/functional/test.cli.dump-config.js
@@ -1,0 +1,27 @@
+import { describe, it } from 'mocha';
+import { assert } from 'chai';
+import parseJSON from 'parse-json';
+
+import { withTempDir, execWebExt, reportCommandErrors } from './common.js';
+
+describe('web-ext dump-config', () => {
+  it('should emit valid JSON string to stdout', () =>
+    withTempDir((tmpDir) => {
+      const argv = ['dump-config'];
+      const cmd = execWebExt(argv, { cwd: tmpDir.path() });
+
+      return cmd.waitForExit.then(({ exitCode, stdout, stderr }) => {
+        if (exitCode !== 0) {
+          reportCommandErrors({
+            argv,
+            exitCode,
+            stdout,
+            stderr,
+          });
+          return;
+        }
+        const parsedConfigData = parseJSON(stdout);
+        assert.equal(parsedConfigData.sourceDir, tmpDir.path());
+      });
+    }));
+});

--- a/tests/functional/test.cli.run.js
+++ b/tests/functional/test.cli.run.js
@@ -110,8 +110,8 @@ describe('web-ext run', () => {
         },
       };
 
-      return execWebExt(argv, spawnOptions).waitForExit.then(({ stdout }) => {
-        assert.match(stdout, /Invalid --watch-file value: .+ is not a file./);
+      return execWebExt(argv, spawnOptions).waitForExit.then(({ stderr }) => {
+        assert.match(stderr, /Invalid --watch-file value: .+ is not a file./);
       });
     }));
 

--- a/tests/functional/test.cli.sign.js
+++ b/tests/functional/test.cli.sign.js
@@ -131,10 +131,10 @@ describe('web-ext sign', () => {
       ];
       const cmd = execWebExt(argv, { cwd: tmpDir });
 
-      return cmd.waitForExit.then(({ exitCode, stdout }) => {
+      return cmd.waitForExit.then(({ exitCode, stderr }) => {
         assert.notEqual(exitCode, 0);
         assert.match(
-          stdout,
+          stderr,
           /web-ext-config.js specified an unknown option: "apiKey"/,
         );
       });

--- a/tests/unit/test.config.js
+++ b/tests/unit/test.config.js
@@ -10,8 +10,8 @@ import {
   applyConfigToArgv,
   discoverConfigFiles,
   loadJSConfigFile,
-  HELP_ERR_REQUIRE_ESM,
   HELP_ERR_IMPORTEXPORT_CJS,
+  HELP_ERR_MODULE_FROM_ESM,
 } from '../../src/config.js';
 import { withTempDir } from '../../src/util/temp-dir.js';
 import { UsageError, WebExtError } from '../../src/errors.js';
@@ -945,7 +945,7 @@ describe('config', () => {
         fs.writeFileSync(pkgFilePath, JSON.stringify({ type: 'module' }));
         const promise = loadJSConfigFile(cfgFilePath);
         await assert.isRejected(promise, UsageError);
-        await assert.isRejected(promise, new RegExp(HELP_ERR_REQUIRE_ESM));
+        await assert.isRejected(promise, new RegExp(HELP_ERR_MODULE_FROM_ESM));
       }));
 
     it('provides help message on load failure due to .js ESM config file and type commonjs package', () =>

--- a/tests/unit/test.config.js
+++ b/tests/unit/test.config.js
@@ -10,6 +10,8 @@ import {
   applyConfigToArgv,
   discoverConfigFiles,
   loadJSConfigFile,
+  HELP_ERR_REQUIRE_ESM,
+  HELP_ERR_IMPORTEXPORT_CJS,
 } from '../../src/config.js';
 import { withTempDir } from '../../src/util/temp-dir.js';
 import { UsageError, WebExtError } from '../../src/errors.js';
@@ -899,21 +901,17 @@ describe('config', () => {
 
   describe('loadJSConfigFile', () => {
     it('throws an error if the config file does not exist', () => {
-      return withTempDir((tmpDir) => {
-        assert.throws(
-          () => {
-            loadJSConfigFile(
-              path.join(tmpDir.path(), 'non-existant-config.js'),
-            );
-          },
-          UsageError,
-          /Cannot read config file/,
+      return withTempDir(async (tmpDir) => {
+        const promise = loadJSConfigFile(
+          path.join(tmpDir.path(), 'non-existant-config.js'),
         );
+        await assert.isRejected(promise, UsageError);
+        await assert.isRejected(promise, /Cannot read config file/);
       });
     });
 
     it('throws an error if the config file has syntax errors', () => {
-      return withTempDir((tmpDir) => {
+      return withTempDir(async (tmpDir) => {
         const configFilePath = path.join(tmpDir.path(), 'config.js');
         fs.writeFileSync(
           configFilePath,
@@ -922,28 +920,105 @@ describe('config', () => {
                 sourceDir 'path/to/fake/source/dir',
               };`,
         );
-        assert.throws(() => {
-          loadJSConfigFile(configFilePath);
-        }, UsageError);
+        await assert.isRejected(loadJSConfigFile(configFilePath), UsageError);
       });
     });
 
-    it('parses the configuration file correctly', () => {
-      return withTempDir((tmpDir) => {
+    it('provides help message on load failure due to .js ESM config file and no package', () => {
+      return withTempDir(async (tmpDir) => {
+        const configFilePath = path.join(tmpDir.path(), 'config.js');
+        fs.writeFileSync(
+          configFilePath,
+          'export default { sourceDir: "fake/dir" };',
+        );
+        const promise = loadJSConfigFile(configFilePath);
+        await assert.isRejected(promise, UsageError);
+        await assert.isRejected(promise, new RegExp(HELP_ERR_IMPORTEXPORT_CJS));
+      });
+    });
+
+    it('provides help message on load failure due to .js CJS config file and type module package', () =>
+      withTempDir(async (tmpDir) => {
+        const cfgFilePath = path.join(tmpDir.path(), 'config.js');
+        const pkgFilePath = path.join(tmpDir.path(), 'package.json');
+        fs.writeFileSync(cfgFilePath, 'module.exports = {};');
+        fs.writeFileSync(pkgFilePath, JSON.stringify({ type: 'module' }));
+        const promise = loadJSConfigFile(cfgFilePath);
+        await assert.isRejected(promise, UsageError);
+        await assert.isRejected(promise, new RegExp(HELP_ERR_REQUIRE_ESM));
+      }));
+
+    it('provides help message on load failure due to .js ESM config file and type commonjs package', () =>
+      withTempDir(async (tmpDir) => {
+        const cfgWithExportFilePath = path.join(
+          tmpDir.path(),
+          'config-with-export.js',
+        );
+        const cfgWithImportFilePath = path.join(
+          tmpDir.path(),
+          'config-with-import.js',
+        );
+        const pkgFilePath = path.join(tmpDir.path(), 'package.json');
+        fs.writeFileSync(cfgWithExportFilePath, 'export default {}');
+        fs.writeFileSync(
+          cfgWithImportFilePath,
+          'import test from "./test.js";',
+        );
+        fs.writeFileSync(pkgFilePath, JSON.stringify({ type: 'commonjs' }));
+
+        const promiseErrOnExport = loadJSConfigFile(cfgWithExportFilePath);
+        await assert.isRejected(promiseErrOnExport, UsageError);
+        await assert.isRejected(
+          promiseErrOnExport,
+          new RegExp(HELP_ERR_IMPORTEXPORT_CJS),
+        );
+
+        const promiseErrOnImport = loadJSConfigFile(cfgWithImportFilePath);
+        await assert.isRejected(promiseErrOnImport, UsageError);
+        await assert.isRejected(
+          promiseErrOnImport,
+          new RegExp(HELP_ERR_IMPORTEXPORT_CJS),
+        );
+      }));
+
+    it('parses successfully .js file as CommonJS config file', () => {
+      return withTempDir(async (tmpDir) => {
         const configFilePath = path.join(tmpDir.path(), 'config.js');
         fs.writeFileSync(
           configFilePath,
           `module.exports = {
-              sourceDir: 'path/to/fake/source/dir',
+              sourceDir: 'fake/dir',
             };`,
         );
-        const configObj = loadJSConfigFile(configFilePath);
-        assert.equal(configObj.sourceDir, 'path/to/fake/source/dir');
+        const promise = loadJSConfigFile(configFilePath);
+        await assert.becomes(promise, { sourceDir: 'fake/dir' });
       });
     });
 
+    it('parses successfully .mjs file as ESM config file when no package type', () =>
+      withTempDir(async (tmpDir) => {
+        const cfgFilePath = path.join(tmpDir.path(), 'config.mjs');
+        fs.writeFileSync(
+          cfgFilePath,
+          'export default { sourceDir: "fake/dir" };',
+        );
+        const promise = loadJSConfigFile(cfgFilePath);
+        await assert.becomes(promise, { sourceDir: 'fake/dir' });
+      }));
+
+    it('parses .cjs file as CommonJS config file when no package type', () =>
+      withTempDir(async (tmpDir) => {
+        const cfgFilePath = path.join(tmpDir.path(), 'config.cjs');
+        fs.writeFileSync(
+          cfgFilePath,
+          'module.exports = { sourceDir: "fake/dir" };',
+        );
+        const promise = loadJSConfigFile(cfgFilePath);
+        await assert.becomes(promise, { sourceDir: 'fake/dir' });
+      }));
+
     it('parses package.json file correctly', () => {
-      return withTempDir((tmpDir) => {
+      return withTempDir(async (tmpDir) => {
         const configFilePath = path.join(tmpDir.path(), 'package.json');
         fs.writeFileSync(
           configFilePath,
@@ -955,21 +1030,21 @@ describe('config', () => {
                 }
             }`,
         );
-        const configObj = loadJSConfigFile(configFilePath);
+        const configObj = await loadJSConfigFile(configFilePath);
         assert.equal(configObj.sourceDir, 'path/to/fake/source/dir');
       });
     });
 
     it('does not throw an error for an empty config', () => {
-      return withTempDir((tmpDir) => {
+      return withTempDir(async (tmpDir) => {
         const configFilePath = path.join(tmpDir.path(), 'config.js');
         fs.writeFileSync(configFilePath, 'module.exports = {};');
-        loadJSConfigFile(configFilePath);
+        await loadJSConfigFile(configFilePath);
       });
     });
 
     it('returns an empty object when webExt key is not in package.json', () => {
-      return withTempDir((tmpDir) => {
+      return withTempDir(async (tmpDir) => {
         const configFilePath = path.join(tmpDir.path(), 'package.json');
         fs.writeFileSync(
           configFilePath,
@@ -978,7 +1053,7 @@ describe('config', () => {
               "version": "1.0.0"
             }`,
         );
-        const configObj = loadJSConfigFile(configFilePath);
+        const configObj = await loadJSConfigFile(configFilePath);
         assert.deepEqual(configObj, {});
       });
     });
@@ -1036,9 +1111,18 @@ describe('config', () => {
         try {
           const fakeHomeDir = path.join(tmpDir.path(), 'home-dir');
           await fs.mkdir(fakeHomeDir);
+          const globalConfigMjs = path.resolve(
+            path.join(fakeHomeDir, '.web-ext-config.mjs'),
+          );
+          const globalConfigCjs = path.resolve(
+            path.join(fakeHomeDir, '.web-ext-config.cjs'),
+          );
           const globalConfig = path.resolve(
             path.join(fakeHomeDir, '.web-ext-config.js'),
           );
+
+          await fs.writeFile(globalConfigMjs, 'export default {}');
+          await fs.writeFile(globalConfigCjs, 'module.exports = {}');
           await fs.writeFile(globalConfig, 'module.exports = {}');
 
           const packageJSONConfig = path.resolve(
@@ -1053,14 +1137,32 @@ describe('config', () => {
               }`,
           );
 
+          const projectConfigMjs = path.resolve(
+            path.join(process.cwd(), '.web-ext-config.mjs'),
+          );
+          const projectConfigCjs = path.resolve(
+            path.join(process.cwd(), '.web-ext-config.cjs'),
+          );
           const projectConfig = path.resolve(
             path.join(process.cwd(), '.web-ext-config.js'),
           );
+
+          await fs.writeFile(projectConfigMjs, 'export default {}');
+          await fs.writeFile(projectConfigCjs, 'module.exports = {}');
           await fs.writeFile(projectConfig, 'module.exports = {}');
 
+          const projectConfigUndottedMjs = path.resolve(
+            path.join(process.cwd(), 'web-ext-config.mjs'),
+          );
+          const projectConfigUndottedCjs = path.resolve(
+            path.join(process.cwd(), 'web-ext-config.cjs'),
+          );
           const projectConfigUndotted = path.resolve(
             path.join(process.cwd(), 'web-ext-config.js'),
           );
+
+          await fs.writeFile(projectConfigUndottedMjs, 'export default {}');
+          await fs.writeFile(projectConfigUndottedCjs, 'module.exports = {}');
           await fs.writeFile(projectConfigUndotted, 'module.exports = {}');
 
           assert.deepEqual(
@@ -1068,9 +1170,15 @@ describe('config', () => {
               getHomeDir: () => fakeHomeDir,
             }),
             [
+              globalConfigMjs,
+              globalConfigCjs,
               globalConfig,
               packageJSONConfig,
+              projectConfigUndottedMjs,
+              projectConfigUndottedCjs,
               projectConfigUndotted,
+              projectConfigMjs,
+              projectConfigCjs,
               projectConfig,
             ],
           );

--- a/tests/unit/test.web-ext.js
+++ b/tests/unit/test.web-ext.js
@@ -17,7 +17,7 @@ describe('webExt', () => {
       resetMockModules();
       stub = undefined;
     });
-    for (const cmd of ['run', 'lint', 'build', 'sign', 'docs']) {
+    for (const cmd of ['run', 'lint', 'build', 'sign', 'docs', 'dump-config']) {
       it(`lazily loads cmd/${cmd}`, async () => {
         const cmdModule = await import(`../../src/cmd/${cmd}.js`);
         stub = sinon.stub({ default: cmdModule.default }, 'default');
@@ -35,7 +35,8 @@ describe('webExt', () => {
         stub?.returns(expectedResult);
 
         const { default: webExtModule } = await import('../../src/main.js');
-        const runCommand = webExtModule.cmd[cmd];
+        const runCommand =
+          webExtModule.cmd[cmd === 'dump-config' ? 'dumpConfig' : cmd];
         const result = await runCommand(params, options);
 
         // Check whether parameters and return values are forwarded as-is.


### PR DESCRIPTION
This PR includes a small set of changes to:
- add support for loading config files in the ESM module format
- add guidance help message to UserError error messages raised when hitting parsing error because the config file is not in the nodejs instance expects it to be (e.g. either a .js config file in CommonJS format from a type module package, or a .js config file in ES module format from a type commonjs package)
- proposed addition of an additional command which does just print all config data loaded from the discovered files

Fixes #2604 

TODO:
- [x] agree with the team if we would prefer the behavior on .js config files to be just throwing and force the user to conver them to either .cjs or .mjs config files (instead of allow them to load successfully whenever possible)
- [x] agree with the team if we feel that introducing an additional command which just dump the config data as discovered and loaded (mainly to make it easier for extensions developers to inspect the resulting data got from loading and merging all discovered config files, e.g. to debug and/or report to us issue with config file loading)
  - [x] either cover the new command with a few new tests or remove the command prototype all together (based on which is the agreement we reached on the parent todo item)