### PR TITLE
fix(sign): Excluded the artifacts directory from the signed package

### DIFF
--- a/src/cmd/sign.js
+++ b/src/cmd/sign.js
@@ -3,6 +3,7 @@ import path from 'path';
 import defaultBuilder from './build.js';
 import { isErrorWithCode, UsageError, WebExtError } from '../errors.js';
 import { prepareArtifactsDir } from '../util/artifacts.js';
+import { createFileFilter as defaultFileFilterCreator } from '../util/file-filter.js';
 import { createLogger } from '../util/logger.js';
 import getValidatedManifest, { getManifestId } from '../util/manifest.js';
 import {
@@ -36,6 +37,7 @@ export default function sign(
   },
   {
     build = defaultBuilder,
+    createFileFilter = defaultFileFilterCreator,
     preValidatedManifest,
     submitAddon = defaultSubmitAddonSigner,
     asyncFsReadFile = defaultAsyncFsReadFile,
@@ -54,10 +56,18 @@ export default function sign(
       manifestData = await getValidatedManifest(sourceDir);
     }
 
+    // The package is built into a temporary directory, so the filter has to
+    // be built here, where the real artifacts directory is known.
+    const fileFilter = createFileFilter({
+      sourceDir,
+      ignoreFiles,
+      artifactsDir,
+    });
+
     const [buildResult, idFromSourceDir] = await Promise.all([
       build(
         { sourceDir, ignoreFiles, artifactsDir: tmpDir.path() },
-        { manifestData, showReadyMessage: false },
+        { manifestData, showReadyMessage: false, fileFilter },
       ),
       getIdFromFile(savedIdPath),
     ]);

--- a/tests/unit/test-cmd/test.sign.js
+++ b/tests/unit/test-cmd/test.sign.js
@@ -15,7 +15,7 @@ import completeSignCommand, {
   extensionIdFile,
   getIdFromFile,
 } from '../../../src/cmd/sign.js';
-import { basicManifest, fixturePath } from '../helpers.js';
+import { basicManifest, fixturePath, ZipFile } from '../helpers.js';
 
 describe('sign', () => {
   function getStubs() {
@@ -114,6 +114,65 @@ describe('sign', () => {
           });
       },
     ));
+
+  it('does not include the artifacts directory in the signed package', () =>
+    withTempDir(async (tmpDir) => {
+      const stubs = getStubs();
+      const sourceDir = path.join(tmpDir.path(), 'source-dir');
+      const artifactsDir = path.join(sourceDir, 'web-ext-artifacts');
+      await promisify(copyDir)(fixturePath('minimal-web-ext'), sourceDir);
+      await fs.mkdir(artifactsDir, { recursive: true });
+      await fs.writeFile(
+        path.join(artifactsDir, 'previous-build.crx'),
+        'previous build',
+      );
+
+      // The built package is read here because sign() removes its temporary
+      // directory as soon as it returns.
+      let fileNames;
+      const submitAddon = async ({ xpiPath }) => {
+        const zipFile = new ZipFile();
+        await zipFile.open(xpiPath);
+        fileNames = await zipFile.extractFilenames();
+        await zipFile.close();
+        return stubs.signingResult;
+      };
+
+      await completeSignCommand(
+        {
+          sourceDir,
+          artifactsDir,
+          channel: 'listed',
+          ...stubs.signingConfig,
+        },
+        { submitAddon },
+      );
+
+      assert.include(fileNames, 'manifest.json');
+      assert.notInclude(fileNames, 'web-ext-artifacts/previous-build.crx');
+    }));
+
+  it('creates the file filter from the real artifacts directory', () =>
+    withTempDir(async (tmpDir) => {
+      const stubs = getStubs();
+      const fileFilter = { wantFile: () => true };
+      const createFileFilter = sinon.spy(() => fileFilter);
+      const params = {
+        sourceDir: tmpDir.path(),
+        artifactsDir: path.join(tmpDir.path(), 'artifacts-dir'),
+        ignoreFiles: ['**/*.log'],
+      };
+      await sign(tmpDir, stubs, {
+        extraArgs: params,
+        extraOptions: { createFileFilter },
+      });
+      sinon.assert.calledWithMatch(createFileFilter, params);
+      sinon.assert.calledWithMatch(
+        stubs.signingOptions.build,
+        sinon.match.any,
+        { fileFilter },
+      );
+    }));
 
   it('requires a channel for submission API', () =>
     withTempDir(async (tmpDir) => {


### PR DESCRIPTION
Fixes #1640.

`web-ext build` leaves the artifacts directory out of the package it creates, but `web-ext sign` puts it in. Anything under `web-ext-artifacts/` that is not a `.zip` or `.xpi` ends up inside the archive that is uploaded to AMO: `.crx` and `.nex` files from Chrome or Opera builds, unpacked copies of the extension, screenshots. Previously built `.zip` and `.xpi` packages are already dropped by the base ignore patterns, so those are not the problem, but everything else is shipped and signed.

The cause is the temporary build directory. `sign()` builds into a temp dir (`artifactsDir: tmpDir.path()`, src/cmd/sign.js:59 on master), and `build()` creates its default file filter from whatever artifacts directory it was given (src/cmd/build.js:210-214). `FileFilter` only adds ignore rules for the artifacts directory when that directory is inside the source directory (src/util/file-filter.js:53). A temp dir is never a subpath of the source dir, so the rule is never added and the real `web-ext-artifacts/` is packaged.

The fix is to build the filter where the real artifacts directory is known. Sign now calls `createFileFilter({ sourceDir, ignoreFiles, artifactsDir })` itself and passes the result to `build()` as its `fileFilter` option, which is a default parameter, so no signature change is needed. That is the same call-site pattern `lint.js` and the extension runners already use. Those `ignoreFiles` go into the filter sign constructs, so `--ignore-files` behaves exactly as before, and the `isSubPath` guard added in #790 is untouched, so behaviour is also unchanged when `--artifacts-dir` points outside the source directory. Only the extension package is affected. The source bundle for `--upload-source-code` is a user supplied path.

Two tests were added to `tests/unit/test-cmd/test.sign.js`. The first runs the real sign command over a source directory that has a `web-ext-artifacts/previous-build.crx` in it, with only the submission call stubbed, and asserts the zip contains `manifest.json` and not the artifacts file. The zip is read inside that stub because sign removes its temporary directory as soon as it returns. The second injects a spy `createFileFilter` and asserts it is called with the real artifacts directory and that the resulting filter reaches `build()`.

The one existing test that runs the real build signs a source directory with no artifacts directory inside it, so nothing leaked; every other sign test stubs build. Both new tests fail before the change, with `AssertionError: expected [ 'web-ext-artifacts/', …(3) ] to not include 'web-ext-artifacts/previous-build.crx'`. With the change, `tests/unit/test-cmd/test.sign.js` gives 16 passing, `test.build.js` 28 passing and `tests/unit/test-util/test.file-filter.js` 18 passing.