### PR TITLE
feat: allow port option when run with target chromium

### DIFF
--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -48,6 +48,7 @@ export default async function run(
     firefoxApkComponent,
     // Chromium CLI options.
     chromiumBinary,
+    chromiumPort,
     chromiumProfile,
   },
   {
@@ -186,6 +187,7 @@ export default async function run(
     const chromiumRunnerParams = {
       ...commonRunnerParams,
       chromiumBinary,
+      chromiumPort,
       chromiumProfile,
     };
 

--- a/src/errors.js
+++ b/src/errors.js
@@ -64,7 +64,7 @@ export class PortInUseError extends UnusablePortError {
     super(message);
   }
 }
-export class PortVerificationFailedError extends UnusablePortError {
+export class PortInvalidError extends UnusablePortError {
   constructor(message = 'The requested port cannot be used.') {
     super(message);
   }

--- a/src/errors.js
+++ b/src/errors.js
@@ -54,6 +54,22 @@ export class MultiExtensionsReloadError extends WebExtError {
   }
 }
 
+export class UnusablePortError extends WebExtError {
+  constructor(message) {
+    super(message);
+  }
+}
+export class PortInUseError extends UnusablePortError {
+  constructor(message = 'The requested port is in use by another process') {
+    super(message);
+  }
+}
+export class PortVerificationFailedError extends UnusablePortError {
+  constructor(message = 'The requested port cannot be used.') {
+    super(message);
+  }
+}
+
 /*
  * Sugar-y way to catch only instances of a certain error.
  *

--- a/src/extension-runners/chromium.js
+++ b/src/extension-runners/chromium.js
@@ -202,6 +202,12 @@ export class ChromiumExtensionRunner {
       chromeFlags.push(...startingUrls);
     }
 
+    let port;
+    if(this.params.chromiumPort && !isNaN(this.params.chromiumPort)) {
+      port = this.params.chromiumPort;
+      log.debug(`(port: ${port})`);
+    }
+
     this.chromiumInstance = await this.chromiumLaunch({
       enableExtensions: true,
       chromePath: chromiumBinary,
@@ -210,6 +216,7 @@ export class ChromiumExtensionRunner {
       userDataDir,
       // Ignore default flags to keep the extension enabled.
       ignoreDefaultFlags: true,
+      port,
     });
 
     this.chromiumInstance.process.once('close', () => {

--- a/src/extension-runners/chromium.js
+++ b/src/extension-runners/chromium.js
@@ -235,7 +235,7 @@ export class ChromiumExtensionRunner {
 
     log.debug('(config: %O)', chromiumConfig);
     this.chromiumInstance = await this.chromiumLaunch(chromiumConfig);
-
+    log.debug('(process: %O)', this.chromiumInstance);
     this.chromiumInstance.process.once('close', () => {
       this.chromiumInstance = null;
 

--- a/src/extension-runners/chromium.js
+++ b/src/extension-runners/chromium.js
@@ -203,7 +203,7 @@ export class ChromiumExtensionRunner {
     }
 
     let port;
-    if(this.params.chromiumPort && !isNaN(this.params.chromiumPort)) {
+    if (this.params.chromiumPort && !isNaN(this.params.chromiumPort)) {
       port = this.params.chromiumPort;
       log.debug(`(port: ${port})`);
     }

--- a/src/util/verify-chromium-port.js
+++ b/src/util/verify-chromium-port.js
@@ -1,114 +1,12 @@
 import { createServer } from 'node:http';
-import { exec } from 'node:child_process';
 
-import { createLogger } from './logger.js';
-import { UnusablePortError, UsageError } from '../errors.js';
-
-const log = createLogger(import.meta.url);
-
-/**
- * Returns a random, available port
- * @returns {number} Available port number to use;
- */
-export async function getRandomPort() {
-  return new Promise((resolve, reject) => {
-    const server = createServer();
-    server.once('listening', () => {
-      const { port } = server.address();
-      server.close(() => resolve(port));
-    });
-    server.once('error', () => reject);
-    server.listen(0);
-  });
-}
-
-/**
- * Search for existing process
- * @param {string} chromeBinary
- * @returns {Promise<string>} Process list output
- */
-async function findProcess(chromeBinary) {
-  const platform = process.platform;
-  let cmd = '';
-
-  switch (platform) {
-    case 'freebsd':
-      // no dash
-      cmd = 'ps axo cmd';
-      break;
-    case 'darwin':
-      cmd = 'ps -axo cmd';
-      break;
-    case 'linux':
-      // dash
-      cmd = 'ps -Ao cmd';
-      cmd = `${cmd} | grep ${chromeBinary}`;
-      break;
-    case 'win32':
-      cmd = `powershell "Get-CimInstance Win32_Process -Filter \\"Name -Like '${chromeBinary}'\\" | Select CommandLine"`;
-      break;
-    default:
-      throw new UsageError('Unsupported platform');
-  }
-
-  const promise = new Promise((resolve, reject) => {
-    exec(cmd, (error, stdout, stderr) => {
-      if (stderr) {
-        log.debug('Error: %s', stderr);
-      }
-
-      if (error) {
-        reject(error);
-      } else {
-        resolve(stdout);
-      }
-    });
-  });
-
-  return promise;
-}
-
-/**
- * Inspect process list output and match against specified port and extension
- * @param {number} port User-requested port
- * @param {string} extension Web-ext temporary extension
- * @param {string} output Output from OS-specific process list containing process command line
- * @returns {Promise<boolean>} Whether an eligible instance was found
- */
-async function inspectProcessList(port, extension, output) {
-  if (!output) {
-    log.info('Browser instance not found');
-    return false;
-  }
-  const lines = output.split('\n');
-  let foundEligibleInstance = false;
-
-  lines.forEach((line) => {
-    const extensionMatch = `--load-extension=${extension}`;
-    const portMatch = `--remote-debugging-port=${port}`;
-
-    const isPortMatch = line.toLowerCase().indexOf(portMatch) > -1;
-    const isExtension = line.indexOf(extensionMatch) > -1;
-
-    if (!isPortMatch) {
-      return;
-    }
-
-    if (!isExtension) {
-      return;
-    }
-
-    foundEligibleInstance = true;
-  });
-
-  return foundEligibleInstance;
-}
+import { UnusablePortError } from '../errors.js';
 
 /**
  * Determine if a port is available
  * @param {number} port Port to test
  * */
-export async function portAvailable(port) {
+async function isPortAvailable(port) {
   return new Promise((resolve) => {
     const server = createServer();
     server.once('listening', () => {
@@ -120,51 +18,35 @@ export async function portAvailable(port) {
 }
 
 /**
- * Validate user-supplied port to ensure it is suitable for use
- * @param {number} port User-supplied port request
- * @param {string} chromeBinary Chromium binary being requested for launch
- * @param {string[]} chromeFlags Array of flags requested for launch
- * @returns {boolean} Whether requested port is usable
+ * Validate that requested port is a valid port
+ * @param {number} port Debugging port
+ * @returns {boolean}
  */
-export async function validatePort(port, chromeBinary, chromeFlags) {
+function isPortValid(port) {
   if (!port) {
     return false;
   }
-  if (isNaN(port)) {
-    throw new UnusablePortError(`Non-numeric port provided (${port})`);
+  if (Number.isNaN(port) || !Number.isInteger(port)) {
+    throw new UnusablePortError(`Port provided is not an integer (${port})`);
   }
   if (port < 0 || port > 65535) {
     throw new UnusablePortError(`Invalid port number: ${port}`);
   }
 
-  const isAvailable = await portAvailable(port);
-  const extensions = chromeFlags.find(
-    (flag) => flag.toLowerCase().indexOf('--load-extension') > -1,
-  );
-  if (!extensions.length || !extensions.length > 1) {
-    // This shouldn't happen...
-    throw new UnusablePortError(
-      'Port is in use and verification of whether the extension is loaded failed',
-    );
+  return true;
+}
+
+/**
+ * Validate user-supplied port to ensure it is suitable for use
+ * @param {number} port User-supplied port request
+ * @param {string} chromiumBinary Chromium binary being requested for launch
+ * @param {string[]} chromeFlags Array of flags requested for launch
+ * @returns {boolean} Whether requested port is usable
+ */
+export async function validatePort(port) {
+  if (!isPortValid(port)) {
+    return false;
   }
 
-  const extension = extensions[0].substring(extensions[0].indexOf('=') + 1);
-
-  if (!extension) {
-    // This also shouldn't happen...
-    throw new UnusablePortError(
-      'Port is in use and verification of whether the extension is loaded failed',
-    );
-  }
-
-  if (isAvailable) {
-    return true;
-  }
-
-  return findProcess(chromeBinary, port)
-    .then((ps) => inspectProcessList(port, extension, ps))
-    .catch((error) => {
-      log.error(error);
-      throw new UnusablePortError(`Unable to validate port: ${error}`);
-    });
+  return isPortAvailable(port);
 }

--- a/src/util/verify-chromium-port.js
+++ b/src/util/verify-chromium-port.js
@@ -51,24 +51,15 @@ async function findProcess(chromeBinary) {
       throw new UsageError('Unsupported platform');
   }
 
-  // log.info('Searching for process %s', chromeBinary);
-  // log.debug('(cmd: %s)', cmd);
-
   const promise = new Promise((resolve, reject) => {
     exec(cmd, (error, stdout, stderr) => {
-      // log.debug('Output: %s', stdout);
       if (stderr) {
         log.debug('Error: %s', stderr);
       }
 
-      // const isMatch =
-      // stdout.toLowerCase().indexOf(chromeBinary.toLowerCase()) > -1;
-
       if (error) {
         reject(error);
       } else {
-        // log.debug('Found at least one instance of %s', chromeBinary);
-        // log.debug('(result: %o)', isMatch);
         resolve(stdout);
       }
     });
@@ -92,8 +83,6 @@ async function inspectProcessList(port, extension, output) {
   const lines = output.split('\n');
   let foundEligibleInstance = false;
 
-  // log.debug('Found %d browser instance(s).  Inspecting...', lines.length);
-
   lines.forEach((line) => {
     const extensionMatch = `--load-extension=${extension}`;
     const portMatch = `--remote-debugging-port=${port}`;
@@ -102,29 +91,16 @@ async function inspectProcessList(port, extension, output) {
     const isExtension = line.indexOf(extensionMatch) > -1;
 
     if (!isPortMatch) {
-      // log.debug('[%d/%d] Not using target port', i, lines.length, port);
       return;
     }
-
-    // log.debug('[%d/%d] Found chromium instance', i, lines.length);
 
     if (!isExtension) {
-      // throw new UnusablePortError(
-      //   'Port is in use by another browser instance that does not have this extension loaded',
-      // );
-      // log.debug('[%d/%d] Extension not loaded', i, lines.length);
       return;
     }
 
-    // log.debug(
-    //   '[%d/%d] Found extension loaded in this instance',
-    //   i,
-    //   lines.length,
-    // );
     foundEligibleInstance = true;
   });
 
-  // log.debug('Inspection complete.  Result: %o', foundEligibleInstance);
   return foundEligibleInstance;
 }
 
@@ -152,7 +128,7 @@ export async function portAvailable(port) {
  */
 export async function validatePort(port, chromeBinary, chromeFlags) {
   if (!port) {
-    return;
+    return false;
   }
   if (isNaN(port)) {
     throw new UnusablePortError(`Non-numeric port provided (${port})`);
@@ -162,7 +138,6 @@ export async function validatePort(port, chromeBinary, chromeFlags) {
   }
 
   const isAvailable = await portAvailable(port);
-  // const flags = new Map();
   const extensions = chromeFlags.find(
     (flag) => flag.toLowerCase().indexOf('--load-extension') > -1,
   );
@@ -181,30 +156,8 @@ export async function validatePort(port, chromeBinary, chromeFlags) {
       'Port is in use and verification of whether the extension is loaded failed',
     );
   }
-  // chromeFlags.forEach((flag) => {
-  //   const valueAt = flag.indexOf('=');
-  //   const [key, value] =
-  //     valueAt === -1
-  //       ? [flag, undefined]
-  //       : [flag.substring(0, valueAt), flag.substring(valueAt + 1)];
-
-  //   // let key;
-  //   // let value;
-  //   // if (valueAt === -1) {
-  //   //   key = flag;
-  //   //   log.debug('flag: [%s]', key);
-  //   // } else {
-  //   //   key = flag.substring(0, valueAt);
-  //   //   value = flag.substring(valueAt + 1);
-  //   //   log.debug('flag: [%s] => %s', key, value);
-  //   // }
-  //   flags.set(key, value);
-  // });
-
-  // const extension = flags.get('--load-extension');
 
   if (isAvailable) {
-    // log.debug('Using debugging port: %d', port);
     return true;
   }
 

--- a/src/util/verify-chromium-port.js
+++ b/src/util/verify-chromium-port.js
@@ -1,0 +1,217 @@
+import { createServer } from 'node:http';
+import { exec } from 'node:child_process';
+
+import { createLogger } from './logger.js';
+import { UnusablePortError, UsageError } from '../errors.js';
+
+const log = createLogger(import.meta.url);
+
+/**
+ * Returns a random, available port
+ * @returns {number} Available port number to use;
+ */
+export async function getRandomPort() {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once('listening', () => {
+      const { port } = server.address();
+      server.close(() => resolve(port));
+    });
+    server.once('error', () => reject);
+    server.listen(0);
+  });
+}
+
+/**
+ * Search for existing process
+ * @param {string} chromeBinary
+ * @returns {Promise<string>} Process list output
+ */
+async function findProcess(chromeBinary) {
+  const platform = process.platform;
+  let cmd = '';
+
+  switch (platform) {
+    case 'freebsd':
+      // no dash
+      cmd = 'ps axo cmd';
+      break;
+    case 'darwin':
+      cmd = 'ps -axo cmd';
+      break;
+    case 'linux':
+      // dash
+      cmd = 'ps -Ao cmd';
+      cmd = `${cmd} | grep ${chromeBinary}`;
+      break;
+    case 'win32':
+      cmd = `powershell "Get-CimInstance Win32_Process -Filter \\"Name -Like '${chromeBinary}'\\" | Select CommandLine"`;
+      break;
+    default:
+      throw new UsageError('Unsupported platform');
+  }
+
+  // log.info('Searching for process %s', chromeBinary);
+  // log.debug('(cmd: %s)', cmd);
+
+  const promise = new Promise((resolve, reject) => {
+    exec(cmd, (error, stdout, stderr) => {
+      // log.debug('Output: %s', stdout);
+      if (stderr) {
+        log.debug('Error: %s', stderr);
+      }
+
+      // const isMatch =
+      // stdout.toLowerCase().indexOf(chromeBinary.toLowerCase()) > -1;
+
+      if (error) {
+        reject(error);
+      } else {
+        // log.debug('Found at least one instance of %s', chromeBinary);
+        // log.debug('(result: %o)', isMatch);
+        resolve(stdout);
+      }
+    });
+  });
+
+  return promise;
+}
+
+/**
+ * Inspect process list output and match against specified port and extension
+ * @param {number} port User-requested port
+ * @param {string} extension Web-ext temporary extension
+ * @param {string} output Output from OS-specific process list containing process command line
+ * @returns {Promise<boolean>} Whether an eligible instance was found
+ */
+async function inspectProcessList(port, extension, output) {
+  if (!output) {
+    log.info('Browser instance not found');
+    return false;
+  }
+  const lines = output.split('\n');
+  let foundEligibleInstance = false;
+
+  // log.debug('Found %d browser instance(s).  Inspecting...', lines.length);
+
+  lines.forEach((line) => {
+    const extensionMatch = `--load-extension=${extension}`;
+    const portMatch = `--remote-debugging-port=${port}`;
+
+    const isPortMatch = line.toLowerCase().indexOf(portMatch) > -1;
+    const isExtension = line.indexOf(extensionMatch) > -1;
+
+    if (!isPortMatch) {
+      // log.debug('[%d/%d] Not using target port', i, lines.length, port);
+      return;
+    }
+
+    // log.debug('[%d/%d] Found chromium instance', i, lines.length);
+
+    if (!isExtension) {
+      // throw new UnusablePortError(
+      //   'Port is in use by another browser instance that does not have this extension loaded',
+      // );
+      // log.debug('[%d/%d] Extension not loaded', i, lines.length);
+      return;
+    }
+
+    // log.debug(
+    //   '[%d/%d] Found extension loaded in this instance',
+    //   i,
+    //   lines.length,
+    // );
+    foundEligibleInstance = true;
+  });
+
+  // log.debug('Inspection complete.  Result: %o', foundEligibleInstance);
+  return foundEligibleInstance;
+}
+
+/**
+ * Determine if a port is available
+ * @param {number} port Port to test
+ * */
+export async function portAvailable(port) {
+  return new Promise((resolve) => {
+    const server = createServer();
+    server.once('listening', () => {
+      server.close(() => resolve(true));
+    });
+    server.once('error', () => resolve(false));
+    server.listen(port);
+  });
+}
+
+/**
+ * Validate user-supplied port to ensure it is suitable for use
+ * @param {number} port User-supplied port request
+ * @param {string} chromeBinary Chromium binary being requested for launch
+ * @param {string[]} chromeFlags Array of flags requested for launch
+ * @returns {boolean} Whether requested port is usable
+ */
+export async function validatePort(port, chromeBinary, chromeFlags) {
+  if (!port) {
+    return;
+  }
+  if (isNaN(port)) {
+    throw new UnusablePortError(`Non-numeric port provided (${port})`);
+  }
+  if (port < 0 || port > 65535) {
+    throw new UnusablePortError(`Invalid port number: ${port}`);
+  }
+
+  const isAvailable = await portAvailable(port);
+  // const flags = new Map();
+  const extensions = chromeFlags.find(
+    (flag) => flag.toLowerCase().indexOf('--load-extension') > -1,
+  );
+  if (!extensions.length || !extensions.length > 1) {
+    // This shouldn't happen...
+    throw new UnusablePortError(
+      'Port is in use and verification of whether the extension is loaded failed',
+    );
+  }
+
+  const extension = extensions[0].substring(extensions[0].indexOf('=') + 1);
+
+  if (!extension) {
+    // This also shouldn't happen...
+    throw new UnusablePortError(
+      'Port is in use and verification of whether the extension is loaded failed',
+    );
+  }
+  // chromeFlags.forEach((flag) => {
+  //   const valueAt = flag.indexOf('=');
+  //   const [key, value] =
+  //     valueAt === -1
+  //       ? [flag, undefined]
+  //       : [flag.substring(0, valueAt), flag.substring(valueAt + 1)];
+
+  //   // let key;
+  //   // let value;
+  //   // if (valueAt === -1) {
+  //   //   key = flag;
+  //   //   log.debug('flag: [%s]', key);
+  //   // } else {
+  //   //   key = flag.substring(0, valueAt);
+  //   //   value = flag.substring(valueAt + 1);
+  //   //   log.debug('flag: [%s] => %s', key, value);
+  //   // }
+  //   flags.set(key, value);
+  // });
+
+  // const extension = flags.get('--load-extension');
+
+  if (isAvailable) {
+    // log.debug('Using debugging port: %d', port);
+    return true;
+  }
+
+  return findProcess(chromeBinary, port)
+    .then((ps) => inspectProcessList(port, extension, ps))
+    .catch((error) => {
+      log.error(error);
+      throw new UnusablePortError(`Unable to validate port: ${error}`);
+    });
+}

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -198,7 +198,9 @@ export class StubChildProcess extends EventEmitter {
     super();
 
     // mimic chrome-launch and set a port property, defaulting to a random port
-    this.port = params.chromiumPort ? params.chromiumPort : getRandomInt(1024, 65536);
+    this.port = params.chromiumPort
+      ? params.chromiumPort
+      : getRandomInt(1024, 65536);
   }
 }
 

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -193,6 +193,13 @@ export class StubChildProcess extends EventEmitter {
   stderr = new EventEmitter();
   stdout = new EventEmitter();
   kill = sinon.spy(() => {});
+
+  constructor(params = {}) {
+    super();
+
+    // mimic chrome-launch and set a port property, defaulting to a random port
+    this.port = params.chromiumPort ? params.chromiumPort : getRandomInt(1024, 65536);
+  }
 }
 
 export function createFakeProcess() {
@@ -335,4 +342,10 @@ export function mockModule({
 
 export function resetMockModules() {
   td.reset();
+}
+
+export function getRandomInt(min, max) {
+  const _min = Math.ceil(min);
+  const _max = Math.floor(max);
+  return Math.floor(Math.random() * (_max - _min) + _min);
 }

--- a/tests/unit/test-extension-runners/test.chromium.js
+++ b/tests/unit/test-extension-runners/test.chromium.js
@@ -618,13 +618,16 @@ describe('util/extension-runners/chromium', async () => {
   it('does pass port to chrome', async () => {
     const port = 9222;
     const { params } = prepareExtensionRunnerParams({
-      chromiumPort: port,
+      params: { chromiumPort: port },
     });
 
-    sinon.assert(calledOnce(params.chromiumLaunch));
-    sinon.assert(calledWithMatch(params.chromiumLaunch, {
+    const runnerInstance = new ChromiumExtensionRunner(params);
+    await runnerInstance.run();
+
+    sinon.assert.calledOnce(params.chromiumLaunch);
+    sinon.assert.calledWithMatch(params.chromiumLaunch, {
       port,
-    }));
+    });
 
     await runnerInstance.exit();
   });

--- a/tests/unit/test-extension-runners/test.chromium.js
+++ b/tests/unit/test-extension-runners/test.chromium.js
@@ -23,7 +23,7 @@ import isDirectory from '../../../src/util/is-directory.js';
 
 function prepareExtensionRunnerParams({ params } = {}) {
   const fakeChromeInstance = {
-    process: new StubChildProcess(),
+    process: new StubChildProcess(params),
     kill: sinon.spy(async () => {}),
   };
   const runnerParams = {
@@ -628,6 +628,9 @@ describe('util/extension-runners/chromium', async () => {
     sinon.assert.calledWithMatch(params.chromiumLaunch, {
       port,
     });
+    assert.isDefined(runnerInstance.chromiumInstance, 'returned process instance');
+    assert.isDefined(runnerInstance.chromiumInstance.process.port, 'process instance has port value');
+    assert.equal(runnerInstance.chromiumInstance.process.port, port, 'process instance configured with correct port');
 
     await runnerInstance.exit();
   });

--- a/tests/unit/test-extension-runners/test.chromium.js
+++ b/tests/unit/test-extension-runners/test.chromium.js
@@ -615,6 +615,20 @@ describe('util/extension-runners/chromium', async () => {
       }),
   );
 
+  it('does pass port to chrome', async () => {
+    const port = 9222;
+    const { params } = prepareExtensionRunnerParams({
+      chromiumPort: port,
+    });
+
+    sinon.assert(calledOnce(params.chromiumLaunch));
+    sinon.assert(calledWithMatch(params.chromiumLaunch, {
+      port,
+    }));
+
+    await runnerInstance.exit();
+  });
+
   describe('reloadAllExtensions', () => {
     let runnerInstance;
     let wsClient;

--- a/tests/unit/test-extension-runners/test.chromium.js
+++ b/tests/unit/test-extension-runners/test.chromium.js
@@ -628,9 +628,19 @@ describe('util/extension-runners/chromium', async () => {
     sinon.assert.calledWithMatch(params.chromiumLaunch, {
       port,
     });
-    assert.isDefined(runnerInstance.chromiumInstance, 'returned process instance');
-    assert.isDefined(runnerInstance.chromiumInstance.process.port, 'process instance has port value');
-    assert.equal(runnerInstance.chromiumInstance.process.port, port, 'process instance configured with correct port');
+    assert.isDefined(
+      runnerInstance.chromiumInstance,
+      'returned process instance',
+    );
+    assert.isDefined(
+      runnerInstance.chromiumInstance.process.port,
+      'process instance has port value',
+    );
+    assert.equal(
+      runnerInstance.chromiumInstance.process.port,
+      port,
+      'process instance configured with correct port',
+    );
 
     await runnerInstance.exit();
   });


### PR DESCRIPTION
This suggestion allows us to create a dependable debug workflow to attach an IDE to the browser that gets spawned with the `run` command.

By default, the underlying `chrome-launcher` flow will choose a random debugging port when launching the browser.  This is not ideal for those of us hoping to attach  our IDE/other debugging tool to the browser.  Ideally, we launch the browser with a predictable port that we can configure into our debugging flow.  The underlying `chrome-launcher` actually already supports this; however, `web-ext` does not currently provide any way to pass the required option through.  This PR bridges that gap.