### PR TITLE
chore: Avoid EINVAL in fake-firefox-binary

### DIFF
--- a/tests/functional/common.js
+++ b/tests/functional/common.js
@@ -21,11 +21,10 @@ export const webExt = process.env.TEST_WEB_EXT_BIN
 export const fixturesDir = path.join(functionalTestsDir, '..', 'fixtures');
 export const minimalAddonPath = path.join(fixturesDir, 'minimal-web-ext');
 export const fixturesUseAsLibrary = path.join(fixturesDir, 'webext-as-library');
+// NOTE: Depends on preload_on_windows.cjs to load this on Windows!
 export const fakeFirefoxPath = path.join(
   functionalTestsDir,
-  process.platform === 'win32'
-    ? 'fake-firefox-binary.bat'
-    : 'fake-firefox-binary.js',
+  'fake-firefox-binary.js',
 );
 export const fakeServerPath = path.join(
   functionalTestsDir,
@@ -33,7 +32,7 @@ export const fakeServerPath = path.join(
 );
 
 export const chromeExtPath = path.join(fixturesDir, 'chrome-extension-mv3');
-// NOTE: Depends on preload_on_windows.cjs to load this!
+// NOTE: Depends on preload_on_windows.cjs to load this on Windows!
 export const fakeChromePath = path.join(
   functionalTestsDir,
   'fake-chrome-binary.js',

--- a/tests/functional/fake-firefox-binary.bat
+++ b/tests/functional/fake-firefox-binary.bat
@@ -1,3 +1,0 @@
-@ECHO OFF
-REM Spawn this file as an Firefox executable on Windows.
-node "%~dp0fake-firefox-binary.js" %*

--- a/tests/functional/preload_on_windows.cjs
+++ b/tests/functional/preload_on_windows.cjs
@@ -20,7 +20,10 @@ const child_process = require('node:child_process');
 const orig_spawn = child_process.spawn;
 child_process.spawn = function(command, args, options, ...remainingArgs) {
   if (typeof command === 'string') {
-    if (command.endsWith('fake-chrome-binary.js')) {
+    if (
+      command.endsWith('fake-chrome-binary.js') ||
+      command.endsWith('fake-firefox-binary.js')
+    ) {
       args = args ? [command, ...args] : [command];
       command = process.execPath;
     }


### PR DESCRIPTION
Fixes #3435.

I manually verified the fix locally in a Windows 11 VM following the STR in that issue. Before the patch, I get EINVAL when running `.\node_modules\.bin\mocha .\tests\functional\test.cli.run.js`. After the patch, the test passes.