### PR TITLE
chore(readme): fix formatting of package.json example

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,10 @@ the source code for your extension.
 `package.json`
 
 ```json
-"scripts": {
-  "start:firefox": "web-ext run --source-dir ./extension-dist/",
+{
+  "scripts": {
+    "start:firefox": "web-ext run --source-dir ./extension-dist/"
+  }
 }
 ```
 


### PR DESCRIPTION
Before this commit, the example of package.json in README.md didn't follow the JSON grammar as the key-value pair was not surrounded by `{}`, and there was a trailing comma after the last key-value pair.
This commit fixes the README.md to include a valid package.json example.