### PR TITLE
Remove npm audit exceptions

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,9 +1,4 @@
 {
   "exceptions": [
-    // jsdiff DoS on diff >=6.0.0 <8.0.3 (via mocha)
-    "https://github.com/advisories/GHSA-73rr-hh4g-fpgx",
-    // serialize-javascript  <=7.0.4
-    "https://github.com/advisories/GHSA-5c6j-r48x-rmvq",
-    "https://github.com/advisories/GHSA-qj8w-gfj5-8c6v"
   ]
 }


### PR DESCRIPTION
These exceptions are no longer necessary.