### PR TITLE
chore: Clean up unnecessary spread

### DIFF
--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -82,7 +82,7 @@ export default async function run(
 
   // Create an alias for --pref since it has been transformed into an
   // object containing one or more preferences.
-  const customPrefs = { ...pref };
+  const customPrefs = pref;
   const manifestData = await getValidatedManifest(sourceDir);
 
   const profileDir = firefoxProfile || chromiumProfile;


### PR DESCRIPTION
The customPrefs alias was introduced in #1039 as a direct alias, but changed to a shallow copy in #2436 because the object was modified. These changes have been dropped in #3136 but the swallow copy remained.

This patch completes the cleanup by reverting to a direct alias.