### PR TITLE
fix(chromium): Fixed silent reload failures on Chrome 125 and earlier

### DIFF
--- a/src/extension-runners/chromium.js
+++ b/src/extension-runners/chromium.js
@@ -395,7 +395,7 @@ export class ChromiumExtensionRunner {
     const runnerName = this.getName();
 
     if (this.forceUseDeprecatedLoadExtension) {
-      this.reloadAllExtensionsFallbackForChrome125andEarlier();
+      await this.reloadAllExtensionsFallbackForChrome125andEarlier();
     } else {
       for (const { sourceDir } of this.params.extensions) {
         try {

--- a/tests/unit/test-extension-runners/test.chromium.js
+++ b/tests/unit/test-extension-runners/test.chromium.js
@@ -624,6 +624,39 @@ describe('util/extension-runners/chromium', async () => {
     sinon.assert.calledOnce(fakeChromeInstance.kill);
   });
 
+  it('rejects when reloading fails (old Chrome)', async () => {
+    const { params } = prepareExtensionRunnerParams(
+      {},
+      { loadUnpackedUnsupported: true },
+    );
+    const runnerInstance = new ChromiumExtensionRunner(params);
+
+    await runnerInstance.run();
+    assert.isTrue(runnerInstance.forceUseDeprecatedLoadExtension);
+
+    sinon
+      .stub(runnerInstance.cdp, 'sendCommand')
+      .rejects(new Error('CDP failure'));
+    const stdoutSpy = sinon.spy(process.stdout, 'write');
+
+    try {
+      await assert.isRejected(
+        runnerInstance.reloadAllExtensions(),
+        /CDP failure/,
+      );
+      assert.isFalse(
+        stdoutSpy.getCalls().some((call) => {
+          return String(call.args[0]).includes('Last extension reload');
+        }),
+        'expected no reload success message when the reload failed',
+      );
+    } finally {
+      stdoutSpy.restore();
+    }
+
+    await runnerInstance.exit();
+  });
+
   describe('getPrefs', () => {
     it('merges default and custom preferences from an object and passes them to the launcher', async () => {
       const { params } = prepareExtensionRunnerParams({


### PR DESCRIPTION
web-ext run -t chromium can report a reload that never happened and then exit. Pressing R or saving a file prints "Last extension reload: <time>" straight away, and if the reload actually failed the process dies on an unhandled rejection instead of logging the usual error. This only affects the --load-extension fallback path, which runs when the browser has no Extensions.loadUnpacked CDP command, so Chrome 125 and earlier or a Chromium build without it.

The cause is a dropped promise. reloadAllExtensions called this.reloadAllExtensionsFallbackForChrome125andEarlier() with no await (src/extension-runners/chromium.js:398). That method is async and its first statement awaits Target.getTargets (chromium.js:445), so the call returned a pending promise, the success line was written, and the function resolved with a plain result. The error therefore never reaches MultiExtensionRunner.handleReloadResults, which only reports a failure when a result carries reloadError (src/extension-runners/index.js:73-88 and 170-181). Nothing in src/ or bin/ installs an unhandledRejection handler, so Node ends the whole process instead.

The change is the await. Nothing else in src/ needed touching. What it surfaces are the transport-level failures in the fallback: Target.getTargets, Target.createTarget, Target.attachToTarget, the explicit "Unexpectedly, no sessionId from attachToTarget" throw, and Runtime.evaluate, plus a pipe that drops mid-reload, where the CDP client rejects every pending response. Per-extension reload failures inside the code evaluated on chrome://extensions/ are deliberately left as they are: they already go through log.error and log.warn further down the same method, and that stays soft.

Letting the rejection propagate is the choice here because MultiExtensionRunner.reloadAllExtensions replaces a runner's resolved value with { runnerName } (src/extension-runners/index.js:78-81), so rejecting is the only way a reload error can reach handleReloadResults and be logged as 'Error occurred while reloading on "Chromium" - <message>'. This does leave the two branches of reloadAllExtensions asymmetric: the Chrome 126 and newer branch catches a failed Extensions.loadUnpacked per extension and logs it (chromium.js:405-407) rather than rejecting. If you would rather have them match, try { await ... } catch (e) { log.error(e); } also fixes the crash and gets the failure logged, but the success line still prints afterwards, so that half of the bug would stay.

One test was added to tests/unit/test-extension-runners/test.chromium.js, next to the existing "falls back to --load-extension when needed (old Chrome)" test, which already builds a runner with loadUnpackedUnsupported: true. It runs the runner so it reaches the fallback the way it does in the field, stubs cdp.sendCommand to reject, then asserts both halves of the bug: that reloadAllExtensions() rejects, and that nothing containing "Last extension reload" was written to stdout. Without the await the test sees a fulfilled result instead of a rejection, which is the bug.

eslint and prettier --check pass on the two changed files.