### PR TITLE
chore(audit): add npm audit exception for uuid transitive dependency

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -4,6 +4,8 @@
     "https://github.com/advisories/GHSA-73rr-hh4g-fpgx",
     // serialize-javascript  <=7.0.4
     "https://github.com/advisories/GHSA-5c6j-r48x-rmvq",
-    "https://github.com/advisories/GHSA-qj8w-gfj5-8c6v"
+    "https://github.com/advisories/GHSA-qj8w-gfj5-8c6v",
+    // uuid < 14.0.0
+    "https://github.com/advisories/GHSA-w5hq-g745-h8pq"
   ]
 }


### PR DESCRIPTION
This patch is adding uuid advisory to the nsprc exception list as a short term workaround to fix CI jobs failures due to it.

After #3689 is signed off and merged then `uuid` would not be used by any of the dependencies included in the released package and without the node-notifier unmaintained dependency it should also be easier to remove this npm audit exception.