### PR TITLE
fix: Allow any positive integer in `--approval-timeout`

### DIFF
--- a/tests/unit/test-util/test.submit-addon.js
+++ b/tests/unit/test-util/test.submit-addon.js
@@ -670,7 +670,7 @@ describe('util.submit-addon', () => {
         );
 
         const clientPromise = client.waitForValidation(uploadUuid);
-        await assert.isRejected(clientPromise, 'Validation: timeout.');
+        await assert.isRejected(clientPromise, 'Validation: timeout exceeded.');
       });
 
       it('waits for validation that passes', async () => {
@@ -873,8 +873,16 @@ describe('util.submit-addon', () => {
         mockNodeFetch(sinon.stub(client, 'nodeFetch'), detailUrl, 'GET', [
           { body: {}, status: 200 },
         ]);
-        const clientPromise = client.waitForApproval(addonId, versionId);
-        await assert.isRejected(clientPromise, 'Approval: timeout.');
+        const editUrl = 'some-edit-url';
+        const clientPromise = client.waitForApproval(
+          addonId,
+          versionId,
+          editUrl,
+        );
+        await assert.isRejected(
+          clientPromise,
+          `Approval: timeout exceeded. When approved the signed XPI file can be downloaded from ${editUrl}`,
+        );
       });
 
       it('waits for approval', async () => {


### PR DESCRIPTION
Fixes https://github.com/mozilla/web-ext/issues/3030

---

## Before

See output in https://github.com/mozilla/web-ext/issues/3030

## After


```
$ web-ext sign --channel=unlisted --amo-metadata=metadata.json --approval-timeout=0
Building web extension from /path/to/test-ext
Waiting for validation...
Waiting for approval and download of signed XPI skipped. When approved the signed XPI file can be downloaded from https://addons.mozilla.org/en-US/developers/addon/xxx/versions/123
```

```
$ web-ext sign --channel=unlisted --amo-metadata=metadata.json --approval-timeout=10
Building web extension from /path/to/test-ext
Waiting for validation...
Waiting for approval...

WebExtError: Approval: timeout exceeded. When approved the signed XPI file can be downloaded from https://addons.mozilla.org/en-US/developers/addon/xxx/versions/123
    at file:///Users/william/projects/mozilla/web-ext/lib/cmd/sign.js:114:13
    at async Program.execute (file:///Users/william/projects/mozilla/web-ext/lib/program.js:273:7)
    at async file:///Users/william/projects/mozilla/web-ext/bin/web-ext.js:13:1
```