### PR TITLE
Fix references to removed CLI flag

### DIFF
--- a/src/program.js
+++ b/src/program.js
@@ -589,7 +589,7 @@ Example: $0 --help run.
             'Path to an archive file containing human readable source code of this submission, ' +
             'if the code in --source-dir has been processed to make it unreadable. ' +
             'See https://extensionworkshop.com/documentation/publish/source-code-submission/ for ' +
-            'details. Only used with `use-submission-api`',
+            'details.',
           type: 'string',
         },
       },

--- a/tests/unit/test-cmd/test.sign.js
+++ b/tests/unit/test-cmd/test.sign.js
@@ -227,7 +227,6 @@ describe('sign', () => {
       return sign(tmpDir, stubs, {
         extraArgs: {
           uploadSourceCode,
-          useSubmissionApi: true,
           channel: 'unlisted',
         },
       }).then(() => {


### PR DESCRIPTION
This PR removes out of date references to the `--use-submission-api` CLI flag.