### PR TITLE
Add a --enterprise CLI flag to the lint command

### DIFF
--- a/src/cmd/lint.js
+++ b/src/cmd/lint.js
@@ -11,6 +11,7 @@ export default function lint(
   {
     artifactsDir,
     boring,
+    enterprise,
     ignoreFiles,
     metadata,
     output,
@@ -39,6 +40,7 @@ export default function lint(
     output,
     boring,
     selfHosted,
+    enterprise,
     shouldScanFile: (fileName) => fileFilter.wantFile(fileName),
     minManifestVersion: 2,
     maxManifestVersion: 3,

--- a/src/program.js
+++ b/src/program.js
@@ -809,6 +809,11 @@ Example: $0 --help run.
         type: 'boolean',
         default: false,
       },
+      enterprise: {
+        describe: 'Treat your extension as an enterprise extension',
+        type: 'boolean',
+        default: false,
+      },
       boring: {
         describe: 'Disables colorful shell output',
         type: 'boolean',

--- a/tests/unit/test-cmd/test.lint.js
+++ b/tests/unit/test-cmd/test.lint.js
@@ -126,6 +126,7 @@ describe('lint', () => {
       output: 'json',
       boring: true,
       selfHosted: true,
+      enterprise: true,
     }).then(() => {
       sinon.assert.calledWithMatch(createLinter, {
         config: {
@@ -135,6 +136,7 @@ describe('lint', () => {
           output: 'json',
           boring: true,
           selfHosted: true,
+          enterprise: true,
           minManifestVersion: 2,
           maxManifestVersion: 3,
         },


### PR DESCRIPTION
Fixes https://github.com/mozilla/web-ext/issues/3771

---

This PR adds a new CLI option to the `lint` command, so that we can lint
an enterprise extension.