### PR TITLE
fix: Added termsofuse.bypassNotification to the default Firefox prefs

### DIFF
--- a/src/firefox/preferences.js
+++ b/src/firefox/preferences.js
@@ -95,6 +95,9 @@ const prefsFirefox = {
   // the privacy info page to be opened on every "web-ext run".
   // (See #1114 for rationale)
   'datareporting.policy.firstRunURL': '',
+
+  // Prevent the terms-of-use modal from appearing on every "web-ext run". (See #3478)
+  'termsofuse.bypassNotification': true,
 };
 
 const prefs = {

--- a/tests/unit/test-firefox/test.preferences.js
+++ b/tests/unit/test-firefox/test.preferences.js
@@ -19,6 +19,8 @@ describe('firefox/preferences', () => {
       // This is a Firefox only pref that we set to prevent Firefox
       // to open the privacy policy info page on every "web-ext run".
       assert.equal(prefs['datareporting.policy.firstRunURL'], '');
+      // This pref prevents the terms-of-use modal from blocking web-ext run (see #3478).
+      assert.equal(prefs['termsofuse.bypassNotification'], true);
     });
 
     it('gets Fennec prefs with some defaults', () => {


### PR DESCRIPTION
Fixes #3478 