### PR TITLE
Add npm audit exceptions for image-size and adm-zip

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,4 +1,9 @@
 {
   "exceptions": [
+    // image-size <=2.0.2 - no fix available
+    "https://github.com/advisories/GHSA-5p2g-fcmc-qvqq",
+    "https://github.com/advisories/GHSA-w3rx-r6r6-pgpr",
+    // adm-zip >=0.5.9 <=0.6.0 - no fix available
+    "https://github.com/advisories/GHSA-vwc7-r8mq-g2x9"
   ]
 }


### PR DESCRIPTION
refs https://github.com/mozilla/web-ext/issues/3806

---

No fix is available for any of these two deps, we'll need to look into
alternatives but for now, let's avoid failing CI everywhere.