### PR TITLE
Bump tmp to v0.2.7 to fix GHSA-7c78-jf6q-g5cm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "source-map-support": "0.5.21",
         "strip-bom": "5.0.0",
         "strip-json-comments": "5.0.3",
-        "tmp": "0.2.6",
+        "tmp": "0.2.7",
         "update-notifier": "7.3.1",
         "watchpack": "2.5.1",
         "yargs": "17.7.2",
@@ -10519,9 +10519,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
-      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"
@@ -18567,9 +18567,9 @@
       "dev": true
     },
     "tmp": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
-      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA=="
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw=="
     },
     "to-regex-range": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "source-map-support": "0.5.21",
     "strip-bom": "5.0.0",
     "strip-json-comments": "5.0.3",
-    "tmp": "0.2.6",
+    "tmp": "0.2.7",
     "update-notifier": "7.3.1",
     "watchpack": "2.5.1",
     "yargs": "17.7.2",


### PR DESCRIPTION
tmp is vulnerable even though `npm audit` doesn't yet return a warning.
This change just bump the version to v0.2.7 that is patched.

https://github.com/raszi/node-tmp/security/advisories/GHSA-7c78-jf6q-g5cm
[Compare v0.2.6...v0.2.7](https://github.com/raszi/node-tmp/compare/v0.2.6...v0.2.7)