### PR TITLE
fix: Treated localized extension names as literal filename text

### DIFF
--- a/src/cmd/build.js
+++ b/src/cmd/build.js
@@ -152,7 +152,9 @@ export async function defaultPackageCreator(
       manifestData,
     });
     // allow for a localized `{name}`, without mutating `manifestData`
-    filenameTemplate = filenameTemplate.replace(/{name}/g, extensionName);
+    filenameTemplate = filenameTemplate.replace(/{name}/g, () =>
+      safeFileName(extensionName),
+    );
   }
 
   const packageName = safeFileName(

--- a/tests/unit/test-cmd/test.build.js
+++ b/tests/unit/test-cmd/test.build.js
@@ -122,6 +122,39 @@ describe('build', () => {
     );
   });
 
+  for (const [name, expectedName] of [
+    ['Price $& Tracker', 'price_tracker'],
+    ['Edition {version}', 'edition_version_'],
+    ['Tools/Kit', 'tools_kit'],
+  ]) {
+    it(`treats localized name ${JSON.stringify(name)} as literal text`, () =>
+      withTempDir(async (tmpDir) => {
+        const sourceDir = path.join(tmpDir.path(), 'source');
+        const artifactsDir = path.join(tmpDir.path(), 'artifacts');
+        await fs.mkdir(path.join(sourceDir, '_locales', 'en'), {
+          recursive: true,
+        });
+        await fs.writeFile(
+          path.join(sourceDir, 'manifest.json'),
+          JSON.stringify({
+            ...basicManifest,
+            name: '__MSG_name__',
+            version: '1.0',
+            default_locale: 'en',
+          }),
+        );
+        await fs.writeFile(
+          path.join(sourceDir, '_locales', 'en', 'messages.json'),
+          JSON.stringify({ name: { message: name } }),
+        );
+        const result = await build({ sourceDir, artifactsDir });
+        assert.equal(
+          path.basename(result.extensionPath),
+          `${expectedName}-1.0.zip`,
+        );
+      }));
+  }
+
   it('sanitizes characters in extension name in filename from template', () => {
     return withTempDir((tmpDir) =>
       build({


### PR DESCRIPTION
A localized extension named `Price $& Tracker` builds as `price_msg_name_tracker-1.0.zip`: the replacement string expands `$&` back to `{name}`, which is then resolved against the original manifest. Likewise, `Edition {version}` substitutes the manifest version, and `Tools/Kit` fails filename validation.

Sanitize the localized name before inserting it into the filename template, using a replacement callback. This gives localized names the same filename treatment as ordinary manifest names and keeps their contents from being interpreted as template syntax.

All three regressions exercise actual package builds and fail before the change. On Windows with Node 24.19.0, the build and full test suite pass (585 passing, 3 pending), as do Prettier and ESLint for both changed files.