### PR TITLE
feat: Added --firefox-debugger-socket option

### DIFF
--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -49,6 +49,7 @@ export default async function run(
     adbRemoveOldArtifacts,
     firefoxApk,
     firefoxApkComponent,
+    firefoxDebuggerSocket,
     // Chromium CLI options.
     chromiumBinary,
     chromiumProfile,
@@ -150,6 +151,7 @@ export default async function run(
       preInstall,
       firefoxApk,
       firefoxApkComponent,
+      firefoxDebuggerSocket,
       adbDevice,
       adbHost,
       adbPort,

--- a/src/program.js
+++ b/src/program.js
@@ -760,6 +760,14 @@ Example: $0 --help run.
         type: 'string',
         requiresArg: true,
       },
+      'firefox-debugger-socket': {
+        describe:
+          'Connect to the specified debugger socket on the Android device. ' +
+          'Example: @org.mozilla.fenix/firefox-debugger-socket',
+        demandOption: false,
+        type: 'string',
+        requiresArg: true,
+      },
     })
     .command('lint', 'Validate the extension source', commands.lint, {
       output: {

--- a/tests/unit/test-extension-runners/test.firefox-android.js
+++ b/tests/unit/test-extension-runners/test.firefox-android.js
@@ -115,6 +115,7 @@ function prepareSelectedDeviceAndAPKParams(
     pushFile: sinon.spy(() => Promise.resolve()),
     startFirefoxAPK: sinon.spy(() => Promise.resolve()),
     setupForward: sinon.spy(() => Promise.resolve()),
+    isSocketResponsive: sinon.spy(() => Promise.resolve(true)),
     clearArtifactsDir: sinon.spy(() => Promise.resolve()),
     detectOrRemoveOldArtifacts: sinon.spy(() => Promise.resolve(true)),
     setUserAbortDiscovery: sinon.spy(() => {}),

--- a/tests/unit/test.program.js
+++ b/tests/unit/test.program.js
@@ -852,6 +852,28 @@ describe('program.main', () => {
     assert.equal(options.firefoxApkComponent, 'CustomView');
   });
 
+  it('passes a custom Firefox debugger socket via --firefox-debugger-socket', async () => {
+    const fakeCommands = fake(commands, {
+      run: () => Promise.resolve(),
+    });
+
+    const customSocket = '@org.mozilla.fenix/firefox-debugger-socket';
+
+    await execProgram(
+      [
+        'run',
+        '--firefox-debugger-socket',
+        customSocket,
+        '-t',
+        'firefox-android',
+      ],
+      { commands: fakeCommands },
+    );
+
+    const options = fakeCommands.run.firstCall.args[0];
+    assert.equal(options.firefoxDebuggerSocket, customSocket);
+  });
+
   describe('--no-input', () => {
     const fakeCommands = fake(commands, {
       run: () => Promise.resolve(),


### PR DESCRIPTION
This allows connecting to Firefox on Android devices without access to `/proc/net/unix`, bypassing automatic socket discovery.