### PR TITLE
README - add a note about extensions now requiring Firefox 58+

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ This platform stabilized in
 [Firefox 48](https://blog.mozilla.org/addons/2016/04/29/webextensions-in-firefox-48/)
 which was released in April of 2016.
 
+**Note:** Due to changes to the addons platform in Summer 2024, newly published extensions will only work on Firefox 58 and later.
+
 ## Get Involved
 
 Hi! This tool is under active development. To get involved you can watch the repo,


### PR DESCRIPTION
this PR updates the webextension readme to note that new published web extensions now require Firefox 58 and later.
https://github.com/mozilla/addons-server/pull/22408

Feel free to suggest different ways communicating this info if it doesn't make sense to be as a `Note:`

[NO_TRAIN]::