### PR TITLE
fix: Fixed --watch-file being ignored for hidden files

### DIFF
--- a/src/watcher.js
+++ b/src/watcher.js
@@ -1,4 +1,5 @@
 import { existsSync, lstatSync } from 'fs';
+import path from 'path';
 
 import Watchpack from 'watchpack';
 import debounce from 'debounce';
@@ -34,8 +35,23 @@ export default function onSourceChange({
   const executeImmediately = false;
   onChange = debounce(onChange, debounceTime, executeImmediately);
 
+  // A file listed in --watch-file was named by the user, so changes to it are
+  // always relevant and must not be dropped by shouldWatchFile (the file
+  // filter ignores hidden files, archives and node_modules by default).
+  // Exclusions that apply at the watcher level, like --watch-ignored, are
+  // unaffected because such paths are never watched in the first place.
+  const explicitlyWatchedFiles = new Set(
+    (watchFile || []).map((file) => path.resolve(file)),
+  );
+
   watcher.on('change', (filePath) => {
-    proxyFileChanges({ artifactsDir, onChange, filePath, shouldWatchFile });
+    proxyFileChanges({
+      artifactsDir,
+      onChange,
+      filePath,
+      shouldWatchFile: (file) =>
+        explicitlyWatchedFiles.has(path.resolve(file)) || shouldWatchFile(file),
+    });
   });
 
   log.debug(

--- a/tests/unit/test.watcher.js
+++ b/tests/unit/test.watcher.js
@@ -10,11 +10,16 @@ import {
   default as onSourceChange,
   proxyFileChanges,
 } from '../../src/watcher.js';
+import { createFileFilter } from '../../src/util/file-filter.js';
 import { withTempDir } from '../../src/util/temp-dir.js';
 import { makeSureItFails } from './helpers.js';
 
 describe('watcher', () => {
-  const watchChange = ({ watchFile, touchedFile } = {}) =>
+  const watchChange = ({
+    watchFile,
+    touchedFile,
+    createShouldWatchFile = () => () => true,
+  } = {}) =>
     withTempDir(async (tmpDir) => {
       const artifactsDir = path.join(tmpDir.path(), 'web-ext-artifacts');
       const someFile = path.join(tmpDir.path(), touchedFile);
@@ -37,7 +42,7 @@ describe('watcher', () => {
         watchFile,
         artifactsDir,
         onChange,
-        shouldWatchFile: () => true,
+        shouldWatchFile: createShouldWatchFile(tmpDir.path()),
       });
 
       const { fileWatchers, directoryWatchers } = watcher;
@@ -109,6 +114,33 @@ describe('watcher', () => {
       sinon.assert.calledOnce(onChange);
       assert.isUndefined(watchedDirPath);
       assert.equal(watchedFilePath, path.join(tmpDirPath, 'foo.txt'));
+    });
+
+    it('changes if a watched hidden file is touched', async () => {
+      const { onChange, watchedFilePath, tmpDirPath } = await watchChange({
+        watchFile: ['.build-finished'],
+        touchedFile: '.build-finished',
+        createShouldWatchFile: (sourceDir) => {
+          const fileFilter = createFileFilter({ sourceDir });
+          return (file) => fileFilter.wantFile(file);
+        },
+      });
+
+      sinon.assert.calledOnce(onChange);
+      assert.equal(watchedFilePath, path.join(tmpDirPath, '.build-finished'));
+    });
+
+    it('changes if a watched zip file is touched', async () => {
+      const { onChange } = await watchChange({
+        watchFile: ['build.zip'],
+        touchedFile: 'build.zip',
+        createShouldWatchFile: (sourceDir) => {
+          const fileFilter = createFileFilter({ sourceDir });
+          return (file) => fileFilter.wantFile(file);
+        },
+      });
+
+      sinon.assert.calledOnce(onChange);
     });
 
     it('does not change if watched file is not touched (await)', async () => {


### PR DESCRIPTION
Fixes #2282.

`web-ext run --watch-file .build-finished` never reloads the extension. web-ext accepts the option and then silently does nothing: every change event is dropped, with only a debug-level line to show for it. Touching a sentinel file when an external build finishes is the documented reason to use --watch-file, and sentinel files are usually hidden, so this is the common case rather than an edge case.

Every change event Watchpack emits is passed through shouldWatchFile in src/watcher.js, including events for the files the user named. src/extension-runners/index.js binds shouldWatchFile to the source directory's FileFilter, and the base ignore patterns in src/util/file-filter.js include `**/.*`, so proxyFileChanges discards the change and only writes "Ignoring change to:" at debug level. The same thing happens to a watched `*.zip` or `*.xpi` and to anything under `node_modules`, because those patterns sit in the same list.

The fix resolves the --watch-file entries once and lets a change to one of them through whatever the filter says. That also beats the user's own --ignore-files patterns for those exact paths, which seems right since naming a single file with --watch-file is the more specific instruction, but it is worth stating rather than leaving to be discovered. Everything else is left alone: the artifacts directory check in proxyFileChanges is untouched, and exclusions that apply at the watcher level, such as --watch-ignored, are untouched because those paths are never watched in the first place. That last point is also why this stays compatible with the `_metadata` exclusion in open PR #3696, which lives in Watchpack's ignored list and not in the filter; #3696 also edits the same watchChange test helper, so whichever lands second needs a small rebase.

Two notes on scope. The bug only bites when the watched file is inside sourceDir, since the filter resolves its patterns against sourceDir, and the default sourceDir is the current directory, which is the situation in the issue. The reporter also suggested the opposite resolution, rejecting dot files in --watch-file with an error instead; reloading looks clearly more useful, but say so if you prefer the error.

Two unit tests cover this, both in the --watch-file block and both built on the real FileFilter: one touches a watched .build-finished, one touches a watched build.zip. The shared watchChange helper hardcoded shouldWatchFile as () => true, which is why no test ever exercised this interaction, so it now takes a filter factory and the existing cases keep their old behaviour. Both new tests fail on master. The watcher unit tests, eslint and prettier --check pass on the two changed files.