### PR TITLE
fix(sign): Defaulted amoBaseUrl when signing from the Node API

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,6 @@ webExt.cmd.sign({
   userAgentString: 'YOUR-CUSTOM-USERAGENT',
   apiKey,
   apiSecret,
-  amoBaseUrl: 'https://addons.mozilla.org/api/v5/',
   sourceDir: ...,
   channel: 'unlisted',
   ...

--- a/src/cmd/sign.js
+++ b/src/cmd/sign.js
@@ -3,6 +3,7 @@ import path from 'path';
 import defaultBuilder from './build.js';
 import { isErrorWithCode, UsageError, WebExtError } from '../errors.js';
 import { prepareArtifactsDir } from '../util/artifacts.js';
+import { AMO_BASE_URL } from '../util/constants.js';
 import { createLogger } from '../util/logger.js';
 import getValidatedManifest, { getManifestId } from '../util/manifest.js';
 import {
@@ -20,7 +21,7 @@ export const uploadUuidFile = '.amo-upload-uuid';
 
 export default function sign(
   {
-    amoBaseUrl,
+    amoBaseUrl = AMO_BASE_URL,
     apiKey,
     apiProxy,
     apiSecret,

--- a/src/program.js
+++ b/src/program.js
@@ -20,6 +20,7 @@ import {
   loadJSConfigFile as defaultLoadJSConfigFile,
   applyConfigToArgv as defaultApplyConfigToArgv,
 } from './config.js';
+import { AMO_BASE_URL } from './util/constants.js';
 
 const log = createLogger(import.meta.url);
 const envPrefix = 'WEB_EXT';
@@ -27,7 +28,7 @@ const envPrefix = 'WEB_EXT';
 // at build time by scripts/babel-plugin-inline-environment-variables.cjs).
 const defaultGlobalEnv = process.env.WEBEXT_BUILD_ENV || 'development';
 
-export const AMO_BASE_URL = 'https://addons.mozilla.org/api/v5/';
+export { AMO_BASE_URL };
 
 /*
  * The command line program.

--- a/src/util/constants.js
+++ b/src/util/constants.js
@@ -1,0 +1,5 @@
+// Shared constants that both the command line interface and the commands
+// themselves need. Keeping them here avoids importing the CLI program (and
+// its dependencies) from a command module.
+
+export const AMO_BASE_URL = 'https://addons.mozilla.org/api/v5/';

--- a/tests/unit/test-cmd/test.sign.js
+++ b/tests/unit/test-cmd/test.sign.js
@@ -115,6 +115,17 @@ describe('sign', () => {
       },
     ));
 
+  it('defaults the AMO base URL when it is not passed in', () =>
+    withTempDir(async (tmpDir) => {
+      const stubs = getStubs();
+      const signingConfig = { ...stubs.signingConfig };
+      delete signingConfig.amoBaseUrl;
+      await sign(tmpDir, { ...stubs, signingConfig });
+      sinon.assert.calledWithMatch(stubs.signingOptions.submitAddon, {
+        amoBaseUrl: AMO_BASE_URL,
+      });
+    }));
+
   it('requires a channel for submission API', () =>
     withTempDir(async (tmpDir) => {
       const stubs = getStubs();


### PR DESCRIPTION
Fixes #3164.

Calling `webExt.cmd.sign({apiKey, apiSecret, artifactsDir, channel, sourceDir})` from Node fails with `Invalid AMO API base URL: undefined`. The default only exists as a yargs default in the CLI option table (src/program.js:527), so it is applied on the command line and nowhere else. src/cmd/sign.js:23 destructures `amoBaseUrl` with no default, and `signAddon` rejects a missing value at src/util/submit-addon.js:500-503. The reporter hit this moving from 7.x to 8.x and worked around it by hardcoding `amoBaseUrl: 'https://addons.mozilla.org/api/v5/'`, which pins them to an API version web-ext is meant to manage for them.

This moves the constant into a new dependency-free module, src/util/constants.js. src/program.js imports it and re-exports it, so `import { AMO_BASE_URL } from './program.js'` keeps working for existing callers and tests, and the CLI option table is untouched. src/cmd/sign.js imports it from the new module rather than from src/program.js, so a Node API caller does not pull yargs and the rest of the CLI in behind it. No command module imports src/program.js today, and src/cmd/index.js loads commands lazily for the same start-up reason (#1302).

One scope note: `signAddon()` in src/util/submit-addon.js still takes `amoBaseUrl` explicitly. It is public API, since package.json exports `./util/submit-addon`, so this is a real choice rather than an oversight. I kept the change to the entry point the issue reports, but signAddon() can get the same default here if you would rather have it in one place.

The new test is "defaults the AMO base URL when it is not passed in" in tests/unit/test-cmd/test.sign.js. `getStubs()` always supplies `amoBaseUrl`, so the test copies the stub config, deletes that key, and asserts that `submitAddon` was called with the default. Reverting the one line in src/cmd/sign.js makes it fail with `amoBaseUrl: undefined`. The README example for `webExt.cmd.sign()` also drops the hardcoded `amoBaseUrl`; the `signAddon()` example below it keeps it, because that entry point still needs it.

Unit tests, eslint and prettier pass locally.