### PR TITLE
docs(sign): clarify description to include AMO upload

### DIFF
--- a/src/program.js
+++ b/src/program.js
@@ -519,7 +519,7 @@ Example: $0 --help run.
     )
     .command(
       'sign',
-      'Sign the extension so it can be installed in Firefox',
+      'Submit the extension to Mozilla Add-ons (AMO) for signing so it can be installed in Firefox',
       commands.sign,
       {
         'amo-base-url': {


### PR DESCRIPTION
Fixes #3493

Clarifies the `sign` command help text to reflect actual behavior: the command signs the extension and can upload it to Mozilla Add-ons (AMO). Current description implies local signing only. The CLI and docs support signing and uploading via AMO API keys. Clear wording reduces user confusion and matches README/help output.