### PR TITLE
chore: Add npm audit exception for low severity adv related to mocha jsdiff transitive dependency

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,3 +1,6 @@
 {
-  "exceptions": []
+  "exceptions": [
+    // Blocked on upstream fix https://github.com/mochajs/mocha/issues/5657
+    "https://github.com/advisories/GHSA-73rr-hh4g-fpgx"
+  ]
 }


### PR DESCRIPTION
This PR adds an exception for jsdiff low severity sec advisor, meant to unbreak the CI jobs currently hitting failures on the audit-deps CI job task.