### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+## Overview
+
+We welcome reports from the security community and are committed to working collaboratively to investigate and resolve vulnerabilities responsibly.
+
+---
+
+## Reporting a Potential Vulnerability
+
+If you find a security vulnerability please submit details through [Bugzilla](https://bugzilla.mozilla.org/enter_bug.cgi?product=addons.mozilla.org). Always submit potential security vulnerabilities via the [webform](https://bugzilla.mozilla.org/enter_bug.cgi?product=addons.mozilla.org); _never_ submit security-related bugs through a Github Issue or by email.
+
+### addons.mozilla.org (AMO)
+
+If your security vulnerability is potentially exploitable via [AMO](https://addons.mozilla.org), you may be eligible for our [bug bounty program](https://www.mozilla.org/en-US/security/web-bug-bounty/) [[FAQ](https://www.mozilla.org/en-US/security/bug-bounty/faq-webapp/)].
+
+### What to include
+
+To help us triage quickly, please provide:
+
+- A clear description of the issue
+- Steps to reproduce (or a proof of concept)
+- Affected versions / environments
+- Potential impact (what an attacker could achieve)
+- Any suggested mitigations or fixes
+
+### Non-security bugs
+
+Other bugs, that have no potential security implications, can be submitted via the [issue tracker](../../issues/new).


### PR DESCRIPTION
Part of https://mozilla-hub.atlassian.net/browse/AMOENG-2640

It points people towards bugzilla directly in most cases, but mentions the bug bounty for anything exploitable via AMO (because the bug bounty scope is limited to certain web and client properties)

Fwiw, I would include this exact file in all repos add-ons own (excluding addons-server, addons-frontend, and addons, which only mention the the HackerOne route)