### PR TITLE
fix: Loaded config files with URL characters in their paths

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,7 @@
 import os from 'os';
 import path from 'path';
 import fs from 'fs/promises';
+import { pathToFileURL } from 'url';
 
 import camelCase from 'camelcase';
 import decamelize from 'decamelize';
@@ -140,7 +141,9 @@ export async function loadJSConfigFile(filePath) {
         await fs.readFile(resolvedFilePath, { encoding: 'utf-8' }),
       );
     } else {
-      configModule = await import(`file://${resolvedFilePath}?nonce=${nonce}`);
+      const configURL = pathToFileURL(resolvedFilePath);
+      configURL.searchParams.set('nonce', nonce);
+      configModule = await import(configURL.href);
     }
 
     if (configModule.default) {

--- a/tests/unit/test.config.js
+++ b/tests/unit/test.config.js
@@ -902,6 +902,25 @@ describe('config', () => {
   });
 
   describe('loadJSConfigFile', () => {
+    for (const extension of ['mjs', 'cjs']) {
+      it(`loads a .${extension} config with URL characters in its path`, () =>
+        withTempDir(async (tmpDir) => {
+          const configFilePath = path.join(
+            tmpDir.path(),
+            `config #1%20.${extension}`,
+          );
+          const exportStatement =
+            extension === 'mjs' ? 'export default' : 'module.exports =';
+          writeFileSync(
+            configFilePath,
+            `${exportStatement} { sourceDir: 'fake/dir' };`,
+          );
+          assert.deepEqual(await loadJSConfigFile(configFilePath), {
+            sourceDir: 'fake/dir',
+          });
+        }));
+    }
+
     it('throws an error if the config file does not exist', () => {
       return withTempDir(async (tmpDir) => {
         const promise = loadJSConfigFile(


### PR DESCRIPTION
Loading a config such as `config #1%20.mjs` fails with `ERR_MODULE_NOT_FOUND`: the `#` becomes a URL fragment and truncates the path passed to `import()`.

Use `pathToFileURL` before adding the cache-busting nonce. Regression tests load both ESM and CommonJS config files with these characters in their names.

Validation: `npm run build` and `npm test` passed on Windows with Node 24.19.0 (582 passing, 3 pending). Both new tests fail before the fix. Prettier passed for the changed files.