### PR TITLE
Work around vercel/ncc import issues

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -157,7 +157,9 @@ export async function loadJSConfigFile(filePath) {
         await fs.readFile(resolvedFilePath, { encoding: 'utf-8' }),
       );
     } else {
-      configModule = await import(`file://${resolvedFilePath}?nonce=${nonce}`);
+      // https://github.com/vercel/ncc/issues/935
+      const _import = new Function('path', 'return import(path)');
+      configModule = await _import(`file://${resolvedFilePath}?nonce=${nonce}`);
     }
 
     if (configModule.default) {


### PR DESCRIPTION
Here is a workaround so web-ext compiles with vercel's ncc. It doesn't like dynamic imports, but will happily ignore them if indirect. Any chance you'd accept this patch?

See https://github.com/vercel/ncc/issues/935 for details.