### PR TITLE
chore: Ensure submit-addon exported methods fallbacks to 'web-ext-lib' userAgentString when not specified

### DIFF
--- a/src/util/submit-addon.js
+++ b/src/util/submit-addon.js
@@ -91,7 +91,7 @@ export default class Client {
     approvalCheckInterval = 1000,
     approvalCheckTimeout = 900000, // 15 minutes.
     downloadDir = process.cwd(),
-    userAgentString,
+    userAgentString = 'web-ext-lib',
   }) {
     this.apiAuth = apiAuth;
     if (apiProxy) {
@@ -478,7 +478,7 @@ export async function signAddon({
   savedUploadUuidPath,
   metaDataJson = {},
   submissionSource,
-  userAgentString,
+  userAgentString = 'web-ext-lib',
   SubmitClient = Client,
   ApiAuthClass = JwtApiAuth,
 }) {

--- a/tests/unit/test-util/test.submit-addon.js
+++ b/tests/unit/test-util/test.submit-addon.js
@@ -1249,6 +1249,27 @@ describe('util.submit-addon', () => {
         sinon.assert.calledOnce(nodeFetchStub);
       });
 
+      it('fallback to userAgentString "web-ext-lib" if not set', async () => {
+        const clientNoUserAgent = new Client({
+          ...clientDefaults,
+          userAgentString: undefined,
+        });
+
+        const clientNoUserAgentFetchStub = sinon.stub(
+          clientNoUserAgent,
+          'nodeFetch',
+        );
+        clientNoUserAgentFetchStub.resolves(new JSONResponse({}, 200));
+
+        await clientNoUserAgent.fetch(baseUrl, 'POST');
+
+        assert.equal(
+          clientNoUserAgentFetchStub.firstCall.args[1].headers['User-Agent'],
+          'web-ext-lib',
+        );
+        sinon.assert.calledOnce(clientNoUserAgentFetchStub);
+      });
+
       it('uses a specified proxy', async () => {
         nodeFetchStub.resolves(new JSONResponse({}, 200));
         const apiProxyHost = 'proxy.url';


### PR DESCRIPTION
As a followup to #3250, this PR sets 'web-ext-lib' as a fallback when userAgentString property has not been explicitly set.