### PR TITLE
fix: Bump version in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-ext",
-  "version": "7.6.0",
+  "version": "8.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "web-ext",
-      "version": "7.6.0",
+      "version": "8.0.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@babel/runtime": "7.23.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-ext",
-  "version": "7.6.0",
+  "version": "8.0.0",
   "description": "A command line tool to help build, run, and test web extensions",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
This should allow users of the unreleased bleeding-edge version of web-ext to report the right version.