### PR TITLE
Expose disabled linter rules

### DIFF
--- a/src/cmd/lint.js
+++ b/src/cmd/lint.js
@@ -11,6 +11,7 @@ export default function lint(
   {
     artifactsDir,
     boring,
+    disableLinterRules,
     enterprise,
     ignoreFiles,
     metadata,
@@ -39,6 +40,7 @@ export default function lint(
     metadata,
     output,
     boring,
+    disableLinterRules,
     selfHosted,
     enterprise,
     shouldScanFile: (fileName) => fileFilter.wantFile(fileName),

--- a/src/program.js
+++ b/src/program.js
@@ -792,6 +792,11 @@ Example: $0 --help run.
         type: 'boolean',
         default: false,
       },
+      'disable-linter-rules': {
+        describe: 'Disable a comma-separated list of linter rules',
+        type: 'string',
+        requiresArg: true,
+      },
       pretty: {
         describe: 'Prettify JSON output',
         type: 'boolean',

--- a/tests/unit/test-cmd/test.lint.js
+++ b/tests/unit/test-cmd/test.lint.js
@@ -93,6 +93,29 @@ describe('lint', () => {
     });
   });
 
+  it('passes disableLinterRules to the linter', () => {
+    const { lint, createLinter } = setUp();
+    const disableLinterRules = 'no-implied-eval, no-unsanitized/property';
+    return lint({ disableLinterRules }).then(() => {
+      sinon.assert.calledWithMatch(createLinter, {
+        config: {
+          disableLinterRules,
+        },
+      });
+    });
+  });
+
+  it('passes disableLinterRules undefined to the linter', () => {
+    const { lint, createLinter } = setUp();
+    return lint().then(() => {
+      sinon.assert.calledWithMatch(createLinter, {
+        config: {
+          disableLinterRules: undefined,
+        },
+      });
+    });
+  });
+
   it('configures the linter when verbose', () => {
     const { lint, createLinter } = setUp();
     return lint({ verbose: true }).then(() => {

--- a/tests/unit/test.program.js
+++ b/tests/unit/test.program.js
@@ -672,6 +672,46 @@ describe('program.main', () => {
     assert.equal(options.selfHosted, configObject.lint.selfHosted);
   });
 
+  it('applies disabled linter rules from the specified config file', async () => {
+    const fakeCommands = fake(commands, {
+      lint: () => Promise.resolve(),
+    });
+    const configFile = path.resolve('custom/web-ext-config.mjs');
+    const disableLinterRules = 'no-implied-eval, no-unsanitized/property';
+
+    await execProgram(['lint', '--config', configFile], {
+      commands: fakeCommands,
+      runOptions: {
+        loadJSConfigFile: makeConfigLoader({
+          configObjects: {
+            [configFile]: { lint: { disableLinterRules } },
+          },
+        }),
+      },
+    });
+
+    assert.equal(
+      fakeCommands.lint.firstCall.args[0].disableLinterRules,
+      disableLinterRules,
+    );
+  });
+
+  it('passes disabled linter rules from the CLI', async () => {
+    const fakeCommands = fake(commands, {
+      lint: () => Promise.resolve(),
+    });
+    const disableLinterRules = 'no-implied-eval,no-unsanitized/property';
+
+    await execProgram(['lint', '--disable-linter-rules', disableLinterRules], {
+      commands: fakeCommands,
+    });
+
+    assert.equal(
+      fakeCommands.lint.firstCall.args[0].disableLinterRules,
+      disableLinterRules,
+    );
+  });
+
   it('discovers config files', async () => {
     const fakeCommands = fake(commands, {
       lint: () => Promise.resolve(),


### PR DESCRIPTION
Fixes #3333

## Summary

- Add `--disable-linter-rules` as a comma-separated string option for `web-ext lint`.
- Support the corresponding `lint.disableLinterRules` config value.
- Forward the value unchanged to addons-linter, which performs rule-name trimming and splitting internally.
- Preserve current behavior when the option is omitted.

## Validation

- `npx prettier --check src/program.js src/cmd/lint.js tests/unit/test.program.js tests/unit/test-cmd/test.lint.js`
- `npx eslint src/program.js src/cmd/lint.js tests/unit/test.program.js tests/unit/test-cmd/test.lint.js`
- `npx mocha tests/unit/test.program.js tests/unit/test-cmd/test.lint.js` (69 passing)
- `npm run build`
- `node bin/web-ext.js lint --source-dir tests/fixtures/minimal-web-ext --disable-linter-rules no-implied-eval --output json`