### PR TITLE
fix: Updated Firefox default prefs to make content scripts visible in the devtools debugger panel by default

### DIFF
--- a/src/firefox/preferences.js
+++ b/src/firefox/preferences.js
@@ -73,6 +73,7 @@ const prefsFirefox = {
   'startup.homepage_welcome_url.additional': '',
   'devtools.errorconsole.enabled': true,
   'devtools.chrome.enabled': true,
+  'devtools.debugger.show-content-scripts': true,
 
   // From:
   // http://hg.mozilla.org/mozilla-central/file/1dd81c324ac7/build/automation.py.in//l388

--- a/tests/unit/test-firefox/test.preferences.js
+++ b/tests/unit/test-firefox/test.preferences.js
@@ -16,6 +16,8 @@ describe('firefox/preferences', () => {
       assert.equal(prefs['devtools.debugger.remote-enabled'], true);
       // This is a Firefox only pref.
       assert.equal(prefs['devtools.chrome.enabled'], true);
+      // This pref makes content scripts visible in the DevTools debugger.
+      assert.equal(prefs['devtools.debugger.show-content-scripts'], true);
       // This is a Firefox only pref that we set to prevent Firefox
       // to open the privacy policy info page on every "web-ext run".
       assert.equal(prefs['datareporting.policy.firstRunURL'], '');


### PR DESCRIPTION
Fixes #3279 