### PR TITLE
fix: restore stdin raw mode to off after ctrl-c quit

### DIFF
--- a/src/extension-runners/index.js
+++ b/src/extension-runners/index.js
@@ -255,7 +255,9 @@ export function defaultReloadStrategy(
   extensionRunner.registerCleanup(() => {
     watcher.close();
     if (allowInput) {
-      if (isTTY(stdin)) setRawMode(stdin, false);
+      if (isTTY(stdin)) {
+        setRawMode(stdin, false);
+      }
       stdin.pause();
     }
   });


### PR DESCRIPTION
When using `web-ext` via [API](https://github.com/mozilla/web-ext#using-web-ext-in-nodejs-code), after quit via `Ctrl-C`, the parent process can no longer respond to any keyboard input.

This PR fixes the issue by correctly returning `stdin` to the parent process.

This fix is ​​only tested and confirmed in the firefox-desktop version.
The firefox-android process may have similar issue, but I cannot test it at the moment.