### PR TITLE
Fix configured run target precedence

### DIFF
--- a/src/program.js
+++ b/src/program.js
@@ -583,7 +583,6 @@ Example: $0 --help run.
         describe:
           'The extensions runners to enable. Specify this option ' +
           'multiple times to run against multiple targets.',
-        default: 'firefox-desktop',
         demandOption: false,
         type: 'array',
         choices: ['firefox-desktop', 'firefox-android', 'chromium'],

--- a/tests/unit/test-cmd/test.run.js
+++ b/tests/unit/test-cmd/test.run.js
@@ -271,6 +271,13 @@ describe('run', () => {
     sinon.assert.calledOnce(desktopRunnerStub);
   });
 
+  it('creates a Firefox Desktop runner if target is undefined', async () => {
+    const cmd = await prepareRun();
+    await cmd.run({ target: undefined });
+    sinon.assert.notCalled(androidRunnerStub);
+    sinon.assert.calledOnce(desktopRunnerStub);
+  });
+
   it('creates a Firefox Desktop runner if "firefox-desktop" is in target', async () => {
     const cmd = await prepareRun();
     await cmd.run({ target: ['firefox-desktop'] });

--- a/tests/unit/test.program.js
+++ b/tests/unit/test.program.js
@@ -672,6 +672,57 @@ describe('program.main', () => {
     assert.equal(options.selfHosted, configObject.lint.selfHosted);
   });
 
+  it('uses the configured run target when omitted from the CLI', async () => {
+    const fakeCommands = fake(commands, {
+      run: () => Promise.resolve(),
+    });
+    const configFile = path.resolve('custom/web-ext-config.mjs');
+    const configObject = {
+      run: {
+        target: ['chromium'],
+      },
+    };
+
+    await execProgram(['run', '--config', configFile], {
+      commands: fakeCommands,
+      runOptions: {
+        loadJSConfigFile: makeConfigLoader({
+          configObjects: { [configFile]: configObject },
+        }),
+      },
+    });
+
+    assert.deepEqual(fakeCommands.run.firstCall.args[0].target, ['chromium']);
+  });
+
+  it('uses the CLI run target over the configured target', async () => {
+    const fakeCommands = fake(commands, {
+      run: () => Promise.resolve(),
+    });
+    const configFile = path.resolve('custom/web-ext-config.mjs');
+    const configObject = {
+      run: {
+        target: ['chromium'],
+      },
+    };
+
+    await execProgram(
+      ['run', '--target', 'firefox-android', '--config', configFile],
+      {
+        commands: fakeCommands,
+        runOptions: {
+          loadJSConfigFile: makeConfigLoader({
+            configObjects: { [configFile]: configObject },
+          }),
+        },
+      },
+    );
+
+    assert.deepEqual(fakeCommands.run.firstCall.args[0].target, [
+      'firefox-android',
+    ]);
+  });
+
   it('discovers config files', async () => {
     const fakeCommands = fake(commands, {
       lint: () => Promise.resolve(),


### PR DESCRIPTION
Fixes #3314

## Summary

- Remove the yargs default from the array-valued `run.target` option so it is not mistaken for an explicit CLI value during config merging.
- Keep Firefox Desktop as the effective default in the run command when no target is provided.
- Add regression coverage for config precedence, explicit CLI precedence, and the undefined-target fallback.

## Validation

- `npx prettier --check src/program.js tests/unit/test.program.js tests/unit/test-cmd/test.run.js`
- `npx eslint src/program.js tests/unit/test.program.js tests/unit/test-cmd/test.run.js`
- `npx mocha tests/unit/test.program.js tests/unit/test-cmd/test.run.js` (83 passing)