### PR TITLE
fix: deno compatibility with firefox

### DIFF
--- a/src/firefox/rdp-client.js
+++ b/src/firefox/rdp-client.js
@@ -1,6 +1,7 @@
 import net from 'net';
 import EventEmitter from 'events';
 import domain from 'domain';
+
 import { isErrorWithCode } from '../errors.js';
 
 export const DEFAULT_PORT = 6000;

--- a/src/firefox/rdp-client.js
+++ b/src/firefox/rdp-client.js
@@ -1,6 +1,7 @@
 import net from 'net';
 import EventEmitter from 'events';
 import domain from 'domain';
+import { isErrorWithCode } from '../errors.js';
 
 export const DEFAULT_PORT = 6000;
 export const DEFAULT_HOST = '127.0.0.1';
@@ -90,7 +91,13 @@ export default class FirefoxRDPClient extends EventEmitter {
 
         this._rdpConnection = conn;
         conn.on('data', this._onData);
-        conn.on('error', this._onError);
+        conn.on('error', (err) => {
+          if (isErrorWithCode('ECONNREFUSED', err) || isErrorWithCode('ENOTFOUND', err) || isErrorWithCode('ETIMEDOUT', err)) {
+            reject(err);
+          } else {
+            this._onError();
+          }
+        });
         conn.on('end', this._onEnd);
         conn.on('timeout', this._onTimeout);
 

--- a/src/firefox/rdp-client.js
+++ b/src/firefox/rdp-client.js
@@ -95,7 +95,7 @@ export default class FirefoxRDPClient extends EventEmitter {
           if (isErrorWithCode('ECONNREFUSED', err) || isErrorWithCode('ENOTFOUND', err) || isErrorWithCode('ETIMEDOUT', err)) {
             reject(err);
           } else {
-            this._onError();
+            this._onError(err);
           }
         });
         conn.on('end', this._onEnd);

--- a/src/firefox/rdp-client.js
+++ b/src/firefox/rdp-client.js
@@ -93,7 +93,11 @@ export default class FirefoxRDPClient extends EventEmitter {
         this._rdpConnection = conn;
         conn.on('data', this._onData);
         conn.on('error', (err) => {
-          if (isErrorWithCode('ECONNREFUSED', err) || isErrorWithCode('ENOTFOUND', err) || isErrorWithCode('ETIMEDOUT', err)) {
+          if (
+            isErrorWithCode('ECONNREFUSED', err) ||
+            isErrorWithCode('ENOTFOUND', err) ||
+            isErrorWithCode('ETIMEDOUT', err)
+          ) {
             reject(err);
           } else {
             this._onError(err);


### PR DESCRIPTION
This is a fix for deno compatibility while running firefox.

rdp-client.js uses `domain` for error handling.

https://github.com/mozilla/web-ext/blob/294573d1a262cdaba4061323639b35aca9606e27/src/firefox/rdp-client.js#L83

It is non-functional in deno and deprecated in node. https://nodejs.org/api/domain.html

It causes deno to fail while running firefox

Sample code:

```
import webExt from 'web-ext';
import * as webExtLogger from 'web-ext/util/logger';
webExtLogger.consoleStream.makeVerbose();
const __dirname = import.meta.dirname;

webExt.cmd
  .run(
    {
      firefox: '/bin/firefox-esr',
      sourceDir: __dirname + '/packages/extension/dist'
    }
  ).then((extensionRunner) => {
    console.log(extensionRunner);
  });

```

Gives output:

```
$ deno -A test.mjs 
[/home/user/test/node_modules/.deno/web-ext@8.10.0/node_modules/web-ext/lib/cmd/run.js][info] Running web extension from /home/user/test/packages/extension/dist
[/home/user/test/node_modules/.deno/web-ext@8.10.0/node_modules/web-ext/lib/util/manifest.js][debug] Validating manifest at /home/user/test/packages/extension/dist/manifest.json
[/home/user/test/node_modules/.deno/web-ext@8.10.0/node_modules/web-ext/lib/extension-runners/firefox-desktop.js][debug] Creating new Firefox profile
[/home/user/test/node_modules/.deno/web-ext@8.10.0/node_modules/web-ext/lib/firefox/index.js][debug] Running Firefox with profile at /tmp/firefox-profiletgp4Eu/
[/home/user/test/node_modules/.deno/web-ext@8.10.0/node_modules/web-ext/lib/firefox/index.js][debug] Executing Firefox binary: /bin/firefox-esr
[/home/user/test/node_modules/.deno/web-ext@8.10.0/node_modules/web-ext/lib/firefox/index.js][debug] Firefox args: -start-debugger-server 36095 -foreground -no-remote -profile /tmp/firefox-profiletgp4Eu/
[/home/user/test/node_modules/.deno/web-ext@8.10.0/node_modules/web-ext/lib/firefox/index.js][info] Use --verbose or --devtools to see logging
[/home/user/test/node_modules/.deno/web-ext@8.10.0/node_modules/web-ext/lib/firefox/remote.js][debug] Connecting to the remote Firefox debugger
[/home/user/test/node_modules/.deno/web-ext@8.10.0/node_modules/web-ext/lib/firefox/remote.js][debug] Connecting to Firefox on port 36095
error: Uncaught Error: Unhandled error. (undefined)
    at FirefoxRDPClient.emit (ext:deno_node/_events.mjs:424:17)
    at FirefoxRDPClient.emit (node:domain:133:14)
    at FirefoxRDPClient.onError (file:///home/user/test/node_modules/.deno/web-ext@8.10.0/node_modules/web-ext/lib/firefox/rdp-client.js:249:10)
    at FirefoxRDPClient._onError (file:///home/user/test/node_modules/.deno/web-ext@8.10.0/node_modules/web-ext/lib/firefox/rdp-client.js:68:39)
    at Socket.<anonymous> (file:///home/user/test/node_modules/.deno/web-ext@8.10.0/node_modules/web-ext/lib/firefox/rdp-client.js:91:10)
    at Socket.emit (ext:deno_node/_events.mjs:436:20)
    at Socket.emit (node:domain:133:14)
    at emitErrorNT (ext:deno_node/internal/streams/destroy.js:177:8)
    at emitErrorCloseNT (ext:deno_node/internal/streams/destroy.js:136:3)
    at processTicksAndRejections (ext:deno_node/_next_tick.ts:39:15)
```
