### PR TITLE
chore: rename default export `webExt`

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@
 //   here).
 //
 // eslint-disable-next-line import/no-unresolved
-import webext from './lib/main.js';
+import webExt from './lib/main.js';
 
-export default webext;
-export const { cmd, main } = webext;
+export default webExt;
+export const { cmd, main } = webExt;


### PR DESCRIPTION
When importing the default export, it's recommended to use the same name as the exported variable (cf. [_import-x/no-rename-default_](https://github.com/un-ts/eslint-plugin-import-x/blob/v4.17.1/docs/rules/no-rename-default.md)).

This package exports a variable named [`webext`](https://github.com/mozilla/web-ext/blob/10.5.0/index.js#L11) (lowercase). With the following file:

```javascript
import webExt from 'web-ext';

webExt.cmd.run("...");
```

ESLint and _import-x/no-rename-default_ report this error:

> Caution: `index.js` has a default export `webext`. This imports `webext` as `webExt`. Check if you meant to write `import webext from 'web-ext'` instead.

---

With this pull request, we will be able to use the name `webExt` (camelCase).