### PR TITLE
fix: Fixed files not being ignored when sourceDir contains glob characters

### DIFF
--- a/src/util/file-filter.js
+++ b/src/util/file-filter.js
@@ -6,6 +6,16 @@ import { createLogger } from './logger.js';
 
 const log = createLogger(import.meta.url);
 
+// Glob characters that minimatch would otherwise read as pattern syntax when
+// they are part of a real directory name, such as an extension living in
+// "/home/me/my ext [beta]". They are escaped as one-character classes and not
+// with a backslash, because minimatch rewrites path.sep to "/" in patterns on
+// Windows, which would destroy a backslash escape. Two characters stay
+// unhandled: a curly brace, because brace expansion runs before character
+// classes are parsed, and a literal backslash in a directory name on POSIX,
+// which minimatch reads as an escape.
+const escapeGlobChars = (filePath) => filePath.replace(/[*?[\]()]/g, '[$&]');
+
 // check if target is a sub directory of src
 export const isSubPath = (src, target) => {
   const relate = path.relative(src, target);
@@ -56,7 +66,13 @@ export class FileFilter {
         `Ignoring artifacts directory "${artifactsDir}" ` +
           'and all its subdirectories',
       );
-      this.addToIgnoreList([artifactsDir, path.join(artifactsDir, '**', '*')]);
+      // The artifacts directory is a real path and never a pattern, so it
+      // is escaped whole and pushed directly.
+      const artifactsPattern = escapeGlobChars(artifactsDir);
+      this.filesToIgnore.push(
+        artifactsPattern,
+        path.join(artifactsPattern, '**', '*'),
+      );
     }
   }
 
@@ -73,15 +89,36 @@ export class FileFilter {
   }
 
   /**
+   *  Resolve an ignore pattern to an absolute pattern, escaping the glob
+   *  characters of the sourceDir part of the path so that the directory the
+   *  extension lives in is matched literally. A pattern that resolves outside
+   *  sourceDir keeps its prefix unescaped, since there is no part of it that
+   *  is known to be a real path.
+   */
+  resolveIgnorePattern(pattern) {
+    const resolvedPath = this.resolveWithSourceDir(pattern);
+    if (
+      resolvedPath !== this.sourceDir &&
+      !resolvedPath.startsWith(`${this.sourceDir}${path.sep}`)
+    ) {
+      return resolvedPath;
+    }
+    return (
+      escapeGlobChars(this.sourceDir) +
+      resolvedPath.slice(this.sourceDir.length)
+    );
+  }
+
+  /**
    *  Insert more files into filesToIgnore array.
    */
   addToIgnoreList(files) {
     for (const file of files) {
       if (file.charAt(0) === '!') {
-        const resolvedFile = this.resolveWithSourceDir(file.substr(1));
+        const resolvedFile = this.resolveIgnorePattern(file.substr(1));
         this.filesToIgnore.push(`!${resolvedFile}`);
       } else {
-        this.filesToIgnore.push(this.resolveWithSourceDir(file));
+        this.filesToIgnore.push(this.resolveIgnorePattern(file));
       }
     }
   }

--- a/tests/unit/test-util/test.file-filter.js
+++ b/tests/unit/test-util/test.file-filter.js
@@ -92,6 +92,35 @@ describe('util/file-filter', () => {
       assert.equal(filter.wantFile('dist/file'), true);
     });
 
+    it('ignores files when sourceDir contains glob characters', () => {
+      const filter = newFileFilter({
+        sourceDir: '/src/my ext [beta]',
+        ignoreFiles: ['*.log', '!node_modules/libdweb/src/**'],
+      });
+      assert.equal(filter.wantFile('manifest.json'), true);
+      assert.equal(filter.wantFile('.git/config'), false);
+      assert.equal(filter.wantFile('node_modules/pkg/index.js'), false);
+      assert.equal(filter.wantFile('previous-build.zip'), false);
+      // The user's own patterns keep their glob meaning.
+      assert.equal(filter.wantFile('some.log'), false);
+      assert.equal(filter.wantFile('node_modules/libdweb/src/lib.js'), true);
+
+      // An extglob opener in the directory name breaks matching the same way.
+      const extglobFilter = newFileFilter({ sourceDir: '/src/build @(v2)' });
+      assert.equal(extglobFilter.wantFile('manifest.json'), true);
+      assert.equal(extglobFilter.wantFile('node_modules/pkg/index.js'), false);
+    });
+
+    it('ignores artifactsDir when sourceDir contains glob characters', () => {
+      const filter = newFileFilter({
+        sourceDir: '/src/my ext [beta]',
+        artifactsDir: '/src/my ext [beta]/out [1]',
+      });
+      assert.equal(filter.wantFile('manifest.json'), true);
+      assert.equal(filter.wantFile('out [1]'), false);
+      assert.equal(filter.wantFile('out [1]/some.js'), false);
+    });
+
     it('resolve relative path', () => {
       const filter = newFileFilter({
         sourceDir: '/src',


### PR DESCRIPTION
If the directory an extension lives in has a glob character in its name, web-ext ignores nothing. A build from a folder like "/src/my ext [beta]" packs .git, node_modules, every dotfile and every previously built zip straight into the artifact, and any pattern the user put in ignoreFiles is silently dead too.

Every ignore pattern is made absolute by prefixing the resolved sourceDir, and minimatch then reads that prefix back as pattern syntax instead of as a real path. "[beta]" is parsed as a one-character class that matches one of b, e, t or a, so the pattern no longer matches the directory it came from and nothing is ignored. The extglob openers "@(", "+(", "*(" and "?(" fail the same way, and a "!(" name matches the wrong sibling directories. Bare parentheses were never a problem, since minimatch already treats a "(" with no extglob character in front of it as a literal.

The fix escapes the glob characters in the sourceDir prefix before the rest of the pattern is appended, so the directory is matched literally while the user's own pattern keeps its glob meaning. Each character is escaped as a one-character class, "[" becoming "[[]", rather than with a backslash, because on Windows minimatch rewrites the path separator to "/" inside patterns and a backslash escape would not survive that. The artifacts directory is a real path and never a pattern, so it is escaped whole.

Two cases stay unfixed. A curly brace in a directory name still breaks matching, because brace expansion runs before character classes are parsed and there is no class that can hide a brace from it. A literal backslash in a directory name on POSIX is also still read as an escape.

Two unit tests cover this: one builds a filter on "/src/my ext [beta]" and on "/src/build @(v2)" and checks that the base patterns and a user ignoreFiles entry with a negation all still behave, and one checks an artifacts directory whose own name contains a bracket class. Both fail on master. eslint and prettier --check pass on the two changed files.
