### PR TITLE
fix: Update Reload Manager Extension for Chromium to MV3

### DIFF
--- a/src/extension-runners/chromium.js
+++ b/src/extension-runners/chromium.js
@@ -282,12 +282,12 @@ export class ChromiumExtensionRunner {
     await fs.writeFile(
       path.join(extPath, 'manifest.json'),
       JSON.stringify({
-        manifest_version: 2,
+        manifest_version: 3,
         name: 'web-ext Reload Manager Extension',
         version: '1.0',
         permissions: ['management', 'tabs'],
         background: {
-          scripts: ['bg.js'],
+          service_worker: 'bg.js',
         },
       }),
     );
@@ -316,7 +316,7 @@ export class ChromiumExtensionRunner {
         await setEnabled(extensionId, true);
       }
 
-      const ws = new window.WebSocket(
+      const ws = new WebSocket(
         "ws://${wssInfo.address}:${wssInfo.port}");
 
       ws.onmessage = async (evt) => {


### PR DESCRIPTION
Related to #3388

Upgrade `web-ext Reload Manager Extension` to Manifest Version 3 to prevent it from being disabled by Chromium-based browsers.

![image](https://github.com/user-attachments/assets/d6072437-1a3f-4a54-ab66-744ac6040c76)
